### PR TITLE
Handling the various different states of includePaths

### DIFF
--- a/lib/module_importer.js
+++ b/lib/module_importer.js
@@ -63,8 +63,9 @@ function makeImporter(eyeglass, sass, options, fallbackImporter) {
     var relativePath = fragments.slice(1).join("/");
     var pkgRootDir = isRealFile ? importUtils.packageRootDir(path.dirname(prev)) : root;
     var jsFile = importUtils.getModuleByName(moduleName, pkgRootDir);
-    // includePaths here is a string, despite the config option being an Array
-    var includePaths = options.includePaths.split(path.delimiter);
+    // in some cases, includePaths here is a string, despite the config option being an Array
+    // other cases, it is an Array (or undefined if it was not passed as an option)
+    var includePaths = (options.includePaths && options.includePaths.split) ? options.includePaths.split(path.delimiter) : options.includePaths || [];;
 
     if (jsFile) {
       // is eyeglass module

--- a/test/fixtures/app_assets/sass/no_includePaths.scss
+++ b/test/fixtures/app_assets/sass/no_includePaths.scss
@@ -1,0 +1,5 @@
+$c: red;
+
+.foo {
+  color: $c;
+}

--- a/test/test_imports.js
+++ b/test/test_imports.js
@@ -16,6 +16,18 @@ describe("core api", function () {
    testutils.assertCompiles(options, expected, done);
  });
 
+ it("should compile a sass file if includePaths was not passed as an option & not needed", function(done) {
+   var expected = ".foo {\n" +
+                  "  color: red; }\n";
+   var rootDir = testutils.fixtureDirectory("app_assets");
+   var eg = new Eyeglass({
+     root: rootDir,
+     file: path.join(rootDir, "sass", "no_includePaths.scss")
+   }, sass);
+
+   testutils.assertCompiles(eg, expected, done);
+ });
+
  it("should compile a sass file honoring includePaths", function(done) {
    var expected = ".foo {\n" +
                   "  color: #112358; }\n";
@@ -32,7 +44,6 @@ describe("core api", function () {
 
    testutils.assertCompiles(eg, expected, done);
  });
-
 
   it("should be able to @import \"folder/file\" from a dir in includePaths", function(done) {
     var expected = ".bar {\n" +


### PR DESCRIPTION
Pull Request #51 to solve issue #47 is causing issues in Grunt for me. Specifically, if I include includePaths like this:

```
  var eyeglass = new Eyeglass({
    includePaths: [path.join(rootDir, 'node_modules','compass-mixins','lib')]
  });
```

I get a `Fatal error: undefined is not a function`

If I exclude includePaths like this:

```
  var eyeglass = new Eyeglass({});
```
I get a `Fatal error: Cannot read property 'forEach' of undefined`

This pull request maintains the logic in #51 when includePaths is a String (which is in the case in the tests), but also handles the previous logic of includePaths being an Array (which is the case when I run it with Grunt).

For reference, here are the versions I'm running:
eyeglass 0.6.1
grunt-sass 1.0.0
node-sass 3.3.2
libsass 3.2.5

@alanhogan @FransTwisk, if you can check if this works with your configurations, that would help.