### PR TITLE
Path Fixes

### DIFF
--- a/lib/module_importer.js
+++ b/lib/module_importer.js
@@ -12,22 +12,9 @@ function existsSync(file) {
   return fs.existsSync(file);
 }
 
-/*
- * All imports use the forward slash as a directory
- * delimeter. This function converts to the filesystem's
- * delimeter if it uses an alternate.
- */
-function makeFsPath(importPath) {
-  var fsPath = importPath;
-  if (path.sep !== "/") {
-    fsPath = fsPath.replace(/\//, path.sep);
-  }
-  return fsPath;
-}
-
 // This is a bootstrap function for calling readFirstFile.
-function readAbstractFile(uri, abstractName, cb) {
-  readFirstFile(uri, efs.getFileNames(abstractName), cb);
+function readAbstractFile(uri, origin, abstractFile, cb) {
+  readFirstFile(uri, efs.expandFileName(uri, origin, abstractFile), cb);
 }
 
 /*
@@ -124,16 +111,8 @@ function makeImporter(eyeglass, sass, options, fallbackImporter) {
         return;
       }
 
-      var filenameSegments = [sassDir];
-
-      if (relativePath) {
-        relativePath = makeFsPath(relativePath);
-        filenameSegments.push(relativePath);
-      }
-
-      var abstractName = path.join.apply(path, filenameSegments);
-
-      readAbstractFile(uri, abstractName, function(err, data) {
+      // read uri from location
+      readAbstractFile(uri, prev, sassDir, function(err, data) {
         if (err) {
           done(err);
         } else {
@@ -142,8 +121,8 @@ function makeImporter(eyeglass, sass, options, fallbackImporter) {
       });
     } else if (isRealFile) {
       // relative file import, potentially relative to the previous import
-      var f = path.resolve(path.dirname(prev), makeFsPath(uri));
-      readAbstractFile(uri, f, function(err, data) {
+      var f = path.resolve(path.dirname(prev), uri.split("/").join(path.sep));
+      readAbstractFile(uri, prev, f, function(err, data) {
         if (err) {
           done(err);
         } else {

--- a/lib/util/files.js
+++ b/lib/util/files.js
@@ -2,6 +2,34 @@
 
 var path = require("path");
 
+function namify(cb) {
+  ["", "_"].forEach(function(prefix) {
+    [".scss", ".sass", ".css"].forEach(function(ext) {
+      cb(prefix, ext);
+    });
+  });
+}
+
+function expand(source, onto) {
+  if (path.extname(source)) {
+    onto.push(source);
+  }
+
+  // underscored versions
+  // foo/bar/baz => foo/bar/_baz.scss
+  namify(function(prefix, ext) {
+    var dir = path.dirname(source);
+    var name = path.basename(source);
+    onto.push(path.join(dir, prefix + name + ext));
+  });
+
+  // indexed versions
+  // foo/bar/baz => foo/bar/baz/_index.scss
+  namify(function(prefix, ext) {
+    onto.push(path.join(source, prefix + "index" + ext));
+  });
+}
+
 /*
  * Sass imports are usually in an abstract form in that
  * they leave off the partial prefix and the suffix.
@@ -10,28 +38,24 @@ var path = require("path");
  * same possible variations. If the import contains an extension,
  * then it is left alone.
  * */
-function getFileNames(abstractName) {
+function expandFileName(uri, origin, abstractFile) {
   var names = [];
-  if (path.extname(abstractName)) {
-    names.push(abstractName);
-  } else {
-    var directory = path.dirname(abstractName);
-    var basename = path.basename(abstractName);
+  var osUri = uri.split("/").join(path.sep);
+  var uriSubmodule = uri.split("/").slice(1).join(path.sep);
+  expand(path.join(path.dirname(abstractFile), osUri), names);
+  expand(abstractFile, names);
 
-    ["", "_"].forEach(function(prefix) {
-      [".scss", ".sass", ".css"].forEach(function(ext) {
-        names.push(path.join(directory, prefix + basename + ext));
-      });
-    });
-
-    // can avoid these if we check if the path is a directory first.
-    ["", "_"].forEach(function(prefix) {
-      [".scss", ".sass", ".css"].forEach(function(ext) {
-        names.push(path.join(abstractName, prefix + "index" + ext));
-      });
-    });
+  // with an origin, check relative paths combined with the uri
+  if (origin.indexOf(path.sep) >= 0) {
+    expand(path.join(path.dirname(origin), osUri), names);
   }
+
+  // check situations in which we expand the module and then need to resolve
+  // the uri relative to the expanded module (loadPaths behavior)
+  expand(path.join(abstractFile, osUri), names);
+  expand(path.join(abstractFile, uriSubmodule), names);
+
   return names;
 }
 
-module.exports.getFileNames = getFileNames;
+module.exports.expandFileName = expandFileName;

--- a/lib/util/files.js
+++ b/lib/util/files.js
@@ -13,6 +13,7 @@ function namify(cb) {
 function expand(source, onto) {
   if (path.extname(source)) {
     onto.push(source);
+    return;
   }
 
   // underscored versions
@@ -37,23 +38,42 @@ function expand(source, onto) {
  * and whether it is a directory index file having those
  * same possible variations. If the import contains an extension,
  * then it is left alone.
- * */
+ *
+ * IMPORTANT ORDERING NOTES:
+ * We should be checking in the following order:
+ * 1. the abstractFile with extension
+ * 2. the abstractFile/uri             (and its permutations)
+ * 3. the abstractFile/uriSub          (and its permutations)
+ * 4. the dirname(abstractFile)/uri    (and its permutations)
+ * 5. the dirname(abstractFile)/uriSub (and its permutations)
+ * 6. the dirname(origin)/uri          (and its permutations)
+ * 7. the abstractFile by itself       (and its permutations)
+ *
+ * uriSub is the original uri, minus the first segment (assumed to be the) node
+ * module
+ *
+ * the permutations are all the possible name variants allowed in Sass load
+ * paths, including an optional underscore "_" before the name, treating the
+ * uri as a directory and searching for "index", and including the ".sass",
+ * ".scss", and ".css" extensions
+ **/
 function expandFileName(uri, origin, abstractFile) {
   var names = [];
   var osUri = uri.split("/").join(path.sep);
   var uriSubmodule = uri.split("/").slice(1).join(path.sep);
-  expand(path.join(path.dirname(abstractFile), osUri), names);
-  expand(abstractFile, names);
+  var abstractDir = path.dirname(abstractFile);
+  var originDir = path.dirname(origin);
 
-  // with an origin, check relative paths combined with the uri
-  if (origin.indexOf(path.sep) >= 0) {
-    expand(path.join(path.dirname(origin), osUri), names);
+  if (path.extname(abstractFile)) {
+    names.push(abstractFile);
   }
 
-  // check situations in which we expand the module and then need to resolve
-  // the uri relative to the expanded module (loadPaths behavior)
   expand(path.join(abstractFile, osUri), names);
   expand(path.join(abstractFile, uriSubmodule), names);
+  expand(path.join(abstractDir, osUri), names);
+  expand(path.join(abstractDir, uriSubmodule), names);
+  expand(path.join(originDir, osUri), names);
+  expand(abstractFile, names);
 
   return names;
 }

--- a/test/fixtures/redundantly_named_modules/node_modules/module_a/eyeglass-exports.js
+++ b/test/fixtures/redundantly_named_modules/node_modules/module_a/eyeglass-exports.js
@@ -1,0 +1,9 @@
+"use strict";
+
+var path = require("path");
+
+module.exports = function(eyeglass, sass) {
+  return {
+    sassDir: path.join(__dirname, "sass")
+  }
+};

--- a/test/fixtures/redundantly_named_modules/node_modules/module_a/package.json
+++ b/test/fixtures/redundantly_named_modules/node_modules/module_a/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "module_a",
+  "keywords": ["eyeglass-module"],
+  "main": "eyeglass-exports.js",
+  "private": true,
+  "version": "1.0.1",
+  "dependencies": {}
+}

--- a/test/fixtures/redundantly_named_modules/node_modules/module_a/sass/_module_a.scss
+++ b/test/fixtures/redundantly_named_modules/node_modules/module_a/sass/_module_a.scss
@@ -1,0 +1,4 @@
+// Edge case from Susy project
+// ====
+
+@import "module_a/subdir/module_a";

--- a/test/fixtures/redundantly_named_modules/node_modules/module_a/sass/module_a/subdir/_module_a.scss
+++ b/test/fixtures/redundantly_named_modules/node_modules/module_a/sass/module_a/subdir/_module_a.scss
@@ -1,0 +1,3 @@
+// relative include goes into our target location
+
+@import "module_a/target";

--- a/test/fixtures/redundantly_named_modules/node_modules/module_a/sass/module_a/subdir/module_a/_target.scss
+++ b/test/fixtures/redundantly_named_modules/node_modules/module_a/sass/module_a/subdir/module_a/_target.scss
@@ -1,0 +1,4 @@
+$hello: hello world;
+.nested-module-a {
+  greeting: $hello;
+}

--- a/test/fixtures/redundantly_named_modules/package.json
+++ b/test/fixtures/redundantly_named_modules/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "redundantly_named_modules",
+  "version": "0.0.1",
+  "main": "package.json",
+  "private": true,
+  "dependencies": {
+    "module_a": "*"
+  }
+}

--- a/test/test_imports.js
+++ b/test/test_imports.js
@@ -149,6 +149,15 @@ describe("eyeglass importer", function () {
    testutils.assertCompiles(options, expected, done);
  });
 
+ it("imports for modules such as foo/bar/_foo.scss wanting foo/bar (#37)", function (done) {
+   var options = {
+     root: testutils.fixtureDirectory("redundantly_named_modules"),
+     data: '@import "module_a";'
+   };
+   var expected = ".nested-module-a {\n  greeting: hello world; }\n";
+   testutils.assertCompiles(options, expected, done);
+ });
+
  it("eyeglass exports can be specified through the " +
     "eyeglass property of package.json.",
    function (done) {


### PR DESCRIPTION
The paths were being scanned incompletely. We were only checking for some of the possible include scenarios, and hadn't accounted for nested directories that shared names identical to the npm module name.

This fix rewrites the file util to be a bit smarter about path expansion and reduces the number of times we're writing forEach loops.

Adds tests to catch the nested-"susy" use case.