### PR TITLE
Cleans up files.js to reduce duplicates and improve readability

### DIFF
--- a/lib/module_importer.js
+++ b/lib/module_importer.js
@@ -13,34 +13,34 @@ function existsSync(file) {
 }
 
 // This is a bootstrap function for calling readFirstFile.
-function readAbstractFile(uri, origin, abstractFile, cb) {
-  readFirstFile(uri, efs.expandFileName(uri, origin, abstractFile), cb);
-}
+function readAbstractFile(uri, origin, file, cb) {
+  var possibleNames = efs.expandFileName(uri, origin, file);
 
-/*
- * Asynchronously walks the file list until a match is found. If
- * no matches are found, calls the callback with an error
- */
-function readFirstFile(uri, filenames, cb, examinedFiles) {
-  var filename = filenames.shift();
-  examinedFiles = examinedFiles || [];
-  examinedFiles.push(filename);
-  fs.readFile(filename, "utf8", function(err, data) {
-    if (err) {
-      if (filenames.length) {
-        readFirstFile(uri, filenames, cb, examinedFiles);
+  /*
+   * Asynchronously walks the file list until a match is found. If
+   * no matches are found, calls the callback with an error
+   */
+  function readFirstFile(filenames) {
+    var filename = filenames.shift();
+    fs.readFile(filename, "utf8", function(err, data) {
+      if (err) {
+        if (filenames.length) {
+          readFirstFile(filenames);
+        } else {
+          cb(new Error("Could not import " + uri +
+                       " from any of the following locations: " +
+                       possibleNames.join(", ")));
+        }
       } else {
-        cb(new Error("Could not import " + uri +
-                     " from any of the following locations: " +
-                     examinedFiles.join(", ")));
+        cb(null, {
+          contents: data.toString(),
+          file: filename
+        });
       }
-    } else {
-      cb(null, {
-        contents: data.toString(),
-        file: filename
-      });
-    }
-  });
+    });
+  }
+
+  readFirstFile(possibleNames);
 }
 
 function packageRootDir(dir) {
@@ -121,8 +121,7 @@ function makeImporter(eyeglass, sass, options, fallbackImporter) {
       });
     } else if (isRealFile) {
       // relative file import, potentially relative to the previous import
-      var f = path.resolve(path.dirname(prev), uri.split("/").join(path.sep));
-      readAbstractFile(uri, prev, f, function(err, data) {
+      readAbstractFile(uri, prev, path.dirname(prev), function(err, data) {
         if (err) {
           done(err);
         } else {

--- a/lib/util/files.js
+++ b/lib/util/files.js
@@ -10,70 +10,88 @@ function namify(cb) {
   });
 }
 
-function expand(source, onto) {
-  if (path.extname(source)) {
-    onto.push(source);
-    return;
-  }
-
-  // underscored versions
-  // foo/bar/baz => foo/bar/_baz.scss
-  namify(function(prefix, ext) {
-    var dir = path.dirname(source);
-    var name = path.basename(source);
-    onto.push(path.join(dir, prefix + name + ext));
-  });
-
-  // indexed versions
-  // foo/bar/baz => foo/bar/baz/_index.scss
-  namify(function(prefix, ext) {
-    onto.push(path.join(source, prefix + "index" + ext));
-  });
-}
+// This is a helpful debugging function when you are tracing the generation
+// of the names[] array. Group the `token` items together to see related
+// permutations in the console.
+// function printLast(n, token) {
+//   token = token || "";
+//   console.log(n[n.length - 1], token);
+// }
 
 /*
  * Sass imports are usually in an abstract form in that
  * they leave off the partial prefix and the suffix.
- * This code creates the possible extensions, whether it is a partial
- * and whether it is a directory index file having those
- * same possible variations. If the import contains an extension,
- * then it is left alone.
+ * This code creates the possible extensions.
  *
  * IMPORTANT ORDERING NOTES:
  * We should be checking in the following order:
- * 1. the abstractFile with extension
- * 2. the abstractFile/uri             (and its permutations)
- * 3. the abstractFile/uriSub          (and its permutations)
- * 4. the dirname(abstractFile)/uri    (and its permutations)
- * 5. the dirname(abstractFile)/uriSub (and its permutations)
- * 6. the dirname(origin)/uri          (and its permutations)
- * 7. the abstractFile by itself       (and its permutations)
- *
- * uriSub is the original uri, minus the first segment (assumed to be the) node
- * module
- *
- * the permutations are all the possible name variants allowed in Sass load
- * paths, including an optional underscore "_" before the name, treating the
- * uri as a directory and searching for "index", and including the ".sass",
- * ".scss", and ".css" extensions
+ * 1. relative paths (based on the origin if set)
+ *   a. if the path has an extension, use as-is
+ *   b. if needed, create underscore + index + ext permutations
+ * 2. node_module expansion (remove the first segment of @import as the module name)
+ *   a. if the path has an extension, use as-is
+ *   b. if needed, create the expanded path + underscore + index + ext permutations
+ *   c. if needed, create the expanded path + subdirectory + underscore + index + ext permutations
  **/
-function expandFileName(uri, origin, abstractFile) {
+function expandFileName(uri, origin, location) {
   var names = [];
   var osUri = uri.split("/").join(path.sep);
-  var uriSubmodule = uri.split("/").slice(1).join(path.sep);
-  var abstractDir = path.dirname(abstractFile);
-  var originDir = path.dirname(origin);
+  var osUriSubpath = osUri.split(path.sep).slice(1).join(path.sep);
 
-  if (path.extname(abstractFile)) {
-    names.push(abstractFile);
+  // relative paths (based on origin)
+  // attempt to build a new location by taking the dirname(origin) as the
+  // starting directory, and creating a new location by attaching the uri
+  if (origin && origin !== "stdin") {
+    namify(function(prefix, ext) {
+      var originDir = path.dirname(origin);
+      var fullLocation = path.join(originDir, osUri);
+      var dir = path.dirname(fullLocation);
+      var name = path.basename(fullLocation);
+
+      // exit early if there is an extension
+      if (path.extname(fullLocation)) {
+        names.push(fullLocation);
+        return;
+      }
+
+      names.push(path.join(dir, prefix + name + ext));
+      names.push(path.join(fullLocation, prefix + "index" + ext));
+    });
   }
 
-  expand(path.join(abstractFile, osUri), names);
-  expand(path.join(abstractFile, uriSubmodule), names);
-  expand(path.join(abstractDir, osUri), names);
-  expand(path.join(abstractDir, uriSubmodule), names);
-  expand(path.join(originDir, osUri), names);
-  expand(abstractFile, names);
+  // treat the first segment of the uri as the node module name and build
+  // a new location string, directory, and filename
+  namify(function(prefix, ext) {
+    var fullLocation = path.join(location, osUriSubpath);
+    var dir = path.dirname(fullLocation);
+    var name = path.basename(fullLocation);
+
+    // exit early if there is an extension
+    if (path.extname(fullLocation)) {
+      names.push(fullLocation);
+      return;
+    }
+
+    // always add the fullLocation + prefix + index + ext combination
+    names.push(path.join(fullLocation, prefix + "index" + ext));
+
+    // if, after removing the node module name from the uri, if there is still
+    // path information in the uriSubpath, the `dir` value is meaningful
+    // and needs to be checked
+    // by adding this test, we avoid printing out and checking the
+    // <sassDir>.css variants
+    if (osUriSubpath && osUri !== osUriSubpath) {
+      names.push(path.join(dir, prefix + name + ext));
+    }
+  });
+
+  // if the module uri has no slashes, we need to check for location/<moduleName>
+  // #37 @import "susy" => <path/to/susy/sassDir/>_susy.scss
+  if (uri.indexOf("/") === -1) {
+    namify(function(prefix, ext) {
+      names.push(path.join(location, prefix + uri + ext));
+    });
+  }
 
   return names;
 }


### PR DESCRIPTION
The original implementation of files.js that fixed #37 was not as maintainable.
This code change improves the readability of the files.js file by splitting
the namify calls out into their individual sections.

if-return checks were added to the individual namify lines to remove duplication
of file names to improve performance.