### PR TITLE
Function Modules in devDependencies are loaded

### DIFF
--- a/lib/function_loader.js
+++ b/lib/function_loader.js
@@ -6,7 +6,7 @@ var hash = require("./util/hash");
 var ARGUMENTS_REGEX = /\(.*\)$/;
 
 function autoDiscoverModules(root) {
-  return discover.simple(root);
+  return discover.simple(root, false, true);
 }
 
 function checkConflicts(obj1, obj2) {

--- a/lib/util/discover.js
+++ b/lib/util/discover.js
@@ -176,9 +176,9 @@ function getModules(dir, shallow, includeDevDependencies) {
   return simplify(discover(dir, shallow, includeDevDependencies));
 }
 
-function getSimple(dir, shallow) {
+function getSimple(dir, shallow, includeDevDependencies) {
   var results = [];
-  var modules = getModules(dir, shallow).modules;
+  var modules = getModules(dir, shallow, includeDevDependencies).modules;
   for (var i = 0; i < modules.length; i++) {
     results.push(modules[i].main);
   }

--- a/test/fixtures/function_modules/node_modules/fn_module_b/eyeglass-exports.js
+++ b/test/fixtures/function_modules/node_modules/fn_module_b/eyeglass-exports.js
@@ -1,0 +1,15 @@
+"use strict";
+
+var fs = require("fs");
+var path = require("path");
+
+module.exports = function(eyeglass, sass) {
+  return {
+    sassDir: __dirname, // directory where the sass files are.
+    functions: {
+      'hellob($name: "World")': function(name, done) {
+        done(sass.types.String("Hello, " + name.getValue() + "!"));
+      }
+    }
+  };
+};

--- a/test/fixtures/function_modules/node_modules/fn_module_b/package.json
+++ b/test/fixtures/function_modules/node_modules/fn_module_b/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "fn_module_b",
+  "keywords": ["eyeglass-module"],
+  "main": "eyeglass-exports.js",
+  "private": true
+}

--- a/test/fixtures/function_modules/package.json
+++ b/test/fixtures/function_modules/package.json
@@ -5,5 +5,8 @@
   "private": true,
   "dependencies": {
     "fn_module_a": "*"
+  },
+  "devDependencies": {
+    "fn_module_b": "*"
   }
 }

--- a/test/test_function_loading.js
+++ b/test/test_function_loading.js
@@ -19,6 +19,15 @@ describe("function loading", function () {
     testutils.assertCompiles(options, expected, done);
   });
 
+  it("should include devDependencies in its list", function (done) {
+    var options = {
+      root: testutils.fixtureDirectory("function_modules"),
+      data: "#hello { greeting: hellob(Chris); }\n"
+    };
+    var expected = "#hello {\n  greeting: Hello, Chris!; }\n";
+    testutils.assertCompiles(options, expected, done);
+  });
+
   it("should let me define my own sass functions too", function (done) {
     var input = "#hello { greeting: hello(Chris); }\n" +
                 "#mine { something: add-one(3em); }\n";


### PR DESCRIPTION
The function loader was not looking at devDependency items, which was causing
custom functions to not load for those following the readme. The custom
function search (done at `new Eyeglass()`) should be a deep search, and include
any devDependency items from a `package.json`.

Related to #40 