### PR TITLE
Fix edge case when project name matches eyeglass module name

### DIFF
--- a/lib/util/eyeglass_modules.js
+++ b/lib/util/eyeglass_modules.js
@@ -204,7 +204,7 @@ function getHierarchy(branch) {
   * @returns {Object} the pruned tree
   */
 function pruneModuleTree(moduleTree) {
-  var finalModule = moduleTree.name && this.find(moduleTree.name);
+  var finalModule = moduleTree.isEyeglassModule && this.find(moduleTree.name);
   // normalize the branch
   var branch = {
     name: finalModule && finalModule.name || moduleTree.name,

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
   "dependencies": {
     "archy": "^1.0.0",
     "deasync": "^0.1.3",
+    "debug": "^2.2.0",
     "fs-extra": "^0.24.0",
     "glob": "^5.0.15",
     "lodash.includes": "^3.1.3",
@@ -41,7 +42,6 @@
     "tmp": "0.0.28"
   },
   "devDependencies": {
-    "debug": "^2.2.0",
     "eslint": "^1.7.1",
     "eyeglass-dev-eslint": "^2.0.0",
     "grunt": "^0.4.5",

--- a/test/fixtures/project_name_is_dep_name/node_modules/eyeglass-my-package/eyeglass-exports.js
+++ b/test/fixtures/project_name_is_dep_name/node_modules/eyeglass-my-package/eyeglass-exports.js
@@ -1,0 +1,9 @@
+"use strict";
+
+var path = require("path");
+
+module.exports = function(eyeglass, sass) {
+  return {
+    sassDir: path.join(__dirname, "sass")
+  };
+};

--- a/test/fixtures/project_name_is_dep_name/node_modules/eyeglass-my-package/package.json
+++ b/test/fixtures/project_name_is_dep_name/node_modules/eyeglass-my-package/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "eyeglass-my-package",
+  "keywords": ["eyeglass-module"],
+  "main": "eyeglass-exports.js",
+  "private": true,
+  "version": "1.0.1",
+  "dependencies": {},
+  "eyeglass": {
+    "needs": "*",
+    "name": "my-package"
+  }
+}

--- a/test/fixtures/project_name_is_dep_name/node_modules/eyeglass-my-package/sass/_index.scss
+++ b/test/fixtures/project_name_is_dep_name/node_modules/eyeglass-my-package/sass/_index.scss
@@ -1,0 +1,3 @@
+.foo {
+  color: red;
+}

--- a/test/fixtures/project_name_is_dep_name/package.json
+++ b/test/fixtures/project_name_is_dep_name/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "my-package",
+  "version": "0.0.1",
+  "main": "package.json",
+  "private": true,
+  "dependencies": {
+    "eyeglass-my-package": "*"
+  }
+}

--- a/test/test_imports.js
+++ b/test/test_imports.js
@@ -279,4 +279,13 @@ describe("eyeglass importer", function () {
     });
   });
 
+  it("handle project name that conflicts with eyeglass module name", function(done) {
+    var options = {
+     root: testutils.fixtureDirectory("project_name_is_dep_name"),
+     data: '@import "my-package";'
+    };
+    var expected = ".foo {\n  color: red; }\n";
+    testutils.assertCompiles(options, expected, done);
+  });
+
 });


### PR DESCRIPTION
This fixes a minor edge case where the project root's name matches the name of an eyeglass module, but they're not the same package.

e.g.

`package.json`
```json
{
  "name": "foo",
  "dependencies": {
    "other-foo": "*"
  }
}
```

`other-foo/package.json`
```json
{
  "name": "other-foo",
  "eyeglass": {
    "name": "foo"
  }
}
```