### PR TITLE
PROPOSAL: Conceptual model of non angle bracket based imports

### DIFF
--- a/lib/module_importer.js
+++ b/lib/module_importer.js
@@ -5,8 +5,6 @@ var path = require("path");
 var efs = require("./util/files");
 var discover = require("./util/discover");
 
-var IMPORT_REGEX = /^<([^>]+)>(?:\/(.+))?$/;
-
 /*
  * All imports use the forward slash as a directory
  * delimeter. This function converts to the filesystem's
@@ -105,24 +103,15 @@ function makeImporter(eyeglass, sass, options, fallbackImporter) {
 
   return function(uri, prev, done) {
     var isRealFile = fs.existsSync(prev);
-    var match = uri.match(IMPORT_REGEX);
+    var fragments = uri.split("/");
+    var moduleName = fragments[0];
+    var relativePath = fragments.slice(1).join("/");
+    var pkgRootDir = isRealFile ? packageRootDir(path.dirname(prev)) : root;
+    var jsFile = getModuleByName(moduleName, pkgRootDir);
 
-    if (match) {
-      // This is an import of the form "<node_module>/some/file"
-      var moduleName = match[1];
-      var relativePath = match[2];
-      var pkgRootDir = isRealFile ? packageRootDir(path.dirname(prev)) : root;
-      var jsFile = getModuleByName(moduleName, pkgRootDir);
-
-      if (!jsFile) {
-        console.error("No Eyeglass module named '" + moduleName +
-                      "' could be found while importing '" + uri + "'.");
-        done({});
-        return;
-      }
-
+    if (jsFile) {
+      // is eyeglass module
       var sassDir = require(jsFile)(eyeglass, sass).sassDir;
-
       if (!sassDir) {
         throw new Error("sassDir is not specified in " + jsFile);
       }
@@ -145,10 +134,8 @@ function makeImporter(eyeglass, sass, options, fallbackImporter) {
           importOnce(data, done);
         }
       });
-
     } else if (isRealFile) {
-      // This is a sass file that is potentially relative to the
-      // previous import.
+      // relative file import, potentially relative to the previous import
       var f = path.resolve(path.dirname(prev), makeFsPath(uri));
       readAbstractFile(uri, f, function(err, data) {
         if (err) {

--- a/test/fixtures/basic_modules/node_modules/module_a/transitive_imports.scss
+++ b/test/fixtures/basic_modules/node_modules/module_a/transitive_imports.scss
@@ -1,1 +1,1 @@
-@import "<transitive_module>";
+@import "transitive_module";

--- a/test/test_imports.js
+++ b/test/test_imports.js
@@ -76,7 +76,7 @@ describe("eyeglass importer", function () {
  it("lets you import sass files from npm modules", function (done) {
     sass.render(eyeglass({
       root: fixtureDirectory("basic_modules"),
-      data: '@import "<module_a>";',
+      data: '@import "module_a";',
       success: function(result) {
         assert.equal(".module-a {\n  greeting: hello world; }\n\n" +
                      ".sibling-in-module-a {\n  sibling: yes; }\n", result.css);
@@ -88,7 +88,7 @@ describe("eyeglass importer", function () {
  it("lets you import from a subdir in a npm module", function (done) {
     sass.render(eyeglass({
       root: fixtureDirectory("basic_modules"),
-      data: '@import "<module_a>/submodule";',
+      data: '@import "module_a/submodule";',
       success: function(result) {
         assert.equal(".submodule {\n  hello: world; }\n", result.css);
         done();
@@ -99,7 +99,7 @@ describe("eyeglass importer", function () {
  it("lets you import explicitly from a subdir in a module", function (done) {
     sass.render(eyeglass({
       root: fixtureDirectory("basic_modules"),
-      data: '@import "<module_a>/submodule/_index.scss";',
+      data: '@import "module_a/submodule/_index.scss";',
       success: function(result) {
         assert.equal(".submodule {\n  hello: world; }\n", result.css);
         done();
@@ -110,7 +110,7 @@ describe("eyeglass importer", function () {
  it("lets you import css files", function (done) {
     sass.render(eyeglass({
       root: fixtureDirectory("basic_modules"),
-      data: '@import "<module_a>/css_file";',
+      data: '@import "module_a/css_file";',
       success: function(result) {
         assert.equal(".css-file {\n  hello: world; }\n", result.css);
         done();
@@ -121,7 +121,7 @@ describe("eyeglass importer", function () {
  it("lets you import sass files from a transitive dependency", function (done) {
     sass.render(eyeglass({
       root: fixtureDirectory("basic_modules"),
-      data: '@import "<module_a>/transitive_imports";',
+      data: '@import "module_a/transitive_imports";',
       success: function(result) {
         assert.equal(".transitive_module {\n  hello: world; }\n", result.css);
         done();
@@ -136,13 +136,12 @@ describe("eyeglass importer", function () {
    }, "stderr");
    sass.render(eyeglass({
      root: fixtureDirectory("basic_modules"),
-     data: '@import "<transitive_module>";',
+     data: '@import "transitive_module";',
      success: function(result) {
        release();
-       // TODO This should not be a successful compile (libsass issue?)
+       // TODO This should not be a successful compile if no importers
+       // TODO actually work (libsass issue?)
        assert.equal("", result.css);
-       assert.equal("No Eyeglass module named 'transitive_module' could be " +
-                    "found while importing '<transitive_module>'.\n", output);
        done();
      }
    }));
@@ -151,7 +150,7 @@ describe("eyeglass importer", function () {
  it("only imports a module dependency once.", function (done) {
     sass.render(eyeglass({
       root: fixtureDirectory("basic_modules"),
-      data: '@import "<module_a>"; @import "<module_a>";',
+      data: '@import "module_a"; @import "module_a";',
       success: function(result) {
         assert.equal(".module-a {\n  greeting: hello world; }\n\n" +
                      ".sibling-in-module-a {\n  sibling: yes; }\n", result.css);
@@ -164,7 +163,7 @@ describe("eyeglass importer", function () {
     function (done) {
       sass.render(eyeglass({
         root: fixtureDirectory("is_a_module"),
-        data: '@import "<is_a_module>";',
+        data: '@import "is_a_module";',
         success: function(result) {
           assert.equal(".is-a-module {\n  this: is a module; }\n", result.css);
           done();
@@ -178,7 +177,7 @@ describe("eyeglass importer", function () {
     function (done) {
       sass.render(eyeglass({
         root: fixtureDirectory("has_a_main_already"),
-        data: '@import "<has_a_main_already>";',
+        data: '@import "has_a_main_already";',
         success: function(result) {
           assert.equal(".has-a-main {\n  main: already; }\n", result.css);
           done();


### PR DESCRIPTION
This is a proof of concept for using pure node.js syntax for imports. The custom importer has been modified to pass modules through silently, letting an unresolved eyeglass module defer to relative imports and finally the native node-sass importer.

Benefits of this implementation:
- `@import` will resolve identically to `require()` from within the sass file
- If an npm style `require` path does not work, it will fall back to Sass' resolution system
- This avoids any additional syntax. No `<foo>`, no "npm!foo" or other syntax to request the node resolution system

Drawbacks of this implementation:
- We no longer can tell the intent of an import. It's ambiguous if the intent was to import an eyeglass module or do a traditional Sass import. This means we lose a layer of error reporting. This is a deficiency in `node-sass`, as errors from the prior Importer are not able to be passed down through the previousImporter function.
- There is a learning curve for someone completely unfamilliar with the npm ecosystem.
- You risk a collision if you have a directory called "foo" and then you went and installed the "foo" npm module (which happened to also be an eyeglass module). Since we are encouraging people to name their modules `eyeglass-*`, I don't forsee this being a serious drawback.