### PR TITLE
importer: Only use done() callback method

### DIFF
--- a/lib/module_importer.js
+++ b/lib/module_importer.js
@@ -123,19 +123,10 @@ function makeImporter(eyeglass, sass, options, fallbackImporter) {
 
   function importOnce(data, enabled, done) {
     if (enabled && importedFiles[data.file]) {
-      var rv = {contents: "", filename: "already-imported:" + data.file};
-      if (done) {
-        done(rv);
-      } else {
-        return rv;
-      }
+      done({contents: "", filename: "already-imported:" + data.file});
     } else {
       importedFiles[data.file] = true;
-      if (done) {
-        done(data);
-      } else {
-        return data;
-      }
+      done(data);
     }
   }
   /*eslint-disable */
@@ -172,58 +163,33 @@ function makeImporter(eyeglass, sass, options, fallbackImporter) {
 
       var abstractName = path.join.apply(path, filenameSegments);
 
-      if (done) {
-        readAbstractFile(uri, abstractName, function(err, data) {
-          if (err) {
-            // TODO: https://github.com/sass-eyeglass/eyeglass/issues/2
-            console.error(err.toString());
-            done({});
-          } else {
-            importOnce(data, eyeglass.enableImportOnce, done);
-          }
-        });
-      } else {
-        return importOnce(readAbstractFileSync(uri, abstractName),
-                          eyeglass.enableImportOnce, done);
-      }
+      readAbstractFile(uri, abstractName, function(err, data) {
+	if (err) {
+	  // TODO: https://github.com/sass-eyeglass/eyeglass/issues/2
+	  console.error(err.toString());
+	  done({});
+	} else {
+	  importOnce(data, eyeglass.enableImportOnce, done);
+	}
+      });
 
     } else if (isRealFile) {
       // This is a sass file that is potentially relative to the
       // previous import.
       var f = path.resolve(path.dirname(prev), makeFsPath(uri));
-      if (done) {
-        readAbstractFile(uri, f, function(err, data) {
-          if (err) {
-            // TODO: https://github.com/sass-eyeglass/eyeglass/issues/2
-            console.error(err.toString());
-            done({});
-          } else {
-            importOnce(data, eyeglass.enableImportOnce, done);
-          }
-        });
-      } else {
-        try { 
-          return importOnce(readAbstractFileSync(uri, f), eyeglass.enableImportOnce, done)
-        } catch(e) {
-          // TODO: https://github.com/sass-eyeglass/eyeglass/issues/2
-          console.error(err.toString());
-          return {};
-        }
-      }
+      readAbstractFile(uri, f, function(err, data) {
+	if (err) {
+	  // TODO: https://github.com/sass-eyeglass/eyeglass/issues/2
+	  console.error(err.toString());
+	  done({});
+	} else {
+	  importOnce(data, eyeglass.enableImportOnce, done);
+	}
+      });
     } else if (fallbackImporter) {
-      // Not our import
-      if (done) {
-        fallbackImporter(uri, prev, done);
-      } else {
-        return fallbackImporter(uri, prev);
-      }
+      fallbackImporter(uri, prev, done);
     } else {
-      if (done) {
-        // give up
-        done({});
-      } else {
-        return {};
-      }
+      done({});
     }
   };
   /*eslint-enable */


### PR DESCRIPTION
In node-sass 3.x last "done" parameter is
always passed to the custom importer.

It should be not necessary to check if
done() has been provided.

Should-Solve: https://github.com/sass/node-sass/issues/849