### PR TITLE
Removing circular reference to options when sassOptions is called

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -40,7 +40,11 @@ Eyeglass.prototype = {
   },
   sassOptions: function() {
     // TODO remove eyeglass specific options or maybe namespace them?
-    return this.options;
+    /*eslint-disable */
+    var options = require('util')._extend({}, this.options);
+    /*eslint-enable */
+    delete options.eyeglass;
+    return options;
   },
   normalizeOptions: function(options) {
     options.root = options.root || this.defaultRoot();


### PR DESCRIPTION
This fixes #52