### PR TITLE
Allow importing when there is a dot in a folder name

### DIFF
--- a/lib/util/files.js
+++ b/lib/util/files.js
@@ -1,6 +1,7 @@
 "use strict";
 
 var path = require("path");
+var lodash = require("lodash");
 
 function namify(cb) {
   ["", "_"].forEach(function(prefix) {
@@ -99,7 +100,7 @@ function expandFileName(uri, origin, location) {
     });
   }
 
-  return names;
+  return lodash.uniq(names);
 }
 
 module.exports.expandFileName = expandFileName;

--- a/lib/util/files.js
+++ b/lib/util/files.js
@@ -87,6 +87,7 @@ function expandFileName(uri, origin, location) {
       dir = path.dirname(fullLocation);
       name = path.basename(fullLocation);
 
+      names.push(fullLocation);
       names.push(path.join(fullLocation, prefix + "index" + ext));
       names.push(path.join(dir, prefix + name + ext));
     }

--- a/lib/util/files.js
+++ b/lib/util/files.js
@@ -35,7 +35,11 @@ function namify(cb) {
  **/
 function expandFileName(uri, origin, location) {
   var names = [];
+
+  // normalize uri for our current OS (e.g., foo\bar on Windows)
   var osUri = uri.split("/").join(path.sep);
+
+  // e.g., for osUri "foo\bar\baz", this becomes "bar\baz"
   var osUriSubpath = osUri.split(path.sep).slice(1).join(path.sep);
 
   // relative paths (based on origin)
@@ -81,6 +85,16 @@ function expandFileName(uri, origin, location) {
     // by adding this test, we avoid printing out and checking the
     // <sassDir>.css variants
     if (osUriSubpath && osUri !== osUriSubpath) {
+      names.push(path.join(dir, prefix + name + ext));
+
+      // but also, we want this to work for sass modules, so we need to check
+      // against osUri, not just osUriSubpath
+
+      fullLocation = path.join(location, osUri);
+      dir = path.dirname(fullLocation);
+      name = path.basename(fullLocation);
+
+      names.push(path.join(fullLocation, prefix + "index" + ext));
       names.push(path.join(dir, prefix + name + ext));
     }
   });

--- a/lib/util/files.js
+++ b/lib/util/files.js
@@ -52,11 +52,7 @@ function expandFileName(uri, origin, location) {
       var dir = path.dirname(fullLocation);
       var name = path.basename(fullLocation);
 
-      // exit early if there is an extension
-      if (path.extname(fullLocation)) {
-        names.push(fullLocation);
-        return;
-      }
+      names.push(fullLocation);
 
       names.push(path.join(dir, prefix + name + ext));
       names.push(path.join(fullLocation, prefix + "index" + ext));
@@ -70,11 +66,7 @@ function expandFileName(uri, origin, location) {
     var dir = path.dirname(fullLocation);
     var name = path.basename(fullLocation);
 
-    // exit early if there is an extension
-    if (path.extname(fullLocation)) {
-      names.push(fullLocation);
-      return;
-    }
+    names.push(fullLocation);
 
     // always add the fullLocation + prefix + index + ext combination
     names.push(path.join(fullLocation, prefix + "index" + ext));

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "gulp-eslint": "0.4.0",
     "gulp-istanbul": "^0.9.0",
     "gulp-mocha": "^2.0.0",
+    "lodash": "^3.10.1",
     "mocha": "^2.1.0",
     "should": ">= 0.0.1"
   }

--- a/test/fixtures/app_assets/sass/advanced_includePaths.scss
+++ b/test/fixtures/app_assets/sass/advanced_includePaths.scss
@@ -1,0 +1,5 @@
+@import "typography/contrast";
+
+.bar {
+  color: $text-color;
+}

--- a/test/fixtures/app_assets/sass/dot_include.scss
+++ b/test/fixtures/app_assets/sass/dot_include.scss
@@ -1,0 +1,5 @@
+@import "heavy.weights/animal.noises";
+
+.bat-noise {
+  color: $noise-bats-make;
+}

--- a/test/fixtures/includable_scss/heavy.weights/_animal.noises.sass
+++ b/test/fixtures/includable_scss/heavy.weights/_animal.noises.sass
@@ -1,0 +1,1 @@
+$noise-bats-make: #eee !global

--- a/test/fixtures/includable_scss/typography/_contrast.scss
+++ b/test/fixtures/includable_scss/typography/_contrast.scss
@@ -1,0 +1,1 @@
+$text-color: #333 !global;

--- a/test/test_imports.js
+++ b/test/test_imports.js
@@ -42,6 +42,19 @@ describe("core api", function () {
     testutils.assertCompiles(eg, expected, done);
   });
 
+  it("should be able to @import a sass file with a dots in its directory name and file name", function(done) {
+    var expected = ".bat-noise {\n" +
+                   "  color: #eee; }\n";
+    var rootDir = testutils.fixtureDirectory("app_assets");
+    var eg = new Eyeglass({
+      root: rootDir,
+      includePaths: ["../../includable_scss"],
+      file: path.join(rootDir, "sass", "dot_include.scss")
+    }, sass);
+
+    testutils.assertCompiles(eg, expected, done);
+  });
+
  it("should compile a sass file with a custom function", function (done) {
    var options = {
      data: "div { content: hello-world(); }",

--- a/test/test_imports.js
+++ b/test/test_imports.js
@@ -29,6 +29,19 @@ describe("core api", function () {
  });
 
 
+  it("should be able to @import \"folder/file\" from a dir in includePaths", function(done) {
+    var expected = ".bar {\n" +
+                   "  color: #333; }\n";
+    var rootDir = testutils.fixtureDirectory("app_assets");
+    var eg = new Eyeglass({
+      root: rootDir,
+      includePaths: ["../../includable_scss"],
+      file: path.join(rootDir, "sass", "advanced_includePaths.scss")
+    }, sass);
+
+    testutils.assertCompiles(eg, expected, done);
+  });
+
  it("should compile a sass file with a custom function", function (done) {
    var options = {
      data: "div { content: hello-world(); }",


### PR DESCRIPTION
This change may yield some number of somewhat nonsensical searched filenames in some cases (like `.scss.scss`) but it also allows imports like `my.folder/my.styles` I believe it may also help with Asset Pipeline-influenced names like `.css.scss`.