### PR TITLE
Use decorator syntax for Grunt example

### DIFF
--- a/README.md
+++ b/README.md
@@ -276,10 +276,12 @@ sass.render(eyeglass.sassOptions(), function(error, result) {
 
 ```js
 ...
+var eyeglassDecorator = require("eyeglass").decorate;
+...
 sass: {
-    options: require("eyeglass").Eyeglass({
+    options: eyeglassDecorator({
         sourceMap: true
-    }).sassOptions(),
+    }),
     dist: {
         files: {
             'public/css/main.css': 'sass/main.scss'


### PR DESCRIPTION
The previous example no longer works, since Eyeglass needs to be called with `new`, ie. `new Eyeglass({})`.

The new decorator syntax is a bit easier to read.

For this to work, #52 still needs to be fixed.