### PR TITLE
Addition of coding conventions, gulp pipeline, and a code scrub

### DIFF
--- a/build/lint.js
+++ b/build/lint.js
@@ -1,0 +1,10 @@
+var eslint = require("gulp-eslint");
+var config = require("eyeglass-dev-eslint");
+
+module.exports = function(gulp) {
+  gulp.task("lint", function() {
+    return gulp.src(["build/**/*.js", "lib/**/*.js", "test/**/*.js"])
+        .pipe(eslint(config))
+        .pipe(eslint.formatEach('stylish', process.stderr));
+  });
+};

--- a/build/lint.js
+++ b/build/lint.js
@@ -1,10 +1,13 @@
+"use strict";
+
 var eslint = require("gulp-eslint");
 var config = require("eyeglass-dev-eslint");
 
-module.exports = function(gulp) {
-  gulp.task("lint", function() {
+module.exports = function(gulp, depends) {
+  gulp.task("lint", depends, function() {
     return gulp.src(["build/**/*.js", "lib/**/*.js", "test/**/*.js"])
         .pipe(eslint(config))
-        .pipe(eslint.formatEach('stylish', process.stderr));
+        .pipe(eslint.formatEach("stylish", process.stderr))
+        .pipe(eslint.failOnError());
   });
 };

--- a/build/test.js
+++ b/build/test.js
@@ -1,0 +1,5 @@
+module.exports = function(gulp) {
+  gulp.task("test", function(cb) {
+    cb();
+  });
+};

--- a/build/test.js
+++ b/build/test.js
@@ -1,5 +1,12 @@
-module.exports = function(gulp) {
-  gulp.task("test", function(cb) {
-    cb();
+"use strict";
+
+var mocha = require("gulp-mocha");
+
+module.exports = function(gulp, depends) {
+  gulp.task("test", depends, function() {
+    return gulp.src([
+      "test/test_*.js"
+      ], {read: false})
+        .pipe(mocha({reporter: "spec"}));
   });
 };

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,4 +1,6 @@
 var gulp = require("gulp");
 
-require("./build/lint")(gulp);
-require("./build/test")(gulp);
+require("./build/lint")(gulp, []);
+require("./build/test")(gulp, ["lint"]);
+
+gulp.task("default", ["test"]);

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,0 +1,4 @@
+var gulp = require("gulp");
+
+require("./build/lint")(gulp);
+require("./build/test")(gulp);

--- a/lib/function_loader.js
+++ b/lib/function_loader.js
@@ -1,25 +1,30 @@
-'use strict';
+"use strict";
 
-var discover = require('./util/discover');
-var hash = require('./util/hash');
+var discover = require("./util/discover");
+var hash = require("./util/hash");
+var ARGUMENTS_REGEX = /\(.*\)$/;
 
 function autoDiscoverModules(root) {
   return discover.simple(root);
-};
+}
 
-function check_for_conflicts(obj1, obj2) {
-  var keys = {}
-  for (var attr in obj1) {
+function checkConflicts(obj1, obj2) {
+  var keys = {};
+  var attr;
+  for (attr in obj1) {
     if (obj1.hasOwnProperty(attr)) {
-      keys[attr.replace(/\(.*\)$/, '')] = attr
+      keys[attr.replace(ARGUMENTS_REGEX, "")] = attr;
     }
   }
-  for (var attr in obj2) {
+  for (attr in obj2) {
     if (obj2.hasOwnProperty(attr)) {
-      var fn_name = attr.replace(/\(.*\)$/, '');
-      if (keys[fn_name] && keys[fn_name] != attr) {
+      var fnName = attr.replace(ARGUMENTS_REGEX, "");
+      if (keys[fnName] && keys[fnName] !== attr) {
         // Better way to report warnings.
-        console.log("WARNING: Function " + fn_name + " was redeclared with conflicting function signatures: " + keys[fn_name] + " vs. " + attr);
+        // XXX this should be console.warn (which goes to stderr)
+        console.log("WARNING: Function " + fnName +
+          " was redeclared with conflicting function signatures: " +
+          keys[fnName] + " vs. " + attr);
       }
     }
   }
@@ -30,15 +35,15 @@ module.exports = function(eyeglass, sass, options, existingFunctions) {
   var functions = {};
   var modules = autoDiscoverModules(root);
 
-  modules.forEach(function(m)  {
+  modules.forEach(function(m) {
     var obj = require(m)(eyeglass, sass);
     if (obj.functions) {
-      check_for_conflicts(functions, obj.functions);
-      hash.merge_into(functions, obj.functions);
+      checkConflicts(functions, obj.functions);
+      hash.merge(functions, obj.functions);
     }
   });
 
-  check_for_conflicts(functions, existingFunctions);
-  hash.merge_into(functions, existingFunctions);
+  checkConflicts(functions, existingFunctions);
+  hash.merge(functions, existingFunctions);
   return functions;
-}
+};

--- a/lib/function_loader.js
+++ b/lib/function_loader.js
@@ -3,7 +3,7 @@
 var discover = require('./util/discover');
 var hash = require('./util/hash');
 
-function auto_discover_modules(root) {
+function autoDiscoverModules(root) {
   return discover.simple(root);
 };
 
@@ -25,11 +25,10 @@ function check_for_conflicts(obj1, obj2) {
   }
 }
 
-module.exports = function(eyeglass, sass, options, existing_functions) {
+module.exports = function(eyeglass, sass, options, existingFunctions) {
   var root = options.root;
   var functions = {};
-
-  var modules = auto_discover_modules(root);
+  var modules = autoDiscoverModules(root);
 
   modules.forEach(function(m)  {
     var obj = require(m)(eyeglass, sass);
@@ -39,7 +38,7 @@ module.exports = function(eyeglass, sass, options, existing_functions) {
     }
   });
 
-  check_for_conflicts(functions, existing_functions);
-  hash.merge_into(functions, existing_functions);
+  check_for_conflicts(functions, existingFunctions);
+  hash.merge_into(functions, existingFunctions);
   return functions;
 }

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,14 +1,14 @@
 'use strict';
 
-var module_importer = require("./module_importer");
-var function_loader = require("./function_loader");
+var importer = require("./module_importer");
+var customFunctions = require("./function_loader");
 var sass = require("node-sass");
 
 
-var normalize_options = function(eyeglass, sass, options) {
+var normalizeOptions = function(eyeglass, sass, options) {
  if (!options.root) options.root = process.cwd();
- options.importer = module_importer(eyeglass, sass, options, options.importer);
- options.functions = function_loader(eyeglass, sass, options, options.functions);
+ options.importer = importer(eyeglass, sass, options, options.importer);
+ options.functions = customFunctions(eyeglass, sass, options, options.functions);
  return options;
 }
 
@@ -18,6 +18,6 @@ var normalize_options = function(eyeglass, sass, options) {
  *
  */
 module.exports = function(options) {
-  var eyeglass_object = {};
-  return normalize_options({}, sass, options);
+  var eyeglassObject = {};
+  return normalizeOptions(eyeglassObject, sass, options);
 }

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,23 +1,28 @@
-'use strict';
+"use strict";
 
 var importer = require("./module_importer");
 var customFunctions = require("./function_loader");
-var sass = require("node-sass");
+var nodeSass = require("node-sass");
 
 
-var normalizeOptions = function(eyeglass, sass, options) {
- if (!options.root) options.root = process.cwd();
+function normalizeOptions(eyeglass, sass, options) {
+ if (!options.root) {
+   options.root = process.cwd();
+ }
  options.importer = importer(eyeglass, sass, options, options.importer);
- options.functions = customFunctions(eyeglass, sass, options, options.functions);
+ options.functions = customFunctions(eyeglass,
+                                     sass,
+                                     options,
+                                     options.functions);
  return options;
 }
 
 /*
  * options: Everything node-sass supports, plus:
- * @option root The root of the project. Defaults to the current working directory.
+ * @option root The root of the project. Defaults to the process.cwd
  *
  */
 module.exports = function(options) {
   var eyeglassObject = {};
-  return normalizeOptions(eyeglassObject, sass, options);
-}
+  return normalizeOptions(eyeglassObject, nodeSass, options);
+};

--- a/lib/module_importer.js
+++ b/lib/module_importer.js
@@ -1,10 +1,9 @@
-'use strict';
+"use strict";
 
-var fs      = require("fs");
-var resolve = require('./util/resolve');
-var path    = require("path");
-var sass    = require('node-sass');
-var efs     = require('./util/files');
+var fs = require("fs");
+var path = require("path");
+var resolve = require("./util/resolve");
+var efs = require("./util/files");
 
 var IMPORT_REGEX = /^<([^>]+)>(?:\/(.+))?$/;
 
@@ -15,7 +14,7 @@ var IMPORT_REGEX = /^<([^>]+)>(?:\/(.+))?$/;
  */
 function makeFsPath(importPath) {
   var fsPath = importPath;
-  if (path.sep != "/") {
+  if (path.sep !== "/") {
     fsPath = fsPath.replace(/\//, path.sep);
   }
   return fsPath;
@@ -41,10 +40,13 @@ function readFirstFile(uri, filenames, cb, examinedFiles) {
       } else {
         cb(new Error("Could not import " + uri +
                      " from any of the following locations: " +
-                     examined_filenames.join(", ")));
+                     examinedFiles.join(", ")));
       }
     } else {
-      cb(null, {contents: data, file: filename})
+      cb(null, {
+        contents: data,
+        file: filename
+      });
     }
   });
 }
@@ -55,38 +57,39 @@ function readFirstFile(uri, filenames, cb, examinedFiles) {
  * fallback importer is the importer that was specified
  * in the node-sass options if one was there.
  */
-function makeImporter(eyeglass, sass, options, fallback_importer) {
+function makeImporter(eyeglass, sass, options, fallbackImporter) {
   var root = options.root;
   return function(uri, prev, done) {
-    var in_real_file = fs.existsSync(prev);
-    var match = uri.match(IMPORT_REGEX)
+    var isRealFile = fs.existsSync(prev);
+    var match = uri.match(IMPORT_REGEX);
 
     if (match) {
       // This is an import of the form "<node_module>/some/file"
-      var module_name   = match[1],
-          relative_path = match[2];
+      var moduleName = match[1];
+      var relativePath = match[2];
+      var jsFile;
 
       try {
-        var js_file = (in_real_file) ?
-                      resolve(module_name, prev, path.dirname(prev)) :
-                      resolve(module_name, root, root);
+        jsFile = (isRealFile) ?
+                      resolve(moduleName, prev, path.dirname(prev)) :
+                      resolve(moduleName, root, root);
       } catch (e) {
         // TODO: https://github.com/sass-eyeglass/eyeglass/issues/2
         console.error(e);
         done({});
         return;
       }
-      var sass_dir = require(js_file)(eyeglass, sass).sass_dir;
-      var abstract_filename_segments = [sass_dir];
+      var sassDir = require(jsFile)(eyeglass, sass).sass;
+      var filenameSegments = [sassDir];
 
-      if (relative_path) {
-        relative_path = makeFsPath(relative_path);
-        abstract_filename_segments.push(relative_path);
+      if (relativePath) {
+        relativePath = makeFsPath(relativePath);
+        filenameSegments.push(relativePath);
       }
 
-      var abstract_filename = path.join.apply(path, abstract_filename_segments);
+      var abstractName = path.join.apply(path, filenameSegments);
 
-      readAbstractFile(uri, abstract_filename, function(err, data) {
+      readAbstractFile(uri, abstractName, function(err, data) {
         if (err) {
           // TODO: https://github.com/sass-eyeglass/eyeglass/issues/2
           console.log(err.toString());
@@ -96,7 +99,7 @@ function makeImporter(eyeglass, sass, options, fallback_importer) {
         }
       });
 
-    } else if (prev.indexOf("node_modules") > 0 && in_real_file) {
+    } else if (prev.indexOf("node_modules") > 0 && isRealFile) {
       // This is a sass file that is potentially relative to the
       // previous import.
       var f = path.resolve(path.dirname(prev), makeFsPath(uri));
@@ -109,14 +112,14 @@ function makeImporter(eyeglass, sass, options, fallback_importer) {
           done(data);
         }
       });
-    } else if (fallback_importer) {
+    } else if (fallbackImporter) {
       // Not our import
-      fallback_importer(uri, prev, done);
+      fallbackImporter(uri, prev, done);
     } else {
       // give up
       done({});
     }
-  }
+  };
 }
 
 module.exports = makeImporter;

--- a/lib/module_importer.js
+++ b/lib/module_importer.js
@@ -1,67 +1,43 @@
 'use strict';
 
-var fs = require("fs"),
-    resolve = require('./util/resolve'),
-    path = require("path"),
-    sass = require('node-sass');
+var fs      = require("fs");
+var resolve = require('./util/resolve');
+var path    = require("path");
+var sass    = require('node-sass');
+var efs     = require('./util/files');
+
+var IMPORT_REGEX = /^<([^>]+)>(?:\/(.+))?$/;
 
 /*
  * All imports use the forward slash as a directory
  * delimeter. This function converts to the filesystem's
  * delimeter if it uses an alternate.
  */
-var import_path_to_fs_path = function(import_path) {
-  var fs_path = import_path;
+function makeFsPath(importPath) {
+  var fsPath = importPath;
   if (path.sep != "/") {
-    fs_path = fs_path.replace(/\//, path.sep);
+    fsPath = fsPath.replace(/\//, path.sep);
   }
-  return fs_path;
+  return fsPath;
+}
+
+// This is a bootstrap function for calling readFirstFile.
+function readAbstractFile(uri, abstractName, cb) {
+  readFirstFile(uri, efs.getFileNames(abstractName), cb);
 }
 
 /*
- * Sass imports are usually in an abstract form in that
- * they leave off the partial prefix and the suffix.
- * This code creates the possible extensions, whether it is a partial
- * and whether it is a directory index file having those
- * same possible variations. If the import contains an extension,
- * then it is left alone.
- * */
-var concrete_filenames = function(abstract_filename) {
-  var names = [];
-  if (path.extname(abstract_filename)) {
-    names.push(abstract_filename);
-  } else {
-    var directory = path.dirname(abstract_filename),
-        basename  = path.basename(abstract_filename);
-    ["", "_"].forEach(function(prefix) {
-      [".scss", ".sass"].forEach(function(ext) {
-        names.push(path.join(directory, prefix + basename + ext));
-      });
-    });
-    // can avoid these if we check if the path is a directory first.
-    ["", "_"].forEach(function(prefix) {
-      [".scss", ".sass"].forEach(function(ext) {
-        names.push(path.join(abstract_filename, prefix + "index" + ext));
-      });
-    });
-  }
-  return names;
-}
-
-// This is a bootstrap function for calling find_first_sass_contents.
-var read_sass_contents = function(uri, abstract_filename, cb) {
-  find_first_sass_contents(uri, concrete_filenames(abstract_filename), [], cb);
-}
-
-// returns the sass contents of the first file it find from the list of
-// filenames given.
-var find_first_sass_contents = function(uri, filenames, examined_filenames, cb) {
+ * Asynchronously walks the file list until a match is found. If
+ * no matches are found, calls the callback with an error
+ */
+function readFirstFile(uri, filenames, cb, examinedFiles) {
   var filename = filenames.shift();
-  examined_filenames.push(filename);
+  examinedFiles = examinedFiles || [];
+  examinedFiles.push(filename);
   fs.readFile(filename, function(err, data) {
     if (err) {
       if (filenames.length) {
-        find_first_sass_contents(uri, filenames, examined_filenames, cb);
+        readFirstFile(uri, filenames, cb, examinedFiles);
       } else {
         cb(new Error("Could not import " + uri +
                      " from any of the following locations: " +
@@ -73,19 +49,17 @@ var find_first_sass_contents = function(uri, filenames, examined_filenames, cb) 
   });
 }
 
-var eyeglass_import_regex = /^<([^>]+)>(?:\/(.+))?$/;
-
 /*
  * Returns an importer suitable for passing to node-sass.
  * options are the eyeglass/node-sass options.
  * fallback importer is the importer that was specified
  * in the node-sass options if one was there.
  */
-var make_eyeglass_importer = function(eyeglass, sass, options, fallback_importer) {
+function makeImporter(eyeglass, sass, options, fallback_importer) {
   var root = options.root;
   return function(uri, prev, done) {
     var in_real_file = fs.existsSync(prev);
-    var match = uri.match(eyeglass_import_regex)
+    var match = uri.match(IMPORT_REGEX)
 
     if (match) {
       // This is an import of the form "<node_module>/some/file"
@@ -106,13 +80,13 @@ var make_eyeglass_importer = function(eyeglass, sass, options, fallback_importer
       var abstract_filename_segments = [sass_dir];
 
       if (relative_path) {
-        relative_path = import_path_to_fs_path(relative_path);
+        relative_path = makeFsPath(relative_path);
         abstract_filename_segments.push(relative_path);
       }
 
       var abstract_filename = path.join.apply(path, abstract_filename_segments);
 
-      read_sass_contents(uri, abstract_filename, function(err, data) {
+      readAbstractFile(uri, abstract_filename, function(err, data) {
         if (err) {
           // TODO: https://github.com/sass-eyeglass/eyeglass/issues/2
           console.log(err.toString());
@@ -125,8 +99,8 @@ var make_eyeglass_importer = function(eyeglass, sass, options, fallback_importer
     } else if (prev.indexOf("node_modules") > 0 && in_real_file) {
       // This is a sass file that is potentially relative to the
       // previous import.
-      var f = path.resolve(path.dirname(prev), import_path_to_fs_path(uri));
-      read_sass_contents(uri, f, function(err, data) {
+      var f = path.resolve(path.dirname(prev), makeFsPath(uri));
+      readAbstractFile(uri, f, function(err, data) {
         if (err) {
           // TODO: https://github.com/sass-eyeglass/eyeglass/issues/2
           console.log(err.toString());
@@ -145,4 +119,4 @@ var make_eyeglass_importer = function(eyeglass, sass, options, fallback_importer
   }
 }
 
-module.exports = make_eyeglass_importer;
+module.exports = makeImporter;

--- a/lib/util/capture.js
+++ b/lib/util/capture.js
@@ -1,16 +1,21 @@
+"use strict";
+
 module.exports = function(callback, stream) {
-    if (!stream) stream = "stdout"
-    var old_write = process[stream].write
+  if (!stream) {
+    stream = "stdout";
+  }
 
-    process[stream].write = (function(write) {
-        return function(string, encoding, fd) {
-            callback(string, encoding, fd, function(s) {
-              write.apply(process[stream], arguments)
-            })
-        }
-    })(process[stream].write)
+  var oldWrite = process[stream].write;
 
-    return function() {
-        process[stream].write = old_write
-    }
-}
+  process[stream].write = (function(write) {
+    return function(string, encoding, fd) {
+      callback(string, encoding, fd, function(/*s*/) {
+        write.apply(process[stream], arguments);
+      });
+    };
+  })(process[stream].write);
+
+  return function() {
+    process[stream].write = oldWrite;
+  };
+};

--- a/lib/util/discover.js
+++ b/lib/util/discover.js
@@ -1,3 +1,5 @@
+"use strict";
+
 var resolve = require("./resolve");
 var semver = require("semver");
 var path = require("path");
@@ -5,10 +7,10 @@ var fs = require("fs");
 
 function getPackage(dir) {
   var pjson = path.join(dir, "package.json");
+  var data;
   try {
-    var data = fs.readFileSync(pjson);
-  }
-  catch(e) {
+    data = fs.readFileSync(pjson);
+  } catch(e) {
     return false;
   }
   return JSON.parse(data);
@@ -36,11 +38,11 @@ function discover(dir) {
       if (!pkg.keywords || pkg.keywords.indexOf("eyeglass-module") === -1) {
         return modules;
       }
-      if (seen[pkg.name + '@' + pkg.version]) {
+      if (seen[pkg.name + "@" + pkg.version]) {
         return modules;
       }
 
-      seen[pkg.name + '@' + pkg.version] = 1;
+      seen[pkg.name + "@" + pkg.version] = 1;
       modules.push({
         name: pkg.name,
         version: pkg.version,
@@ -54,7 +56,9 @@ function discover(dir) {
       if (pkg.dependencies) {
         Object.keys(pkg.dependencies).forEach(function(dep) {
           var p = resolve(dep + "/package.json", parent, inDir);
-          modules = modules.concat(scan(path.dirname(p), pkg.name, pkg.version));
+          modules = modules.concat(scan(path.dirname(p),
+                                   pkg.name,
+                                   pkg.version));
         });
       }
 

--- a/lib/util/files.js
+++ b/lib/util/files.js
@@ -1,0 +1,33 @@
+var path = require("path");
+
+/*
+ * Sass imports are usually in an abstract form in that
+ * they leave off the partial prefix and the suffix.
+ * This code creates the possible extensions, whether it is a partial
+ * and whether it is a directory index file having those
+ * same possible variations. If the import contains an extension,
+ * then it is left alone.
+ * */
+function getFileNames(abstractName) {
+  var names = [];
+  if (path.extname(abstractName)) {
+    names.push(abstractName);
+  } else {
+    var directory = path.dirname(abstractName),
+        basename  = path.basename(abstractName);
+    ["", "_"].forEach(function(prefix) {
+      [".scss", ".sass"].forEach(function(ext) {
+        names.push(path.join(directory, prefix + basename + ext));
+      });
+    });
+    // can avoid these if we check if the path is a directory first.
+    ["", "_"].forEach(function(prefix) {
+      [".scss", ".sass"].forEach(function(ext) {
+        names.push(path.join(abstractName, prefix + "index" + ext));
+      });
+    });
+  }
+  return names;
+}
+
+module.exports.getFileNames = getFileNames;

--- a/lib/util/files.js
+++ b/lib/util/files.js
@@ -1,3 +1,5 @@
+"use strict";
+
 var path = require("path");
 
 /*
@@ -13,13 +15,15 @@ function getFileNames(abstractName) {
   if (path.extname(abstractName)) {
     names.push(abstractName);
   } else {
-    var directory = path.dirname(abstractName),
-        basename  = path.basename(abstractName);
+    var directory = path.dirname(abstractName);
+    var basename = path.basename(abstractName);
+
     ["", "_"].forEach(function(prefix) {
       [".scss", ".sass"].forEach(function(ext) {
         names.push(path.join(directory, prefix + basename + ext));
       });
     });
+
     // can avoid these if we check if the path is a directory first.
     ["", "_"].forEach(function(prefix) {
       [".scss", ".sass"].forEach(function(ext) {

--- a/lib/util/hash.js
+++ b/lib/util/hash.js
@@ -1,9 +1,11 @@
-'use strict';
+"use strict";
 
 module.exports = {
-  merge_into: function(obj1, obj2) {
+  merge: function(obj1, obj2) {
     for (var attr in obj2) {
-      if (obj2.hasOwnProperty(attr)) obj1[attr] = obj2[attr];
+      if (obj2.hasOwnProperty(attr)) {
+        obj1[attr] = obj2[attr];
+      }
     }
   }
 };

--- a/lib/util/resolve.js
+++ b/lib/util/resolve.js
@@ -1,5 +1,9 @@
-var Module = require('module'),
-    path = require("path");
+/*eslint no-underscore-dangle:0*/
+// underscores allowed in this file for calling privately into node.js
+
+"use strict";
+
+var Module = require("module");
 
 /*
  * Resolves a node module into a path. This uses

--- a/package.json
+++ b/package.json
@@ -1,12 +1,20 @@
 {
-  "author": "chris@eppsteins.net",
-  "license": "Apache License 2.0",
   "name": "eyeglass",
+  "description": "Sass modules for npm.",
   "version": "0.0.1",
-  "description": "Sass modules for NPM.",
+  "author": {
+    "name": "The eyeglass team and contributors",
+    "url": "https://github.com/sass-eyeglass/eyeglass/graphs/contributors"
+  },
+  "license": "Apache License 2.0",
   "main": "lib/index.js",
+  "README": "README.md",
   "scripts": {
-    "test": "node_modules/.bin/mocha"
+    "test": "./node_modules/.bin/gulp test"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/sass-eyeglass/eyeglass.git"
   },
   "keywords": [
     "sass",
@@ -18,15 +26,11 @@
   },
   "devDependencies": {
     "eslint": "^0.14.1",
+    "eyeglass-dev-eslint": "0.0.2",
     "gulp": "^3.8.11",
     "gulp-eslint": "0.4.0",
     "gulp-mocha": "^2.0.0",
-    "mocha": "*",
+    "mocha": "^2.1.0",
     "should": ">= 0.0.1"
-  },
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/sass-eyeglass/eyeglass.git"
-  },
-  "README": "README.md"
+  }
 }

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "eslint": "^0.14.1",
     "gulp": "^3.8.11",
     "gulp-eslint": "0.4.0",
+    "gulp-mocha": "^2.0.0",
     "mocha": "*",
     "should": ">= 0.0.1"
   },

--- a/package.json
+++ b/package.json
@@ -17,6 +17,9 @@
     "semver": "^4.2.0"
   },
   "devDependencies": {
+    "eslint": "^0.14.1",
+    "gulp": "^3.8.11",
+    "gulp-eslint": "0.4.0",
     "mocha": "*",
     "should": ">= 0.0.1"
   },

--- a/test/fixtures/basic_modules/node_modules/module_a/eyeglass-exports.js
+++ b/test/fixtures/basic_modules/node_modules/module_a/eyeglass-exports.js
@@ -1,5 +1,7 @@
-module.exports = function(eyeglass, sass) {
+"use strict";
+
+module.exports = function(/*eyeglass, sass*/) {
   return {
-    sass_dir: __dirname // directory where the sass files are.
-  }
+    sass: __dirname // directory where the sass files are.
+  };
 };

--- a/test/fixtures/basic_modules/node_modules/module_a/node_modules/transitive_module/eyeglass-exports.js
+++ b/test/fixtures/basic_modules/node_modules/module_a/node_modules/transitive_module/eyeglass-exports.js
@@ -1,5 +1,7 @@
-module.exports = function(Eyeglass, Sass) {
+"use strict";
+
+module.exports = function(/*eyeglass, sass*/) {
   return {
-    sass_dir: __dirname // directory where the sass files are.
-  }
+    sass: __dirname // directory where the sass files are.
+  };
 };

--- a/test/fixtures/function_modules/node_modules/fn_module_a/eyeglass-exports.js
+++ b/test/fixtures/function_modules/node_modules/fn_module_a/eyeglass-exports.js
@@ -1,10 +1,12 @@
+"use strict";
+
 module.exports = function(eyeglass, sass) {
   return {
-    sass_dir: __dirname, // directory where the sass files are.
+    sass: __dirname, // directory where the sass files are.
     functions: {
       'hello($name: "World")': function(name, done) {
         done(sass.types.String("Hello, " + name.getValue() + "!"));
       }
     }
-  }
+  };
 };

--- a/test/fixtures/function_modules/node_modules/fn_module_a/node_modules/transitive_fn/eyeglass-exports.js
+++ b/test/fixtures/function_modules/node_modules/fn_module_a/node_modules/transitive_fn/eyeglass-exports.js
@@ -1,10 +1,12 @@
+"use strict";
+
 module.exports = function(eyeglass, sass) {
   return {
-    sass_dir: __dirname, // directory where the sass files are.
+    sass: __dirname, // directory where the sass files are.
     functions: {
-      'transitive()': function(done) {
+      "transitive()": function(done) {
         done(sass.types.String("transitive"));
       }
     }
-  }
+  };
 };

--- a/test/test_function_loading.js
+++ b/test/test_function_loading.js
@@ -1,54 +1,56 @@
-'use strict';
+"use strict";
 
-var assert   = require("assert"),
-    sass     = require("node-sass"),
-    path     = require("path"),
-    eyeglass = require('../lib'),
-    capture  = require('../lib/util/capture');
+var assert = require("assert");
+var sass = require("node-sass");
+var path = require("path");
+var eyeglass = require("../lib");
+var capture = require("../lib/util/capture");
 
 function fixtureDirectory(subpath) {
   return path.join(__dirname, "fixtures", subpath);
 }
 
-describe('function loading', function () {
+describe("function loading", function () {
 
- it('should discover sass functions', function (done) {
+ it("should discover sass functions", function (done) {
    sass.render(eyeglass({
      root: fixtureDirectory("function_modules"),
-     data: '#hello { greeting: hello(Chris); }\n' +
-           '#transitive { is: transitive(); }\n',
+     data: "#hello { greeting: hello(Chris); }\n" +
+           "#transitive { is: transitive(); }\n",
      success: function(result) {
-       assert.equal("#hello {\n  greeting: Hello, Chris!; }\n\n#transitive {\n  is: transitive; }\n",
+       assert.equal("#hello {\n  greeting: Hello, Chris!; }\n\n" +
+                    "#transitive {\n  is: transitive; }\n",
                     result.css);
        done();
      }
    }));
  });
 
- it('should let me define my own sass functions too', function (done) {
+ it("should let me define my own sass functions too", function (done) {
    sass.render(eyeglass({
      root: fixtureDirectory("function_modules"),
-     data: '#hello { greeting: hello(Chris); }\n' +
-           '#mine { something: add-one(3em); }\n',
+     data: "#hello { greeting: hello(Chris); }\n" +
+           "#mine { something: add-one(3em); }\n",
      functions: {
-       "add-one($number)" : function(number) {
+       "add-one($number)": function(number) {
          return sass.types.Number(number.getValue() + 1, number.getUnit());
        }
      },
      success: function(result) {
-       assert.equal("#hello {\n  greeting: Hello, Chris!; }\n\n#mine {\n  something: 4em; }\n",
+       assert.equal("#hello {\n  greeting: Hello, Chris!; }\n\n" +
+                    "#mine {\n  something: 4em; }\n",
                     result.css);
        done();
      }
    }));
  });
 
- it('should let local functions override imported functions', function (done) {
+ it("should let local functions override imported functions", function (done) {
    sass.render(eyeglass({
      root: fixtureDirectory("function_modules"),
-     data: '#hello { greeting: hello(Chris); }\n',
+     data: "#hello { greeting: hello(Chris); }\n",
      functions: {
-       'hello($name: "World")' : function(name) {
+       "hello($name: 'World')": function(name) {
          return sass.types.String("Goodbye, " + name.getValue() + "!");
        }
      },
@@ -60,17 +62,16 @@ describe('function loading', function () {
    }));
  });
 
- it('should warn about conflicting function signatures', function (done) {
+ it("should warn about conflicting function signatures", function (done) {
    var output = "";
-   var release = capture(function(string, encoding, fd, real_write) {
-     // real_write("YO" + string);
+   var release = capture(function(string) {
      output = output + string;
    });
    sass.render(eyeglass({
      root: fixtureDirectory("function_modules"),
-     data: '#hello { greeting: hello(Chris); }\n',
+     data: "#hello { greeting: hello(Chris); }\n",
      functions: {
-       "hello($name: 'Sucker')" : function(name) {
+       "hello($name: 'Sucker')": function(name) {
          return sass.types.String("Goodbye, " + name.getValue() + "!");
        }
      },
@@ -78,10 +79,11 @@ describe('function loading', function () {
        release();
        assert.equal("#hello {\n  greeting: Goodbye, Chris!; }\n",
                     result.css);
-       assert.equal("WARNING: Function hello was redeclared with conflicting function signatures: hello($name: \"World\") vs. hello($name: 'Sucker')\n", output);
+       assert.equal("WARNING: Function hello was redeclared with " +
+                    "conflicting function signatures: hello($name: \"World\")" +
+                    " vs. hello($name: 'Sucker')\n", output);
        done();
      }
    }));
  });
 });
-

--- a/test/test_imports.js
+++ b/test/test_imports.js
@@ -1,19 +1,19 @@
-'use strict';
+"use strict";
 
-var assert   = require("assert"),
-    sass     = require("node-sass"),
-    path     = require("path"),
-    eyeglass = require('../lib'),
-    capture  = require('../lib/util/capture');
+var assert = require("assert");
+var sass = require("node-sass");
+var path = require("path");
+var eyeglass = require("../lib");
+var capture = require("../lib/util/capture");
 
 function fixtureDirectory(subpath) {
   return path.join(__dirname, "fixtures", subpath);
 }
 
-describe('core api', function () {
+describe("core api", function () {
 
- it('should compile a sass file', function (done) {
-    var result = sass.render({
+ it("should compile a sass file", function (done) {
+    sass.render({
       data: "div { $c: red; color: $c; }",
       success: function(result) {
         assert.equal("div {\n  color: red; }\n", result.css);
@@ -22,8 +22,8 @@ describe('core api', function () {
     });
  });
 
- it('should compile a sass file with a custom function', function (done) {
-    var result = sass.render({
+ it("should compile a sass file with a custom function", function (done) {
+    sass.render({
       data: "div { content: hello-world(); }",
       functions: {
         "hello-world()": function() {
@@ -31,39 +31,39 @@ describe('core api', function () {
         }
       },
       success: function(result) {
-        assert.equal("div {\n  content: \"Hello World!\"; }\n", result.css);
+        assert.equal('div {\n  content: "Hello World!"; }\n', result.css);
         done();
       }
     });
  });
 
- it('should compile a sass file with a custom async function', function (done) {
-    var result = sass.render({
+ it("should compile a sass file with a custom async function", function (done) {
+    sass.render({
       data: "div { content: hello-world(); }",
       functions: {
-        "hello-world()": function(done) {
+        "hello-world()": function(sassCb) {
           setTimeout(function() {
-            done(sass.types.String('"Hello World!"'));
+            sassCb(sass.types.String('"Hello World!"'));
           });
         }
       },
       success: function(result) {
-        assert.equal("div {\n  content: \"Hello World!\"; }\n", result.css);
+        assert.equal('div {\n  content: "Hello World!"; }\n', result.css);
         done();
       }
     });
  });
 
- it('passes through node-sass options', function (done) {
-    var result = sass.render(eyeglass({
+ it("passes through node-sass options", function (done) {
+    sass.render(eyeglass({
       data: "div { content: hello-world(); }",
       functions: {
-        "hello-world()": function(done) {
+        "hello-world()": function() {
           return sass.types.String('"Hello World!"');
         }
       },
       success: function(result) {
-        assert.equal("div {\n  content: \"Hello World!\"; }\n", result.css);
+        assert.equal('div {\n  content: "Hello World!"; }\n', result.css);
         done();
       }
     }));
@@ -71,21 +71,22 @@ describe('core api', function () {
 
 });
 
-describe('eyeglass importer', function () {
+describe("eyeglass importer", function () {
 
- it('lets you import sass files from npm modules', function (done) {
-    var result = sass.render(eyeglass({
+ it("lets you import sass files from npm modules", function (done) {
+    sass.render(eyeglass({
       root: fixtureDirectory("basic_modules"),
       data: '@import "<module_a>";',
       success: function(result) {
-        assert.equal(".module-a {\n  greeting: hello world; }\n\n.sibling-in-module-a {\n  sibling: yes; }\n", result.css);
+        assert.equal(".module-a {\n  greeting: hello world; }\n\n" +
+                     ".sibling-in-module-a {\n  sibling: yes; }\n", result.css);
         done();
       }
     }));
  });
 
- it('lets you import from a subdirectory from a sass npm module', function (done) {
-    var result = sass.render(eyeglass({
+ it("lets you import from a subdir in a npm module", function (done) {
+    sass.render(eyeglass({
       root: fixtureDirectory("basic_modules"),
       data: '@import "<module_a>/submodule";',
       success: function(result) {
@@ -95,8 +96,8 @@ describe('eyeglass importer', function () {
     }));
  });
 
- it('lets you import explicitly from a subdirectory from a sass npm module', function (done) {
-    var result = sass.render(eyeglass({
+ it("lets you import explicitly from a subdir in a module", function (done) {
+    sass.render(eyeglass({
       root: fixtureDirectory("basic_modules"),
       data: '@import "<module_a>/submodule/_index.scss";',
       success: function(result) {
@@ -106,8 +107,8 @@ describe('eyeglass importer', function () {
     }));
  });
 
- it('lets you import sass files from a transitive dependency', function (done) {
-    var result = sass.render(eyeglass({
+ it("lets you import sass files from a transitive dependency", function (done) {
+    sass.render(eyeglass({
       root: fixtureDirectory("basic_modules"),
       data: '@import "<module_a>/transitive_imports";',
       success: function(result) {
@@ -117,9 +118,9 @@ describe('eyeglass importer', function () {
     }));
  });
 
- it('does not let you import transitive sass files', function (done) {
+ it("does not let you import transitive sass files", function (done) {
    var output = "";
-   var release = capture(function(string, encoding, fd, real_write) {
+   var release = capture(function(string) {
      output = output + string;
    }, "stderr");
    sass.render(eyeglass({
@@ -129,7 +130,8 @@ describe('eyeglass importer', function () {
        release();
        // TODO This should not be a successful compile (libsass issue?)
        assert.equal("", result.css);
-       assert.equal("{ [Error: Cannot find module 'transitive_module'] code: 'MODULE_NOT_FOUND' }\n", output);
+       assert.equal("{ [Error: Cannot find module 'transitive_module']" +
+                    " code: 'MODULE_NOT_FOUND' }\n", output);
        done();
      }
    }));


### PR DESCRIPTION
This commit is uncomfortably large due to the amount of scrubbing that was done. That said, I'm really glad we're addressing this now.

* All files are now compatible with the ESLint file defined in [sass-eyeglass/eyeglass-dev-eslint](https://github.com/sass-eyeglass/eyeglass-dev-eslint).
* gulp was chosen as the build pipeline. It was easier than grunt to programatically invoke things for what we were doing

All tests are passing still, and now they all pass ESLint as well. This sets us up for CI integration.