### PR TITLE
Correctly handle when an npm module is itself an eyeglass module.

### DIFF
--- a/lib/function_loader.js
+++ b/lib/function_loader.js
@@ -21,8 +21,7 @@ function checkConflicts(obj1, obj2) {
       var fnName = attr.replace(ARGUMENTS_REGEX, "");
       if (keys[fnName] && keys[fnName] !== attr) {
         // Better way to report warnings.
-        // XXX this should be console.warn (which goes to stderr)
-        console.log("WARNING: Function " + fnName +
+        console.warn("WARNING: Function " + fnName +
           " was redeclared with conflicting function signatures: " +
           keys[fnName] + " vs. " + attr);
       }

--- a/lib/module_importer.js
+++ b/lib/module_importer.js
@@ -116,6 +116,11 @@ function makeImporter(eyeglass, sass, options, fallbackImporter) {
       }
 
       var sassDir = require(jsFile)(eyeglass, sass).sassDir;
+
+      if (!sassDir) {
+        throw new Error("sassDir is not specified in " + jsFile);
+      }
+
       var filenameSegments = [sassDir];
 
       if (relativePath) {

--- a/lib/module_importer.js
+++ b/lib/module_importer.js
@@ -2,7 +2,6 @@
 
 var fs = require("fs");
 var path = require("path");
-var resolve = require("./util/resolve");
 var efs = require("./util/files");
 var discover = require("./util/discover");
 

--- a/lib/module_importer.js
+++ b/lib/module_importer.js
@@ -4,6 +4,7 @@ var fs = require("fs");
 var path = require("path");
 var resolve = require("./util/resolve");
 var efs = require("./util/files");
+var discover = require("./util/discover");
 
 var IMPORT_REGEX = /^<([^>]+)>(?:\/(.+))?$/;
 
@@ -51,6 +52,17 @@ function readFirstFile(uri, filenames, cb, examinedFiles) {
   });
 }
 
+function packageRootDir(dir) {
+  if (fs.existsSync(path.join(dir, "package.json"))) {
+    return dir;
+  } else {
+    var parentDir = path.resolve(dir, "..");
+    if (parentDir !== dir) {
+      return packageRootDir(parentDir);
+    }
+  }
+}
+
 /*
  * Returns an importer suitable for passing to node-sass.
  * options are the eyeglass/node-sass options.
@@ -60,6 +72,21 @@ function readFirstFile(uri, filenames, cb, examinedFiles) {
 function makeImporter(eyeglass, sass, options, fallbackImporter) {
   var importedFiles = {};
   var root = options.root;
+  var allModulesCache = {};
+
+  function getModuleByName(moduleName, dir) {
+    var allModules = allModulesCache[dir];
+    if (!allModules) {
+      allModules = discover.all(dir, true).modules;
+      allModulesCache[dir] = allModules;
+    }
+
+    for (var i = 0; i < allModules.length; i++) {
+      if (moduleName === allModules[i].name) {
+        return allModules[i].main;
+      }
+    }
+  }
 
   function importOnce(data, done) {
     if (importedFiles[data.file]) {
@@ -78,18 +105,16 @@ function makeImporter(eyeglass, sass, options, fallbackImporter) {
       // This is an import of the form "<node_module>/some/file"
       var moduleName = match[1];
       var relativePath = match[2];
-      var jsFile;
+      var pkgRootDir = isRealFile ? packageRootDir(path.dirname(prev)) : root;
+      var jsFile = getModuleByName(moduleName, pkgRootDir);
 
-      try {
-        jsFile = (isRealFile) ?
-                      resolve(moduleName, prev, path.dirname(prev)) :
-                      resolve(moduleName, root, root);
-      } catch (e) {
-        // TODO: https://github.com/sass-eyeglass/eyeglass/issues/2
-        console.error(e);
+      if (!jsFile) {
+        console.error("No Eyeglass module named '" + moduleName +
+                      "' could be found while importing '" + uri + "'.");
         done({});
         return;
       }
+
       var sassDir = require(jsFile)(eyeglass, sass).sassDir;
       var filenameSegments = [sassDir];
 

--- a/lib/util/discover.js
+++ b/lib/util/discover.js
@@ -33,7 +33,9 @@ function discover(dir, shallow) {
     function resolvedModuleDef(pkg, parent, inDir, parentName, parentVersion) {
       var packageName = parentName ? pkg.name : "./";
       var eyeglassExports;
-      if (pkg.eyeglass) {
+      if (pkg.eyeglass && packageName === "./") {
+        eyeglassExports = packageName + pkg.eyeglass;
+      } else if (pkg.eyeglass) {
         eyeglassExports = path.join(packageName, pkg.eyeglass);
       } else {
         eyeglassExports = packageName; // use node default

--- a/lib/util/discover.js
+++ b/lib/util/discover.js
@@ -16,8 +16,7 @@ function getPackage(dir) {
   return JSON.parse(data);
 }
 
-function discover(dir) {
-  return (function() {
+function discover(dir, shallow) {
     var seen = {};
     var allModules = [];
     var topPackage = getPackage(dir);
@@ -27,7 +26,44 @@ function discover(dir) {
       return allModules;
     }
 
-    function scan(inDir, parentName, parentVersion) {
+    function isEyeglassPlugin(pkg) {
+      return pkg.keywords && pkg.keywords.indexOf("eyeglass-module") >= 0;
+    }
+
+    function resolvedModuleDef(pkg, parent, inDir, parentName, parentVersion) {
+      var packageName = parentName ? pkg.name : "./";
+      var eyeglassExports;
+      if (pkg.eyeglass) {
+        eyeglassExports = path.join(packageName, pkg.eyeglass);
+      } else {
+        eyeglassExports = packageName; // use node default
+      }
+
+      var resolvedPkg = {
+        name: pkg.name,
+        version: pkg.version,
+        main: resolve(eyeglassExports, parent, inDir)
+      };
+
+      if (parentName) {
+        resolvedPkg.origin = {
+          name: parentName,
+          version: parentVersion
+        };
+      }
+
+      return resolvedPkg;
+    }
+
+    function shouldRecurse(depth) {
+      return (depth !== undefined && depth > 0) || depth === undefined;
+    }
+
+    function nextDepth(depth) {
+      return (depth !== undefined && depth > 0) ? depth - 1 : depth;
+    }
+
+    function scan(inDir, parentName, parentVersion, depth) {
       var pkg = getPackage(inDir);
       var parent = path.join(inDir, "package.json");
       var modules = [];
@@ -35,7 +71,7 @@ function discover(dir) {
       if (!pkg) {
         return modules;
       }
-      if (!pkg.keywords || pkg.keywords.indexOf("eyeglass-module") === -1) {
+      if (!isEyeglassPlugin(pkg)) {
         return modules;
       }
       if (seen[pkg.name + "@" + pkg.version]) {
@@ -43,38 +79,38 @@ function discover(dir) {
       }
 
       seen[pkg.name + "@" + pkg.version] = 1;
-      modules.push({
-        name: pkg.name,
-        version: pkg.version,
-        origin: {
-          name: parentName,
-          version: parentVersion
-        },
-        main: resolve(pkg.name, parent, inDir)
-      });
 
-      if (pkg.dependencies) {
+      modules.push(resolvedModuleDef(pkg, parent, inDir, parentName, parentVersion));
+
+      if (pkg.dependencies && shouldRecurse(depth)) {
         Object.keys(pkg.dependencies).forEach(function(dep) {
           var p = resolve(dep + "/package.json", parent, inDir);
           modules = modules.concat(scan(path.dirname(p),
-                                   pkg.name,
-                                   pkg.version));
+                                        pkg.name,
+                                        pkg.version,
+                                        nextDepth(depth)));
         });
       }
 
       return modules;
     }
 
+    // look at top package and add itself if it's an eyeglass plugin.
+    if (isEyeglassPlugin(topPackage)) {
+      allModules.push(resolvedModuleDef(topPackage, topParent, dir));
+    }
+
+    // look at all dependencies and find the eyeglass plugins.
     if (topPackage.dependencies) {
       Object.keys(topPackage.dependencies).forEach(function(dep) {
         var p = resolve(dep + "/package.json", topParent, dir);
-        allModules = allModules.concat(scan(path.dirname(p)));
+        allModules = allModules.concat(scan(path.dirname(p),
+                                            undefined, undefined,
+                                            shallow ? 0 : undefined));
       });
     }
 
     return allModules;
-
-  }());
 }
 
 function simplify(modules) {
@@ -115,15 +151,13 @@ function simplify(modules) {
   };
 }
 
-function getModules(dir) {
-  var allModules = discover(dir);
-  var results = simplify(allModules);
-  return results;
+function getModules(dir, shallow) {
+  return simplify(discover(dir, shallow));
 }
 
-function getSimple(dir) {
+function getSimple(dir, shallow) {
   var results = [];
-  var modules = getModules(dir).modules;
+  var modules = getModules(dir, shallow).modules;
   for (var i = 0; i < modules.length; i++) {
     results.push(modules[i].main);
   }

--- a/lib/util/discover.js
+++ b/lib/util/discover.js
@@ -57,15 +57,7 @@ function discover(dir, shallow) {
       return resolvedPkg;
     }
 
-    function shouldRecurse(depth) {
-      return (depth !== undefined && depth > 0) || depth === undefined;
-    }
-
-    function nextDepth(depth) {
-      return (depth !== undefined && depth > 0) ? depth - 1 : depth;
-    }
-
-    function scan(inDir, parentName, parentVersion, depth) {
+    function scan(inDir, parentName, parentVersion) {
       var pkg = getPackage(inDir);
       var parent = path.join(inDir, "package.json");
       var modules = [];
@@ -82,15 +74,15 @@ function discover(dir, shallow) {
 
       seen[pkg.name + "@" + pkg.version] = 1;
 
-      modules.push(resolvedModuleDef(pkg, parent, inDir, parentName, parentVersion));
+      modules.push(resolvedModuleDef(pkg, parent, inDir,
+                                     parentName, parentVersion));
 
-      if (pkg.dependencies && shouldRecurse(depth)) {
+      if (pkg.dependencies && !shallow) {
         Object.keys(pkg.dependencies).forEach(function(dep) {
           var p = resolve(dep + "/package.json", parent, inDir);
           modules = modules.concat(scan(path.dirname(p),
                                         pkg.name,
-                                        pkg.version,
-                                        nextDepth(depth)));
+                                        pkg.version));
         });
       }
 
@@ -106,9 +98,7 @@ function discover(dir, shallow) {
     if (topPackage.dependencies) {
       Object.keys(topPackage.dependencies).forEach(function(dep) {
         var p = resolve(dep + "/package.json", topParent, dir);
-        allModules = allModules.concat(scan(path.dirname(p),
-                                            undefined, undefined,
-                                            shallow ? 0 : undefined));
+        allModules = allModules.concat(scan(path.dirname(p)));
       });
     }
 

--- a/test/fixtures/basic_modules/node_modules/module_a/package.json
+++ b/test/fixtures/basic_modules/node_modules/module_a/package.json
@@ -2,5 +2,8 @@
   "name": "module_a",
   "keywords": ["eyeglass-module"],
   "main": "eyeglass-exports.js",
-  "private": true
+  "private": true,
+  "dependencies": {
+    "transitive_module": "*"
+  }
 }

--- a/test/fixtures/basic_modules/package.json
+++ b/test/fixtures/basic_modules/package.json
@@ -1,9 +1,9 @@
 {
-  "name": "function_modules",
+  "name": "basic_modules",
   "version": "0.0.1",
   "main": "package.json",
   "private": true,
   "dependencies": {
-    "fn_module_a": "*"
+    "module_a": "*"
   }
 }

--- a/test/fixtures/has_a_main_already/eyeglass-exports.js
+++ b/test/fixtures/has_a_main_already/eyeglass-exports.js
@@ -1,0 +1,12 @@
+"use strict";
+
+module.exports = function(eyeglass, sass) {
+  return {
+    sassDir: __dirname, // directory where the sass files are.
+    functions: {
+      "hello($name: 'Not Main')": function(name, done) {
+        done(sass.types.String("Hello, " + name.getValue() + "!"));
+      }
+    }
+  };
+};

--- a/test/fixtures/has_a_main_already/index.scss
+++ b/test/fixtures/has_a_main_already/index.scss
@@ -1,0 +1,3 @@
+.has-a-main {
+  main: already;
+}

--- a/test/fixtures/has_a_main_already/main.js
+++ b/test/fixtures/has_a_main_already/main.js
@@ -1,0 +1,1 @@
+throw new Error("This should not have been loaded.");

--- a/test/fixtures/has_a_main_already/package.json
+++ b/test/fixtures/has_a_main_already/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "has_a_main_already",
+  "main": "main.js",
+  "eyeglass": "eyeglass-exports.js",
+  "keywords": ["eyeglass-module"],
+  "private": true
+}

--- a/test/fixtures/is_a_module/eyeglass-exports.js
+++ b/test/fixtures/is_a_module/eyeglass-exports.js
@@ -2,7 +2,7 @@
 
 module.exports = function(eyeglass, sass) {
   return {
-    sass: __dirname, // directory where the sass files are.
+    sassDir: __dirname, // directory where the sass files are.
     functions: {
       "hello($name: Myself)": function(name, done) {
         done(sass.types.String("Hello, " + name.getValue() + "!"));

--- a/test/fixtures/is_a_module/eyeglass-exports.js
+++ b/test/fixtures/is_a_module/eyeglass-exports.js
@@ -1,0 +1,12 @@
+"use strict";
+
+module.exports = function(eyeglass, sass) {
+  return {
+    sass: __dirname, // directory where the sass files are.
+    functions: {
+      "hello($name: Myself)": function(name, done) {
+        done(sass.types.String("Hello, " + name.getValue() + "!"));
+      }
+    }
+  };
+};

--- a/test/fixtures/is_a_module/index.scss
+++ b/test/fixtures/is_a_module/index.scss
@@ -1,0 +1,3 @@
+.is-a-module {
+  this: is a module;
+}

--- a/test/fixtures/is_a_module/package.json
+++ b/test/fixtures/is_a_module/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "is_a_module",
+  "main": "eyeglass-exports.js",
+  "keywords": ["eyeglass-module"],
+  "private": true
+}

--- a/test/test_function_loading.js
+++ b/test/test_function_loading.js
@@ -7,7 +7,8 @@ var eyeglass = require("../lib");
 var capture = require("../lib/util/capture");
 
 function fixtureDirectory(subpath) {
-  return path.join(__dirname, "fixtures", subpath);
+  var p = path.join(__dirname, "fixtures", subpath);
+  return p;
 }
 
 describe("function loading", function () {
@@ -92,4 +93,18 @@ describe("function loading", function () {
      }
    }));
  });
+
+ it("load functions from modules if they are themselves a npm eyeglass module.",
+    function (done) {
+      sass.render(eyeglass({
+        root: fixtureDirectory("is_a_module"),
+        data: "#hello { greeting: hello(); }\n",
+        success: function(result) {
+          assert.equal("#hello {\n  greeting: Hello, Myself!; }\n",
+                       result.css);
+                       done();
+        }
+      }));
+  });
+
 });

--- a/test/test_function_loading.js
+++ b/test/test_function_loading.js
@@ -72,7 +72,7 @@ describe("function loading", function () {
    var output = "";
    var release = capture(function(string) {
      output = output + string;
-   });
+   }, "stderr");
    sass.render(eyeglass({
      root: fixtureDirectory("function_modules"),
      data: "#hello { greeting: hello(Chris); }\n",

--- a/test/test_imports.js
+++ b/test/test_imports.js
@@ -130,8 +130,8 @@ describe("eyeglass importer", function () {
        release();
        // TODO This should not be a successful compile (libsass issue?)
        assert.equal("", result.css);
-       assert.equal("{ [Error: Cannot find module 'transitive_module']" +
-                    " code: 'MODULE_NOT_FOUND' }\n", output);
+       assert.equal("No Eyeglass module named 'transitive_module' could be " +
+                    "found while importing '<transitive_module>'.\n", output);
        done();
      }
    }));
@@ -148,5 +148,18 @@ describe("eyeglass importer", function () {
       }
     }));
  });
+
+ it("imports modules if they are themselves a npm eyeglass module.",
+    function (done) {
+      sass.render(eyeglass({
+        root: fixtureDirectory("is_a_module"),
+        data: '@import "<is_a_module>";',
+        success: function(result) {
+          assert.equal(".is-a-module {\n  this: is a module; }\n", result.css);
+          done();
+        }
+      }));
+    }
+ );
 
 });

--- a/test/test_imports.js
+++ b/test/test_imports.js
@@ -162,4 +162,18 @@ describe("eyeglass importer", function () {
     }
  );
 
+ it("eyeglass exports can be specified through the " +
+    "eyeglass property of package.json.",
+    function (done) {
+      sass.render(eyeglass({
+        root: fixtureDirectory("has_a_main_already"),
+        data: '@import "<has_a_main_already>";',
+        success: function(result) {
+          assert.equal(".has-a-main {\n  main: already; }\n", result.css);
+          done();
+        }
+      }));
+    }
+ );
+
 });


### PR DESCRIPTION
This lets code in tests written for an eyeglass module work exactly like it would if it were a consumer of the module using dependencies.