### PR TITLE
Improves module resolution to rely on 'module' instead of node-resolve

### DIFF
--- a/lib/module_importer.js
+++ b/lib/module_importer.js
@@ -1,9 +1,27 @@
 'use strict';
 
 var fs = require("fs"),
+    Module = require('module'),
     path = require("path"),
-    resolve = require("resolve"),
     sass = require('node-sass');
+
+/*
+ * Resolves a node module into a path. This uses
+ * the node.js internals from the Module API, but the
+ * API is marked "5 - Locked" and shouldn't change
+ * from here on out. This was done to remove the dependency on
+ * node-resolve.
+ * API docs: http://nodejs.org/api/modules.html
+ * node.js code: https://sourcegraph.com/github.com/joyent/node/
+ *   .CommonJSPackage/node/.def/commonjs/lib/module.js/-/_resolveFilename
+ */
+var resolve = function(id, parent, parentDir) {
+  return Module._resolveFilename(id, {
+    paths: Module._nodeModulePaths(parentDir),
+    filename: parent,
+    id: parent
+  });
+};
 
 /*
  * All imports use the forward slash as a directory
@@ -92,15 +110,15 @@ var make_eyeglass_importer = function(options, fallback_importer) {
       var module_name   = match[1],
           relative_path = match[2];
 
-
       try {
-        var js_file = resolve.sync(module_name, {
-          basedir: in_real_file ? path.dirname(prev) : root });
+        var js_file = (in_real_file) ?
+                      resolve(module_name, prev, path.dirname(prev)) :
+                      resolve(module_name, root, root);
       } catch (e) {
         // TODO: https://github.com/sass-eyeglass/eyeglass/issues/2
         console.error(e);
         done({});
-        return
+        return;
       }
       var sass_dir = require(js_file)({}, sass).sass_dir;
       var abstract_filename_segments = [sass_dir];

--- a/package.json
+++ b/package.json
@@ -13,8 +13,7 @@
     "compass"
   ],
   "dependencies": {
-    "node-sass": "*",
-    "resolve": "^1.1.0"
+    "node-sass": "*"
   },
   "devDependencies": {
     "mocha": "*",


### PR DESCRIPTION
This change updates the module_importer to rely on the node.js native 'module' implementation for resolving module dependencies. In addition to removing a dependency, this also enables inclusion of globally installed node.js modules as well as modules installed using `npm link`.

Addresses some portion of the work from #2 by returning errors as if the item had been `require()`ed in node.js parlance.