### PR TITLE
Make importer work with @import "foo/bar"

### DIFF
--- a/lib/util/files.js
+++ b/lib/util/files.js
@@ -35,7 +35,11 @@ function namify(cb) {
  **/
 function expandFileName(uri, origin, location) {
   var names = [];
+
+  // normalize uri for our current OS (e.g., foo\bar on Windows)
   var osUri = uri.split("/").join(path.sep);
+
+  // e.g., for osUri "foo\bar\baz", this becomes "bar\baz"
   var osUriSubpath = osUri.split(path.sep).slice(1).join(path.sep);
 
   // relative paths (based on origin)
@@ -81,6 +85,16 @@ function expandFileName(uri, origin, location) {
     // by adding this test, we avoid printing out and checking the
     // <sassDir>.css variants
     if (osUriSubpath && osUri !== osUriSubpath) {
+      names.push(path.join(dir, prefix + name + ext));
+
+      // but also, we want this to work for sass modules, so we need to check
+      // against osUri, not just osUriSubpath
+
+      fullLocation = path.join(location, osUri);
+      dir = path.dirname(fullLocation);
+      name = path.basename(fullLocation);
+
+      names.push(path.join(fullLocation, prefix + "index" + ext));
       names.push(path.join(dir, prefix + name + ext));
     }
   });

--- a/test/fixtures/app_assets/sass/advanced_includePaths.scss
+++ b/test/fixtures/app_assets/sass/advanced_includePaths.scss
@@ -1,0 +1,5 @@
+@import "typography/contrast";
+
+.bar {
+  color: $text-color;
+}

--- a/test/fixtures/includable_scss/typography/_contrast.scss
+++ b/test/fixtures/includable_scss/typography/_contrast.scss
@@ -1,0 +1,1 @@
+$text-color: #333 !global;

--- a/test/test_imports.js
+++ b/test/test_imports.js
@@ -29,6 +29,19 @@ describe("core api", function () {
  });
 
 
+  it("should be able to @import \"folder/file\" from a dir in includePaths", function(done) {
+    var expected = ".bar {\n" +
+                   "  color: #333; }\n";
+    var rootDir = testutils.fixtureDirectory("app_assets");
+    var eg = new Eyeglass({
+      root: rootDir,
+      includePaths: ["../../includable_scss"],
+      file: path.join(rootDir, "sass", "advanced_includePaths.scss")
+    }, sass);
+
+    testutils.assertCompiles(eg, expected, done);
+  });
+
  it("should compile a sass file with a custom function", function (done) {
    var options = {
      data: "div { content: hello-world(); }",


### PR DESCRIPTION
In particular when used in conjunction with includePaths.

Includes a test.