### PR TITLE
fix example

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ compile a Sass file.
 
 ```js
 #!/usr/bin/env node
+var path = require("path");
 var sass = require("node-sass");
 var Eyeglass = require("eyeglass").Eyeglass;
 var rootDir = __dirname;
@@ -75,7 +76,7 @@ options.root = rootDir;
 options.buildDir = path.join(rootDir, "dist");
 
 // prefix to give assets for their output url.
-options.assetsHttpPrefix: "assets";
+options.assetsHttpPrefix = "assets";
  
 var eyeglass = new Eyeglass(options, sass);
  


### PR DESCRIPTION
add require('path') and fix syntax error to README example so it can be copied and run.