### PR TITLE
Removes need to differentiate between sync/async custom functions

### DIFF
--- a/lib/eyeglass-exports.js
+++ b/lib/eyeglass-exports.js
@@ -1,0 +1,11 @@
+"use strict";
+
+var path = require("path");
+
+module.exports = function(eyeglass, sass) {
+  var opts = {
+    sassDir: path.join(__dirname, "..", "sass"), // directory where the sass files are.
+    functions: require("./functions")(eyeglass, sass)
+  };
+  return opts;
+};

--- a/lib/function_loader.js
+++ b/lib/function_loader.js
@@ -1,6 +1,7 @@
 "use strict";
 
 var discover = require("./util/discover");
+var syncFn = require("./util/sync_fn");
 var hash = require("./util/hash");
 var ARGUMENTS_REGEX = /\(.*\)$/;
 
@@ -44,5 +45,8 @@ module.exports = function(eyeglass, sass, options, existingFunctions) {
 
   checkConflicts(functions, existingFunctions);
   hash.merge(functions, existingFunctions);
+
+  functions = syncFn.all(functions);
+
   return functions;
 };

--- a/lib/function_loader.js
+++ b/lib/function_loader.js
@@ -32,7 +32,6 @@ function checkConflicts(obj1, obj2) {
 module.exports = function(eyeglass, sass, options, existingFunctions) {
   var root = options.root;
   var functions = {};
-  hash.merge(functions, require("./functions")(eyeglass, sass));
   var modules = autoDiscoverModules(root);
 
   modules.forEach(function(m) {

--- a/lib/function_loader.js
+++ b/lib/function_loader.js
@@ -32,6 +32,7 @@ function checkConflicts(obj1, obj2) {
 module.exports = function(eyeglass, sass, options, existingFunctions) {
   var root = options.root;
   var functions = {};
+  hash.merge(functions, require("./functions")(eyeglass, sass));
   var modules = autoDiscoverModules(root);
 
   modules.forEach(function(m) {

--- a/lib/functions.js
+++ b/lib/functions.js
@@ -4,7 +4,7 @@ var hash = require("./util/hash");
 
 module.exports = function(eyeglass, sass) {
   var functions = {};
-  ["asset_url"].forEach(function(name) {
+  ["asset_url", "version"].forEach(function(name) {
     var fn = require("./functions/" + name)(eyeglass, sass);
     hash.merge(functions, fn);
   });

--- a/lib/functions.js
+++ b/lib/functions.js
@@ -1,0 +1,12 @@
+"use strict";
+
+var hash = require("./util/hash");
+
+module.exports = function(eyeglass, sass) {
+  var functions = {};
+  ["asset_url"].forEach(function(name) {
+    var fn = require("./functions/" + name)(eyeglass, sass);
+    hash.merge(functions, fn);
+  });
+  return functions;
+};

--- a/lib/functions/asset_url.js
+++ b/lib/functions/asset_url.js
@@ -1,9 +1,17 @@
 "use strict";
 
+var unquote = require("../util/unquote");
+
 module.exports = function(eyeglass, sass) {
   return {
-    "asset-url($relative-path)": function(relativePath, done) {
-      done(sass.types.String("url(" + relativePath.getValue() + ")"));
+    "eyeglass-asset-uri($relative-path)": function(relativePathString, done) {
+      var relativePath = unquote(relativePathString.getValue());
+      var assetLocation = eyeglass.findAsset(relativePath);
+      if (assetLocation) {
+        done(sass.types.String(assetLocation.httpDir + "/" + relativePath));
+      } else {
+        done(sass.types.Error("Asset not found: " + relativePath));
+      }
     }
   };
 };

--- a/lib/functions/asset_url.js
+++ b/lib/functions/asset_url.js
@@ -1,0 +1,9 @@
+"use strict";
+
+module.exports = function(eyeglass, sass) {
+  return {
+    "asset-url($relative-path)": function(relativePath, done) {
+      done(sass.types.String("url(" + relativePath.getValue() + ")"));
+    }
+  };
+};

--- a/lib/functions/version.js
+++ b/lib/functions/version.js
@@ -1,0 +1,35 @@
+"use strict";
+
+var discover = require("../util/discover");
+var unquote = require("../util/unquote");
+
+// REFACTOR ME: this is copy pasta from module_importer.js
+function eyeglassName(moduleDef) {
+  return (moduleDef.eyeglass &&
+         typeof moduleDef.eyeglass == "object" &&
+         moduleDef.eyeglass.name) ||
+         moduleDef.name;
+}
+
+
+
+module.exports = function(eyeglass, sass) {
+  return {
+    "eyeglass-version($module: eyeglass)": function(moduleName, done) {
+      var name = unquote(moduleName.getValue());
+      var modules = discover.all(eyeglass.root()).modules; // TODO Cache this value?
+      var mod;
+      for (var i = 0; i < modules.length; i++) {
+        if (eyeglassName(modules[i]) === name) {
+          mod = modules[i];
+          break;
+        }
+      }
+      if (mod) {
+        done(sass.types.String('"' + (mod.version || "versonless") + '"'));
+      } else {
+        done(sass.types.Null());
+      }
+    }
+  };
+};

--- a/lib/index.js
+++ b/lib/index.js
@@ -23,6 +23,7 @@ AssetLocation.prototype = {
 function Eyeglass(options, sass) {
   sass = sass || require("node-sass");
   this.options = this.normalizeOptions(sass, options);
+  this.enableImportOnce = true;
   this.assetPath = [];
 }
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -2,20 +2,30 @@
 
 var importer = require("./module_importer");
 var customFunctions = require("./function_loader");
-var nodeSass = require("node-sass");
 
-
-function normalizeOptions(eyeglass, sass, options) {
- if (!options.root) {
-   options.root = process.cwd();
- }
- options.importer = importer(eyeglass, sass, options, options.importer);
- options.functions = customFunctions(eyeglass,
-                                     sass,
-                                     options,
-                                     options.functions);
- return options;
+function Eyeglass(options, sass) {
+  sass = sass || require("node-sass");
+  this.options = this.normalizeOptions(sass, options);
 }
+
+Eyeglass.prototype = {
+  defaultRoot: function() {
+    return process.cwd();
+  },
+  root: function() {
+    return this.options.root;
+  },
+  sassOptions: function() {
+    // TODO remove eyeglass specific options or maybe namespace them?
+    return this.options;
+  },
+  normalizeOptions: function(sass, options) {
+    options.root = options.root || this.defaultRoot();
+    options.importer = importer(this, sass, options, options.importer);
+    options.functions = customFunctions(this, sass, options, options.functions);
+    return options;
+  }
+};
 
 /*
  * options: Everything node-sass supports, plus:
@@ -23,6 +33,5 @@ function normalizeOptions(eyeglass, sass, options) {
  *
  */
 module.exports = function(options) {
-  var eyeglassObject = {};
-  return normalizeOptions(eyeglassObject, nodeSass, options);
+  return new Eyeglass(options);
 };

--- a/lib/index.js
+++ b/lib/index.js
@@ -2,10 +2,28 @@
 
 var importer = require("./module_importer");
 var customFunctions = require("./function_loader");
+var path = require("path");
+var fs = require("fs");
+
+function existsSync(file) {
+  // This fs method is going to be deprecated
+  // but can be re-implemented with fs.accessSync later.
+  return fs.existsSync(file);
+}
+
+function AssetLocation(sourceDir, httpDir, buildDir) {
+  this.sourceDir = sourceDir;
+  this.httpDir = httpDir;
+  this.buildDir = buildDir;
+}
+
+AssetLocation.prototype = {
+};
 
 function Eyeglass(options, sass) {
   sass = sass || require("node-sass");
   this.options = this.normalizeOptions(sass, options);
+  this.assetPath = [];
 }
 
 Eyeglass.prototype = {
@@ -24,6 +42,34 @@ Eyeglass.prototype = {
     options.importer = importer(this, sass, options, options.importer);
     options.functions = customFunctions(this, sass, options, options.functions);
     return options;
+  },
+  // Register assets to be referenced by asset-url().
+  // @param sourceDir The source directory containing assets
+  // @param httpDir The directory from where the assets are served to the web.
+  // @param buildDir [Optional] The intermediate location where these assets should be copied during build.
+  assets: function(sourceDir, httpDir, buildDir) {
+    sourceDir = path.resolve(this.root(), sourceDir);
+    buildDir = buildDir && path.resolve(this.root(), buildDir);
+    this.assetPath.push(new AssetLocation(sourceDir, httpDir, buildDir));
+  },
+  PATH_SEPARATOR_REGEX: /\//g,
+  // Finds an asset in the asset path.
+  findAsset: function(relativePath) {
+    // All sass files should use forward slash (/) to separate paths.
+    // We translate this to the windows separator if needed.
+    if (path.sep !== "/") {
+      relativePath = relativePath.replace(this.PATH_SEPARATOR_REGEX, path.sep);
+    }
+    // Look for this file in all the locations
+    for (var i = 0; i < this.assetPath.length; i++) {
+      var pathEntry = this.assetPath[i];
+      var fullSourcePath = path.join(pathEntry.sourceDir, relativePath);
+      if (existsSync(fullSourcePath)) {
+        // TODO URL formatting
+        // TODO Asset installation
+        return pathEntry;
+      }
+    }
   }
 };
 

--- a/lib/module_importer.js
+++ b/lib/module_importer.js
@@ -7,6 +7,14 @@ var discover = require("./util/discover");
 
 var IMPORT_REGEX = /^<([^>]+)>(?:\/(.+))?$/;
 
+// Returns whether a file exists.
+function existsSync(file) {
+  // This fs method is going to be deprecated
+  // but can be re-implemented with fs.accessSync later.
+  return fs.existsSync(file);
+}
+
+
 /*
  * All imports use the forward slash as a directory
  * delimeter. This function converts to the filesystem's
@@ -23,6 +31,11 @@ function makeFsPath(importPath) {
 // This is a bootstrap function for calling readFirstFile.
 function readAbstractFile(uri, abstractName, cb) {
   readFirstFile(uri, efs.getFileNames(abstractName), cb);
+}
+
+// This is a bootstrap function for calling readFirstFile.
+function readAbstractFileSync(uri, abstractName) {
+  return readFirstFileSync(uri, efs.getFileNames(abstractName));
 }
 
 /*
@@ -44,11 +57,25 @@ function readFirstFile(uri, filenames, cb, examinedFiles) {
       }
     } else {
       cb(null, {
-        contents: data,
+        contents: data.toString(),
         file: filename
       });
     }
   });
+}
+
+function readFirstFileSync(uri, filenames) {
+  for (var i = 0; i < filenames.length; i++) {
+    if (existsSync(filenames[i])) {
+      return {
+        contents: fs.readFileSync(filenames[i]).toString(),
+        file: filenames[i]
+      };
+    }
+  }
+  throw new Error("Could not import " + uri +
+                  " from any of the following locations: " +
+                  filenames.join(", "))
 }
 
 function packageRootDir(dir) {
@@ -96,13 +123,22 @@ function makeImporter(eyeglass, sass, options, fallbackImporter) {
 
   function importOnce(data, enabled, done) {
     if (enabled && importedFiles[data.file]) {
-      done({contents: "", filename: "already-imported:" + data.file});
+      var rv = {contents: "", filename: "already-imported:" + data.file};
+      if (done) {
+        done(rv);
+      } else {
+        return rv;
+      }
     } else {
       importedFiles[data.file] = true;
-      done(data);
+      if (done) {
+        done(data);
+      } else {
+        return data;
+      }
     }
   }
-
+  /*eslint-disable */
   return function(uri, prev, done) {
     var isRealFile = fs.existsSync(prev);
     var match = uri.match(IMPORT_REGEX);
@@ -136,37 +172,61 @@ function makeImporter(eyeglass, sass, options, fallbackImporter) {
 
       var abstractName = path.join.apply(path, filenameSegments);
 
-      readAbstractFile(uri, abstractName, function(err, data) {
-        if (err) {
-          // TODO: https://github.com/sass-eyeglass/eyeglass/issues/2
-          console.error(err.toString());
-          done({});
-        } else {
-          importOnce(data, eyeglass.enableImportOnce, done);
-        }
-      });
+      if (done) {
+        readAbstractFile(uri, abstractName, function(err, data) {
+          if (err) {
+            // TODO: https://github.com/sass-eyeglass/eyeglass/issues/2
+            console.error(err.toString());
+            done({});
+          } else {
+            importOnce(data, eyeglass.enableImportOnce, done);
+          }
+        });
+      } else {
+        return importOnce(readAbstractFileSync(uri, abstractName),
+                          eyeglass.enableImportOnce, done);
+      }
 
     } else if (isRealFile) {
       // This is a sass file that is potentially relative to the
       // previous import.
       var f = path.resolve(path.dirname(prev), makeFsPath(uri));
-      readAbstractFile(uri, f, function(err, data) {
-        if (err) {
+      if (done) {
+        readAbstractFile(uri, f, function(err, data) {
+          if (err) {
+            // TODO: https://github.com/sass-eyeglass/eyeglass/issues/2
+            console.error(err.toString());
+            done({});
+          } else {
+            importOnce(data, eyeglass.enableImportOnce, done);
+          }
+        });
+      } else {
+        try { 
+          return importOnce(readAbstractFileSync(uri, f), eyeglass.enableImportOnce, done)
+        } catch(e) {
           // TODO: https://github.com/sass-eyeglass/eyeglass/issues/2
           console.error(err.toString());
-          done({});
-        } else {
-          importOnce(data, eyeglass.enableImportOnce, done);
+          return {};
         }
-      });
+      }
     } else if (fallbackImporter) {
       // Not our import
-      fallbackImporter(uri, prev, done);
+      if (done) {
+        fallbackImporter(uri, prev, done);
+      } else {
+        return fallbackImporter(uri, prev);
+      }
     } else {
-      // give up
-      done({});
+      if (done) {
+        // give up
+        done({});
+      } else {
+        return {};
+      }
     }
   };
+  /*eslint-enable */
 }
 
 module.exports = makeImporter;

--- a/lib/module_importer.js
+++ b/lib/module_importer.js
@@ -139,7 +139,7 @@ function makeImporter(eyeglass, sass, options, fallbackImporter) {
       readAbstractFile(uri, abstractName, function(err, data) {
         if (err) {
           // TODO: https://github.com/sass-eyeglass/eyeglass/issues/2
-          console.log(err.toString());
+          console.error(err.toString());
           done({});
         } else {
           importOnce(data, done);
@@ -153,7 +153,7 @@ function makeImporter(eyeglass, sass, options, fallbackImporter) {
       readAbstractFile(uri, f, function(err, data) {
         if (err) {
           // TODO: https://github.com/sass-eyeglass/eyeglass/issues/2
-          console.log(err.toString());
+          console.error(err.toString());
           done({});
         } else {
           importOnce(data, done);

--- a/lib/module_importer.js
+++ b/lib/module_importer.js
@@ -94,8 +94,8 @@ function makeImporter(eyeglass, sass, options, fallbackImporter) {
     }
   }
 
-  function importOnce(data, done) {
-    if (importedFiles[data.file]) {
+  function importOnce(data, enabled, done) {
+    if (enabled && importedFiles[data.file]) {
       done({contents: "", filename: "already-imported:" + data.file});
     } else {
       importedFiles[data.file] = true;
@@ -142,7 +142,7 @@ function makeImporter(eyeglass, sass, options, fallbackImporter) {
           console.error(err.toString());
           done({});
         } else {
-          importOnce(data, done);
+          importOnce(data, eyeglass.enableImportOnce, done);
         }
       });
 
@@ -156,7 +156,7 @@ function makeImporter(eyeglass, sass, options, fallbackImporter) {
           console.error(err.toString());
           done({});
         } else {
-          importOnce(data, done);
+          importOnce(data, eyeglass.enableImportOnce, done);
         }
       });
     } else if (fallbackImporter) {

--- a/lib/options_decorator.js
+++ b/lib/options_decorator.js
@@ -1,0 +1,8 @@
+"use strict";
+
+var Eyeglass = require("./index");
+
+module.exports = function(options) {
+  var eg = new Eyeglass(options);
+  return eg.sassOptions();
+};

--- a/lib/util/discover.js
+++ b/lib/util/discover.js
@@ -19,12 +19,9 @@ function getPackage(dir) {
 function discover(dir, shallow) {
     var seen = {};
     var allModules = [];
+
     var topPackage = getPackage(dir);
     var topParent = path.join(dir, "package.json");
-
-    if (!topPackage) {
-      return allModules;
-    }
 
     function isEyeglassPlugin(pkg) {
       return pkg.keywords && pkg.keywords.indexOf("eyeglass-module") >= 0;
@@ -108,17 +105,25 @@ function discover(dir, shallow) {
       return modules;
     }
 
-    // look at top package and add itself if it's an eyeglass plugin.
-    if (isEyeglassPlugin(topPackage)) {
-      allModules.push(resolvedModuleDef(topPackage, topParent, dir));
-    }
+    // Add eyeglass itself.
+    var eyeglassDir = path.resolve(__dirname, "..", "..");
+    var eyeglassPkgPath = path.join(eyeglassDir, "package.json");
+    var eyeglassPkg = getPackage(eyeglassDir);
+    allModules.push(resolvedModuleDef(eyeglassPkg, eyeglassPkgPath, eyeglassDir));
 
-    // look at all dependencies and find the eyeglass plugins.
-    if (topPackage.dependencies) {
-      Object.keys(topPackage.dependencies).forEach(function(dep) {
-        var p = resolve(dep + "/package.json", topParent, dir);
-        allModules = allModules.concat(scan(path.dirname(p)));
-      });
+    if (topPackage) {
+      // look at top package and add itself if it's an eyeglass plugin.
+      if (isEyeglassPlugin(topPackage)) {
+        allModules.push(resolvedModuleDef(topPackage, topParent, dir));
+      }
+
+      // look at all dependencies and find the eyeglass plugins.
+      if (topPackage.dependencies) {
+        Object.keys(topPackage.dependencies).forEach(function(dep) {
+          var p = resolve(dep + "/package.json", topParent, dir);
+          allModules = allModules.concat(scan(path.dirname(p)));
+        });
+      }
     }
 
     return allModules;

--- a/lib/util/sync_fn.js
+++ b/lib/util/sync_fn.js
@@ -1,0 +1,64 @@
+/**
+ * Custom function wrapper to ensure sync/async compatibility
+ * ---
+ * In the docs for render() and renderSync(), custom functions behave
+ * differently. However, we want eyeglass custom functions to act just like
+ * importers, always receiving an optional `done()` argument at the end. A
+ * developer can either asynchronously call `done()` or they can return a
+ * value in a synchronous manner.
+ *
+ * To make this work, we rely on the `deasync` library to turn an event loop
+ * while holding a C level `sleep()` open. This allows an async function to
+ * resolve without having to run a fiber through the entire node-sass project.
+ *
+ * The original problem and solution can be found on stack overflow:
+ * http://stackoverflow.com/questions/21819858/how-to-wrap-async-function-
+ * calls-into-a-sync-function-in-node-js-or-javascript
+ */
+"use strict";
+
+var deasync = require("deasync");
+function sync(fn) {
+  return function() {
+    var result;
+    var args = [].slice.call(arguments, 0);
+    var last = args[args.length - 1];
+
+    // last arg is a function (async capture)
+    if (typeof last === "function") {
+      return fn.apply(fn, args);
+    }
+
+    // last arg is not a function (synchronous mode)
+    // for some reason, there is a bridge object that shouldn't be on the args
+    // replace it with our custom callback
+    // turn the loop once, and then begin blocking until we resolve
+    function cb(res) {
+      setTimeout(function() {
+        result = res;
+      }, 0);
+    }
+
+    args.pop();     // bridge object BAD
+    args.push(cb);  // capture callback GOOD
+    result = fn.apply(fn, args);
+
+    if (result) {
+      return result;
+    }
+    while (!result) {
+      deasync.runLoopOnce();
+    }
+
+    return result;
+  };
+}
+
+sync.all = function(obj) {
+  for (var name in obj) {
+    obj[name] = sync(obj[name]);
+  }
+  return obj;
+};
+
+module.exports = sync;

--- a/lib/util/unquote.js
+++ b/lib/util/unquote.js
@@ -1,0 +1,11 @@
+"use strict";
+
+var UNQUOTE_RE = /^("|')(.*)\1$/;
+
+module.exports = function(string) {
+  if (string.getValue) {
+    return string.constructor(string.getValue().replace(UNQUOTE_RE, "$2"));
+  } else {
+    return string.replace(UNQUOTE_RE, "$2");
+  }
+};

--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
   },
   "dependencies": {
     "node-sass": "*",
-    "semver": "^4.2.0"
+    "semver": "^4.2.0",
+    "tmp": "0.0.25"
   },
   "devDependencies": {
     "eslint": "^0.14.1",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "exports": "lib/eyeglass-exports"
   },
   "dependencies": {
-    "node-sass": "*",
+    "node-sass": "^3.0.0-beta.5",
     "semver": "^4.2.0",
     "tmp": "0.0.25"
   },

--- a/package.json
+++ b/package.json
@@ -24,9 +24,10 @@
     "exports": "lib/eyeglass-exports"
   },
   "dependencies": {
+    "tmp": "0.0.25",
+    "deasync": "0.0.10",
     "node-sass": "^3.0.0-beta.5",
-    "semver": "^4.2.0",
-    "tmp": "0.0.25"
+    "semver": "^4.2.0"
   },
   "devDependencies": {
     "eslint": "^0.14.1",

--- a/package.json
+++ b/package.json
@@ -18,8 +18,11 @@
   },
   "keywords": [
     "sass",
-    "compass"
+    "eyeglass-module"
   ],
+  "eyeglass": {
+    "exports": "lib/eyeglass-exports"
+  },
   "dependencies": {
     "node-sass": "*",
     "semver": "^4.2.0"

--- a/sass/assets.scss
+++ b/sass/assets.scss
@@ -1,0 +1,3 @@
+@function asset-url($relative-path) {
+  @return url(eyeglass-asset-uri($relative-path));
+}

--- a/test/fixtures/basic_modules/node_modules/module_a/package.json
+++ b/test/fixtures/basic_modules/node_modules/module_a/package.json
@@ -3,6 +3,7 @@
   "keywords": ["eyeglass-module"],
   "main": "eyeglass-exports.js",
   "private": true,
+  "version": "1.0.1",
   "dependencies": {
     "transitive_module": "*"
   }

--- a/test/test_assets.js
+++ b/test/test_assets.js
@@ -1,0 +1,25 @@
+"use strict";
+
+var assert = require("assert");
+var sass = require("node-sass");
+var path = require("path");
+var eyeglass = require("../lib");
+var capture = require("../lib/util/capture");
+
+function fixtureDirectory(subpath) {
+  return path.join(__dirname, "fixtures", subpath);
+}
+
+describe("assets", function () {
+
+ it("should create a url to an asset", function (done) {
+    sass.render(eyeglass({
+      data: "div { background-image: asset-url('foo.png'); }",
+      success: function(result) {
+        assert.equal("div {\n  background-image: url('foo.png'); }\n", result.css);
+        done();
+      }
+    }));
+ });
+
+});

--- a/test/test_assets.js
+++ b/test/test_assets.js
@@ -3,23 +3,66 @@
 var assert = require("assert");
 var sass = require("node-sass");
 var path = require("path");
-var eyeglass = require("../lib");
+var tmp = require("tmp");
+var eyeglass = require("../lib/options_decorator");
+var Eyeglass = require("../lib");
 var capture = require("../lib/util/capture");
 
 function fixtureDirectory(subpath) {
   return path.join(__dirname, "fixtures", subpath);
 }
 
+function assertMultilineEqual(string1, string2) {
+  var lines1 = string1.split("\n");
+  var lines2 = string2.split("\n");
+  assert.equal(lines1.length, lines2.length, "Number of lines differ.");
+  for (var lineNumber = 0; lineNumber < lines1.length; lineNumber++) {
+    assert.equal(lines1[lineNumber], lines2[lineNumber], "Line #" + lineNumber + "differs.");
+  }
+}
+
 describe("assets", function () {
 
- it("should create a url to an asset", function (done) {
+ it("should give an error when an asset is not found", function (done) {
+   var output = "";
+   var release = capture(function(string) {
+     output = output + string;
+   }, "stderr");
     sass.render(eyeglass({
-      data: "div { background-image: asset-url('foo.png'); }",
+      data: "@import '<eyeglass>/assets'; div { background-image: asset-url('fake.png'); }",
       success: function(result) {
-        assert.equal("div {\n  background-image: url('foo.png'); }\n", result.css);
+        release();
+        assert(false, "should not have compiled to: " + result.css);
+        done();
+      },
+      error: function(error) {
+        var expected_error_message = "error in C function eyeglass-asset-uri: Asset not found: fake.png\n" +
+                                     "Backtrace:\n" +
+                                     "	sass/assets.scss:2, in function `eyeglass-asset-uri`\n" +
+                                     "	sass/assets.scss:2, in function `asset-url`\n" +
+                                     "	stdin:1";
+        assertMultilineEqual(expected_error_message, error.message);
         done();
       }
     }));
+ });
+
+ it("should let an app refer to it's own assets", function (done) {
+   var input = "@import '<eyeglass>/assets'; div { background-image: asset-url('foo.png'); font: asset-url('foo.woff'); }";
+   var expected = "div {\n  background-image: url(/assets/images/foo.png);\n  font: url(/assets/fonts/foo.woff); }\n";
+   var rootDir = fixtureDirectory("app_assets");
+   var distDir = tmp.dirSync();
+   var eg = new Eyeglass({
+     root: rootDir,
+     data: input,
+     success: function(result) {
+       assert.equal(expected, result.css);
+       done();
+     }
+   }, sass);
+   eg.assets("images", "/assets/images", path.join(distDir.name, "public", "assets", "images"));
+   eg.assets("fonts", "/assets/fonts", path.join(distDir.name, "public", "assets", "fonts"));
+   sass.render(eg.sassOptions());
  });
 
 });

--- a/test/test_assets.js
+++ b/test/test_assets.js
@@ -1,68 +1,43 @@
 "use strict";
 
-var assert = require("assert");
 var sass = require("node-sass");
 var path = require("path");
 var tmp = require("tmp");
-var eyeglass = require("../lib/options_decorator");
 var Eyeglass = require("../lib");
-var capture = require("../lib/util/capture");
-
-function fixtureDirectory(subpath) {
-  return path.join(__dirname, "fixtures", subpath);
-}
-
-function assertMultilineEqual(string1, string2) {
-  var lines1 = string1.split("\n");
-  var lines2 = string2.split("\n");
-  assert.equal(lines1.length, lines2.length, "Number of lines differ.");
-  for (var lineNumber = 0; lineNumber < lines1.length; lineNumber++) {
-    assert.equal(lines1[lineNumber], lines2[lineNumber], "Line #" + lineNumber + "differs.");
-  }
-}
+var testutils = require("./testutils");
 
 describe("assets", function () {
 
  it("should give an error when an asset is not found", function (done) {
-   var output = "";
-   var release = capture(function(string) {
-     output = output + string;
-   }, "stderr");
-    sass.render(eyeglass({
-      data: "@import '<eyeglass>/assets'; div { background-image: asset-url('fake.png'); }",
-      success: function(result) {
-        release();
-        assert(false, "should not have compiled to: " + result.css);
-        done();
-      },
-      error: function(error) {
-        var expected_error_message = "error in C function eyeglass-asset-uri: Asset not found: fake.png\n" +
-                                     "Backtrace:\n" +
-                                     "	sass/assets.scss:2, in function `eyeglass-asset-uri`\n" +
-                                     "	sass/assets.scss:2, in function `asset-url`\n" +
-                                     "	stdin:1";
-        assertMultilineEqual(expected_error_message, error.message);
-        done();
-      }
-    }));
+   testutils.assertStderr(function(checkStderr) {
+     var options = {
+       data: "@import '<eyeglass>/assets'; div { background-image: asset-url('fake.png'); }"
+     };
+     var expectedError = "error in C function eyeglass-asset-uri: Asset not found: fake.png\n" +
+                         "Backtrace:\n" +
+                         "	<eyeglass>/assets:1, in function `eyeglass-asset-uri`\n" +
+                         "	<eyeglass>/assets:1, in function `asset-url`\n" +
+                         "	stdin:0";
+     testutils.assertCompilationError(options, expectedError, function() {
+       checkStderr("");
+       done();
+     });
+   });
  });
 
  it("should let an app refer to it's own assets", function (done) {
    var input = "@import '<eyeglass>/assets'; div { background-image: asset-url('foo.png'); font: asset-url('foo.woff'); }";
    var expected = "div {\n  background-image: url(/assets/images/foo.png);\n  font: url(/assets/fonts/foo.woff); }\n";
-   var rootDir = fixtureDirectory("app_assets");
+   var rootDir = testutils.fixtureDirectory("app_assets");
    var distDir = tmp.dirSync();
    var eg = new Eyeglass({
      root: rootDir,
-     data: input,
-     success: function(result) {
-       assert.equal(expected, result.css);
-       done();
-     }
+     data: input
    }, sass);
    eg.assets("images", "/assets/images", path.join(distDir.name, "public", "assets", "images"));
    eg.assets("fonts", "/assets/fonts", path.join(distDir.name, "public", "assets", "fonts"));
-   sass.render(eg.sassOptions());
+
+   testutils.assertCompiles(eg, expected, done);
  });
 
 });

--- a/test/test_function_loading.js
+++ b/test/test_function_loading.js
@@ -3,7 +3,7 @@
 var assert = require("assert");
 var sass = require("node-sass");
 var path = require("path");
-var eyeglass = require("../lib");
+var eyeglass = require("../lib/options_decorator");
 var capture = require("../lib/util/capture");
 
 function fixtureDirectory(subpath) {

--- a/test/test_function_loading.js
+++ b/test/test_function_loading.js
@@ -1,12 +1,14 @@
 "use strict";
 
+var assert = require("assert");
 var sass = require("node-sass");
 var testutils = require("./testutils");
+
+var eyeglass = require("../lib/options_decorator");
 
 describe("function loading", function () {
 
   it("should discover sass functions", function (done) {
-    console.log("1");
     var options = {
       root: testutils.fixtureDirectory("function_modules"),
       data: "#hello { greeting: hello(Chris); }\n" +
@@ -18,7 +20,6 @@ describe("function loading", function () {
   });
 
   it("should let me define my own sass functions too", function (done) {
-    console.log("2");
     var input = "#hello { greeting: hello(Chris); }\n" +
                 "#mine { something: add-one(3em); }\n";
     var options = {
@@ -36,7 +37,6 @@ describe("function loading", function () {
   });
 
   it("should let local functions override imported functions", function (done) {
-    console.log("3");
     testutils.assertStdout(function(checkOutput) {
       var input = "#hello { greeting: hello(Chris); }\n";
       var expectedOutput = "#hello {\n  greeting: Goodbye, Chris!; }\n";
@@ -57,7 +57,6 @@ describe("function loading", function () {
   });
 
   it("should warn about conflicting function signatures", function (done) {
-    console.log("4");
     testutils.assertStderr(function(checkStderr) {
       var input = "#hello { greeting: hello(Chris); }\n";
       var options = {
@@ -81,7 +80,6 @@ describe("function loading", function () {
 
  it("load functions from modules if they are themselves a npm eyeglass module.",
     function (done) {
-   console.log("5");
       var options = {
         root: testutils.fixtureDirectory("is_a_module"),
         data: "#hello { greeting: hello(); }\n"
@@ -89,4 +87,17 @@ describe("function loading", function () {
       var expectedOutput = "#hello {\n  greeting: Hello, Myself!; }\n";
       testutils.assertCompiles(options, expectedOutput, done);
   });
+
+  it("will always block and masquerade as an asynchronous function",
+    function(done) {
+      var input = "#hello { greeting: hello(); }\n";
+      var expected = "#hello {\n  greeting: Hello, Myself!; }\n";
+      var result = sass.renderSync(eyeglass({
+        root: testutils.fixtureDirectory("is_a_module"),
+        data: input
+      }));
+      assert.equal(expected, result.css);
+      done();
+  });
+
 });

--- a/test/test_function_loading.js
+++ b/test/test_function_loading.js
@@ -1,110 +1,92 @@
 "use strict";
 
-var assert = require("assert");
 var sass = require("node-sass");
-var path = require("path");
-var eyeglass = require("../lib/options_decorator");
-var capture = require("../lib/util/capture");
-
-function fixtureDirectory(subpath) {
-  var p = path.join(__dirname, "fixtures", subpath);
-  return p;
-}
+var testutils = require("./testutils");
 
 describe("function loading", function () {
 
- it("should discover sass functions", function (done) {
-   sass.render(eyeglass({
-     root: fixtureDirectory("function_modules"),
-     data: "#hello { greeting: hello(Chris); }\n" +
-           "#transitive { is: transitive(); }\n",
-     success: function(result) {
-       assert.equal("#hello {\n  greeting: Hello, Chris!; }\n\n" +
-                    "#transitive {\n  is: transitive; }\n",
-                    result.css);
-       done();
-     }
-   }));
- });
+  it("should discover sass functions", function (done) {
+    console.log("1");
+    var options = {
+      root: testutils.fixtureDirectory("function_modules"),
+      data: "#hello { greeting: hello(Chris); }\n" +
+            "#transitive { is: transitive(); }\n"
+    };
+    var expected = "#hello {\n  greeting: Hello, Chris!; }\n\n" +
+                   "#transitive {\n  is: transitive; }\n";
+    testutils.assertCompiles(options, expected, done);
+  });
 
- it("should let me define my own sass functions too", function (done) {
-   sass.render(eyeglass({
-     root: fixtureDirectory("function_modules"),
-     data: "#hello { greeting: hello(Chris); }\n" +
-           "#mine { something: add-one(3em); }\n",
-     functions: {
-       "add-one($number)": function(number) {
-         return sass.types.Number(number.getValue() + 1, number.getUnit());
-       }
-     },
-     success: function(result) {
-       assert.equal("#hello {\n  greeting: Hello, Chris!; }\n\n" +
-                    "#mine {\n  something: 4em; }\n",
-                    result.css);
-       done();
-     }
-   }));
- });
+  it("should let me define my own sass functions too", function (done) {
+    console.log("2");
+    var input = "#hello { greeting: hello(Chris); }\n" +
+                "#mine { something: add-one(3em); }\n";
+    var options = {
+      root: testutils.fixtureDirectory("function_modules"),
+      data: input,
+      functions: {
+        "add-one($number)": function(number) {
+          return sass.types.Number(number.getValue() + 1, number.getUnit());
+        }
+      }
+    };
+    var expected = "#hello {\n  greeting: Hello, Chris!; }\n\n" +
+                   "#mine {\n  something: 4em; }\n";
+    testutils.assertCompiles(options, expected, done);
+  });
 
- it("should let local functions override imported functions", function (done) {
-   var output = "";
-   var release = capture(function(string) {
-     output = output + string;
-   });
-   sass.render(eyeglass({
-     root: fixtureDirectory("function_modules"),
-     data: "#hello { greeting: hello(Chris); }\n",
-     functions: {
-       "hello($name: \"World\")": function(name) {
-         return sass.types.String("Goodbye, " + name.getValue() + "!");
-       }
-     },
-     success: function(result) {
-       release();
-       assert.equal("#hello {\n  greeting: Goodbye, Chris!; }\n",
-                    result.css);
-       assert.equal("", output);
-       done();
-     }
-   }));
- });
+  it("should let local functions override imported functions", function (done) {
+    console.log("3");
+    testutils.assertStdout(function(checkOutput) {
+      var input = "#hello { greeting: hello(Chris); }\n";
+      var expectedOutput = "#hello {\n  greeting: Goodbye, Chris!; }\n";
+      var options = {
+        root: testutils.fixtureDirectory("function_modules"),
+        data: input,
+        functions: {
+          "hello($name: \"World\")": function(name) {
+            return sass.types.String("Goodbye, " + name.getValue() + "!");
+          }
+        }
+      };
+      testutils.assertCompiles(options, expectedOutput, function() {
+        checkOutput("");
+        done();
+      });
+    });
+  });
 
- it("should warn about conflicting function signatures", function (done) {
-   var output = "";
-   var release = capture(function(string) {
-     output = output + string;
-   }, "stderr");
-   sass.render(eyeglass({
-     root: fixtureDirectory("function_modules"),
-     data: "#hello { greeting: hello(Chris); }\n",
-     functions: {
-       "hello($name: 'Sucker')": function(name) {
-         return sass.types.String("Goodbye, " + name.getValue() + "!");
-       }
-     },
-     success: function(result) {
-       release();
-       assert.equal("#hello {\n  greeting: Goodbye, Chris!; }\n",
-                    result.css);
-       assert.equal("WARNING: Function hello was redeclared with " +
+  it("should warn about conflicting function signatures", function (done) {
+    console.log("4");
+    testutils.assertStderr(function(checkStderr) {
+      var input = "#hello { greeting: hello(Chris); }\n";
+      var options = {
+        root: testutils.fixtureDirectory("function_modules"),
+        data: input,
+        functions: {
+          "hello($name: 'Sucker')": function(name) {
+            return sass.types.String("Goodbye, " + name.getValue() + "!");
+          }
+        }
+      };
+      var expectedOutput = "#hello {\n  greeting: Goodbye, Chris!; }\n";
+      testutils.assertCompiles(options, expectedOutput, function() {
+        checkStderr("WARNING: Function hello was redeclared with " +
                     "conflicting function signatures: hello($name: \"World\")" +
-                    " vs. hello($name: 'Sucker')\n", output);
-       done();
-     }
-   }));
- });
+                    " vs. hello($name: 'Sucker')\n");
+        done();
+      });
+    });
+  });
 
  it("load functions from modules if they are themselves a npm eyeglass module.",
     function (done) {
-      sass.render(eyeglass({
-        root: fixtureDirectory("is_a_module"),
-        data: "#hello { greeting: hello(); }\n",
-        success: function(result) {
-          assert.equal("#hello {\n  greeting: Hello, Myself!; }\n",
-                       result.css);
-                       done();
-        }
-      }));
+   console.log("5");
+      var options = {
+        root: testutils.fixtureDirectory("is_a_module"),
+        data: "#hello { greeting: hello(); }\n"
+      };
+      var expectedOutput = "#hello {\n  greeting: Hello, Myself!; }\n";
+      testutils.assertCompiles(options, expectedOutput, done);
   });
-
 });

--- a/test/test_imports.js
+++ b/test/test_imports.js
@@ -1,72 +1,57 @@
 "use strict";
 
-var assert = require("assert");
 var sass = require("node-sass");
-var path = require("path");
-var eyeglass = require("../lib/options_decorator");
-var capture = require("../lib/util/capture");
-
-function fixtureDirectory(subpath) {
-  return path.join(__dirname, "fixtures", subpath);
-}
+var testutils = require("./testutils");
 
 describe("core api", function () {
 
  it("should compile a sass file", function (done) {
-    sass.render({
-      data: "div { $c: red; color: $c; }",
-      success: function(result) {
-        assert.equal("div {\n  color: red; }\n", result.css);
-        done();
-      }
-    });
+   var options = {
+     data: "div { $c: red; color: $c; }"
+   };
+   var expected = "div {\n  color: red; }\n";
+   testutils.assertCompiles(options, expected, done);
  });
 
  it("should compile a sass file with a custom function", function (done) {
-    sass.render({
-      data: "div { content: hello-world(); }",
-      functions: {
-        "hello-world()": function() {
-          return sass.types.String('"Hello World!"');
-        }
-      },
-      success: function(result) {
-        assert.equal('div {\n  content: "Hello World!"; }\n', result.css);
-        done();
-      }
-    });
+   var options = {
+     data: "div { content: hello-world(); }",
+     functions: {
+       "hello-world()": function() {
+         return sass.types.String('"Hello World!"');
+       }
+     }
+   };
+   var expected = 'div {\n  content: "Hello World!"; }\n';
+   testutils.assertCompiles(options, expected, done);
  });
 
  it("should compile a sass file with a custom async function", function (done) {
-    sass.render({
-      data: "div { content: hello-world(); }",
-      functions: {
-        "hello-world()": function(sassCb) {
-          setTimeout(function() {
-            sassCb(sass.types.String('"Hello World!"'));
-          });
-        }
-      },
-      success: function(result) {
-        assert.equal('div {\n  content: "Hello World!"; }\n', result.css);
-        done();
-      }
-    });
+   var options = {
+     data: "div { content: hello-world(); }",
+     functions: {
+       "hello-world()": function(sassCb) {
+         setTimeout(function() {
+           sassCb(sass.types.String('"Hello World!"'));
+         });
+       }
+     }
+   };
+   var expected = 'div {\n  content: "Hello World!"; }\n';
+   testutils.assertCompiles(options, expected, done);
  });
 
  it("passes through node-sass options", function (done) {
-    sass.render(eyeglass({
-      data: "div { content: hello-world(); }",
-      functions: {
-        "hello-world()": function() {
-          return sass.types.String('"Hello World!"');
-        }
-      },
-      success: function(result) {
-        assert.equal('div {\n  content: "Hello World!"; }\n', result.css);
-        done();
-      }
-    }));
+   var options = {
+     data: "div { content: hello-world(); }",
+     functions: {
+       "hello-world()": function() {
+         return sass.types.String('"Hello World!"');
+       }
+     }
+   };
+   var expected = 'div {\n  content: "Hello World!"; }\n';
+   testutils.assertCompiles(options, expected, done);
  });
 
 });
@@ -74,117 +59,96 @@ describe("core api", function () {
 describe("eyeglass importer", function () {
 
  it("lets you import sass files from npm modules", function (done) {
-    sass.render(eyeglass({
-      root: fixtureDirectory("basic_modules"),
-      data: '@import "<module_a>";',
-      success: function(result) {
-        assert.equal(".module-a {\n  greeting: hello world; }\n\n" +
-                     ".sibling-in-module-a {\n  sibling: yes; }\n", result.css);
-        done();
-      }
-    }));
+   var options = {
+     root: testutils.fixtureDirectory("basic_modules"),
+     data: '@import "<module_a>";'
+   };
+   var expected = ".module-a {\n  greeting: hello world; }\n\n" +
+                  ".sibling-in-module-a {\n  sibling: yes; }\n";
+   testutils.assertCompiles(options, expected, done);
  });
 
  it("lets you import from a subdir in a npm module", function (done) {
-    sass.render(eyeglass({
-      root: fixtureDirectory("basic_modules"),
-      data: '@import "<module_a>/submodule";',
-      success: function(result) {
-        assert.equal(".submodule {\n  hello: world; }\n", result.css);
-        done();
-      }
-    }));
+   var options = {
+     root: testutils.fixtureDirectory("basic_modules"),
+     data: '@import "<module_a>/submodule";'
+   };
+   var expected = ".submodule {\n  hello: world; }\n";
+   testutils.assertCompiles(options, expected, done);
  });
 
  it("lets you import explicitly from a subdir in a module", function (done) {
-    sass.render(eyeglass({
-      root: fixtureDirectory("basic_modules"),
-      data: '@import "<module_a>/submodule/_index.scss";',
-      success: function(result) {
-        assert.equal(".submodule {\n  hello: world; }\n", result.css);
-        done();
-      }
-    }));
+   var options = {
+     root: testutils.fixtureDirectory("basic_modules"),
+     data: '@import "<module_a>/submodule/_index.scss";'
+   };
+   var expected = ".submodule {\n  hello: world; }\n";
+   testutils.assertCompiles(options, expected, done);
  });
 
  it("lets you import css files", function (done) {
-    sass.render(eyeglass({
-      root: fixtureDirectory("basic_modules"),
-      data: '@import "<module_a>/css_file";',
-      success: function(result) {
-        assert.equal(".css-file {\n  hello: world; }\n", result.css);
-        done();
-      }
-    }));
+   var options = {
+     root: testutils.fixtureDirectory("basic_modules"),
+     data: '@import "<module_a>/css_file";'
+   };
+   var expected = ".css-file {\n  hello: world; }\n";
+   testutils.assertCompiles(options, expected, done);
  });
 
  it("lets you import sass files from a transitive dependency", function (done) {
-    sass.render(eyeglass({
-      root: fixtureDirectory("basic_modules"),
-      data: '@import "<module_a>/transitive_imports";',
-      success: function(result) {
-        assert.equal(".transitive_module {\n  hello: world; }\n", result.css);
-        done();
-      }
-    }));
+   var options = {
+     root: testutils.fixtureDirectory("basic_modules"),
+     data: '@import "<module_a>/transitive_imports";'
+   };
+   var expected = ".transitive_module {\n  hello: world; }\n";
+   testutils.assertCompiles(options, expected, done);
  });
 
  it("does not let you import transitive sass files", function (done) {
-   var output = "";
-   var release = capture(function(string) {
-     output = output + string;
-   }, "stderr");
-   sass.render(eyeglass({
-     root: fixtureDirectory("basic_modules"),
-     data: '@import "<transitive_module>";',
-     success: function(result) {
-       release();
-       // TODO This should not be a successful compile (libsass issue?)
-       assert.equal("", result.css);
-       assert.equal("No Eyeglass module named 'transitive_module' could be " +
-                    "found while importing '<transitive_module>'.\n", output);
+   testutils.assertStderr(function(checkStderr) {
+     var options = {
+       root: testutils.fixtureDirectory("basic_modules"),
+       data: '@import "<transitive_module>";'
+     };
+     // TODO This should not be a successful compile (libsass issue?)
+     var expected = "";
+     testutils.assertCompiles(options, expected, function() {
+       checkStderr("No Eyeglass module named 'transitive_module' could be " +
+                   "found while importing '<transitive_module>'.\n");
        done();
-     }
-   }));
+     });
+   });
  });
 
  it("only imports a module dependency once.", function (done) {
-    sass.render(eyeglass({
-      root: fixtureDirectory("basic_modules"),
-      data: '@import "<module_a>"; @import "<module_a>";',
-      success: function(result) {
-        assert.equal(".module-a {\n  greeting: hello world; }\n\n" +
-                     ".sibling-in-module-a {\n  sibling: yes; }\n", result.css);
-        done();
-      }
-    }));
+   var options = {
+     root: testutils.fixtureDirectory("basic_modules"),
+     data: '@import "<module_a>"; @import "<module_a>";'
+   };
+   var expected = ".module-a {\n  greeting: hello world; }\n\n" +
+                  ".sibling-in-module-a {\n  sibling: yes; }\n";
+   testutils.assertCompiles(options, expected, done);
  });
 
- it("imports modules if they are themselves a npm eyeglass module.",
-    function (done) {
-      sass.render(eyeglass({
-        root: fixtureDirectory("is_a_module"),
-        data: '@import "<is_a_module>";',
-        success: function(result) {
-          assert.equal(".is-a-module {\n  this: is a module; }\n", result.css);
-          done();
-        }
-      }));
-    }
- );
+ it("imports modules if they are themselves a npm eyeglass module.", function(done) {
+    var options = {
+      root: testutils.fixtureDirectory("is_a_module"),
+      data: '@import "<is_a_module>";'
+    };
+   var expected = ".is-a-module {\n  this: is a module; }\n";
+   testutils.assertCompiles(options, expected, done);
+ });
 
  it("eyeglass exports can be specified through the " +
     "eyeglass property of package.json.",
-    function (done) {
-      sass.render(eyeglass({
-        root: fixtureDirectory("has_a_main_already"),
-        data: '@import "<has_a_main_already>";',
-        success: function(result) {
-          assert.equal(".has-a-main {\n  main: already; }\n", result.css);
-          done();
-        }
-      }));
-    }
+   function (done) {
+     var options = {
+       root: testutils.fixtureDirectory("has_a_main_already"),
+       data: '@import "<has_a_main_already>";'
+     };
+     var expected = ".has-a-main {\n  main: already; }\n";
+     testutils.assertCompiles(options, expected, done);
+   }
  );
 
 });

--- a/test/test_imports.js
+++ b/test/test_imports.js
@@ -3,7 +3,7 @@
 var assert = require("assert");
 var sass = require("node-sass");
 var path = require("path");
-var eyeglass = require("../lib");
+var eyeglass = require("../lib/options_decorator");
 var capture = require("../lib/util/capture");
 
 function fixtureDirectory(subpath) {

--- a/test/test_utils.js
+++ b/test/test_utils.js
@@ -1,0 +1,45 @@
+"use strict";
+
+var assert = require("assert");
+var hash = require("../lib/util/hash");
+var unquote = require("../lib/util/unquote");
+var sass = require("node-sass");
+
+describe("utilities", function () {
+
+ it("merge two 'hash' objects", function (done) {
+    var hash1 = {a: 1, c: 3};
+    var hash2 = {b: 2, c: 4};
+    var rv = hash.merge(hash1, hash2);
+    assert.equal(undefined, rv);
+    assert(hash1.hasOwnProperty("a"));
+    assert(hash1.hasOwnProperty("b"));
+    assert(hash1.hasOwnProperty("c"));
+    assert(!hash2.hasOwnProperty("a"));
+    assert(hash2.hasOwnProperty("b"));
+    assert(hash2.hasOwnProperty("c"));
+    assert.equal(1, hash1.a);
+    assert.equal(2, hash1.b);
+    assert.equal(4, hash1.c);
+    done();
+ });
+
+ it("unquote handles js strings", function(done) {
+   assert.equal("asdf", unquote('"asdf"'));
+   assert.equal("asdf", unquote("'asdf'"));
+   assert.equal("\"asdf'", unquote("\"asdf'"));
+   assert.equal("'asdf\"", unquote("'asdf\""));
+   assert.equal("asdf", unquote("asdf"));
+   done();
+ });
+
+ it("unquote handles sass strings", function(done) {
+   var s = sass.types.String;
+   assert.equal("asdf", unquote(s('"asdf"')).getValue());
+   assert.equal("asdf", unquote(s("'asdf'")).getValue());
+   assert.equal("\"asdf'", unquote(s("\"asdf'")).getValue());
+   assert.equal("'asdf\"", unquote(s("'asdf\"")).getValue());
+   assert.equal("asdf", unquote(s("asdf")).getValue());
+   done();
+ });
+});

--- a/test/test_version.js
+++ b/test/test_version.js
@@ -1,0 +1,34 @@
+"use strict";
+
+var assert = require("assert");
+var sass = require("node-sass");
+var path = require("path");
+var fs = require("fs");
+var eyeglass = require("../lib/options_decorator");
+
+function fixtureDirectory(subpath) {
+  return path.join(__dirname, "fixtures", subpath);
+}
+
+describe("sass version function", function () {
+ it("should return the eyeglass version", function (done) {
+   var eyeglassVersion = JSON.parse(fs.readFileSync(path.resolve(__dirname, "../package.json"))).version;
+    sass.render(eyeglass({
+      data: "/* Eyeglass version is #{eyeglass-version()} */",
+      success: function(result) {
+        assert.equal("/* Eyeglass version is " + eyeglassVersion + " */", result.css);
+        done();
+      }
+    }));
+ });
+ it("should return a module's version", function (done) {
+    sass.render(eyeglass({
+      root: fixtureDirectory("basic_modules"),
+      data: "/* module_a version is #{eyeglass-version('module_a')} */",
+      success: function(result) {
+        assert.equal("/* module_a version is 1.0.1 */", result.css);
+        done();
+      }
+    }));
+ });
+});

--- a/test/test_version.js
+++ b/test/test_version.js
@@ -1,34 +1,25 @@
 "use strict";
 
-var assert = require("assert");
-var sass = require("node-sass");
 var path = require("path");
 var fs = require("fs");
-var eyeglass = require("../lib/options_decorator");
-
-function fixtureDirectory(subpath) {
-  return path.join(__dirname, "fixtures", subpath);
-}
+var testutils = require("./testutils");
 
 describe("sass version function", function () {
  it("should return the eyeglass version", function (done) {
    var eyeglassVersion = JSON.parse(fs.readFileSync(path.resolve(__dirname, "../package.json"))).version;
-    sass.render(eyeglass({
-      data: "/* Eyeglass version is #{eyeglass-version()} */",
-      success: function(result) {
-        assert.equal("/* Eyeglass version is " + eyeglassVersion + " */", result.css);
-        done();
-      }
-    }));
+   var options = {
+     data: "/* Eyeglass version is #{eyeglass-version()} */"
+   };
+   var expectedOutput = "/* Eyeglass version is \"" + eyeglassVersion + "\" */\n";
+   testutils.assertCompiles(options, expectedOutput, done);
  });
+
  it("should return a module's version", function (done) {
-    sass.render(eyeglass({
-      root: fixtureDirectory("basic_modules"),
-      data: "/* module_a version is #{eyeglass-version('module_a')} */",
-      success: function(result) {
-        assert.equal("/* module_a version is 1.0.1 */", result.css);
-        done();
-      }
-    }));
+   var options = {
+     root: testutils.fixtureDirectory("basic_modules"),
+     data: ".version {\nmodule-a: eyeglass-version('module_a')}"
+   };
+   var expectedOutput = '.version {\n  module-a: "1.0.1"; }\n';
+   testutils.assertCompiles(options, expectedOutput, done);
  });
 });

--- a/test/testutils.js
+++ b/test/testutils.js
@@ -1,0 +1,61 @@
+"use strict";
+
+var eyeglass = require("../lib/options_decorator");
+var sass = require("node-sass");
+var path = require("path");
+var assert = require("assert");
+var capture = require("../lib/util/capture");
+
+module.exports = {
+  fixtureDirectory: function(subpath) {
+    return path.join(__dirname, "fixtures", subpath);
+  },
+  assertCompiles: function(options, expectedOutput, done) {
+    this.compile(options, function(err, result) {
+      assert(!err);
+      assert.equal(expectedOutput, result.css.toString());
+      done();
+    });
+  },
+  assertCompilationError: function(options, expectedError, done) {
+    var testutils = this;
+    this.compile(options, function(err, result) {
+      assert(err);
+      assert(!result);
+      testutils.assertMultilineEqual(err.message, expectedError);
+      done();
+    });
+  },
+  compile: function(options, cb) {
+    if (typeof options.sassOptions === "function") {
+      options = options.sassOptions();
+    } else {
+      options = eyeglass(options);
+    }
+    sass.render(options, cb);
+  },
+  assertStdout: function(work) {
+    this.assertCapture(work, "stdout");
+  },
+  assertStderr: function(work) {
+    this.assertCapture(work, "stderr");
+  },
+  assertCapture: function(work, stream) {
+    var output = "";
+    var release = capture(function(string) {
+      output = output + string;
+    }, stream);
+    work(function(expectedOutput) {
+      release();
+      assert.equal(output, expectedOutput);
+    });
+  },
+  assertMultilineEqual: function(string1, string2) {
+    var lines1 = string1.split("\n");
+    var lines2 = string2.split("\n");
+    assert.equal(lines1.length, lines2.length, "Number of lines differ.");
+    for (var lineNumber = 0; lineNumber < lines1.length; lineNumber++) {
+      assert.equal(lines1[lineNumber], lines2[lineNumber], "Line #" + lineNumber + " differs: " + lines1[lineNumber] + " != " + lines2[lineNumber]);
+    }
+  }
+};


### PR DESCRIPTION
This creates a single pattern (like importers) for custom functions. This code
can be removed when `node-sass` has similar support. For now, we have an
additional `.gyp` dependency when using this patch. The `deasync` library
allows us to create a blocking `while()` loop and drain the event queue. This
pattern is a bit better for our application than using a `node-fiber`, since
we want to not replumb the entire custom function flow.

Custom functions w/ this patch can either call `done()` (always the last
argument), or return a value synchronously.

Includes test.