### PR TITLE
allow uri fragments within asset-url. fixes #75

### DIFF
--- a/lib/assets.js
+++ b/lib/assets.js
@@ -123,12 +123,11 @@ function newExportableAssetCollection(srcPath, opts) {
     return assets.export(srcPath, opts);
 }
 
-function resolveAssetDefaults(sass, sassUtils, registeredAssetsMap, relativePathString) {
+function resolveAssetDefaults(sass, sassUtils, registeredAssetsMap, relativePath) {
+
   registeredAssetsMap = sassUtils.handleEmptyMap(registeredAssetsMap);
   sassUtils.assertType(registeredAssetsMap, "map");
-  sassUtils.assertType(relativePathString, "string");
 
-  var relativePath = unquote(relativePathString.getValue());
   var registeredAssets = sassUtils.castToJs(registeredAssetsMap);
 
   var appAssets = registeredAssets.coerce.get(null);
@@ -164,7 +163,18 @@ function httpJoin() {
 }
 
 function resolveAsset(eyeglass, sass, sassUtils, registeredAssetsMap, relativePathString, cb) {
-  var data = resolveAssetDefaults(sass, sassUtils, registeredAssetsMap, relativePathString);
+
+  sassUtils.assertType(relativePathString, "string");
+  relativePathString = unquote(relativePathString.getValue());
+
+  var uriFragments = /^([^\?#]+)(\?[^#]*)?(#.*)?/.exec(relativePathString);
+  uriFragments = {
+    path: uriFragments[1],
+    search: uriFragments[2] || "",
+    hash: uriFragments[3] || ""
+  };
+
+  var data = resolveAssetDefaults(sass, sassUtils, registeredAssetsMap, uriFragments.path);
 
   if (data) {
     var uri = data.coerce.get("uri");
@@ -179,24 +189,29 @@ function resolveAsset(eyeglass, sass, sassUtils, registeredAssetsMap, relativePa
         cb(error);
       } else {
         // handle a string here?
-        var combined = assetUriInfo.path;
+        var finalUri = assetUriInfo.path;
         if (eyeglass.options.assetsRelativeTo) {
-          combined = path.relative(eyeglass.options.assetsRelativeTo, assetUriInfo.path);
+          finalUri = path.relative(eyeglass.options.assetsRelativeTo, assetUriInfo.path);
         }
+        // if a query param was specified, append it to the uri query
         if (assetUriInfo.query) {
-          combined = combined + "?" + assetUriInfo.query;
+          uriFragments.search = (uriFragments.search ? "&" : "?") + assetUriInfo.query;
         }
+
+        // append the fragments back into the final uri
+        finalUri += uriFragments.search + uriFragments.hash;
+
         eyeglass.assets.install(filepath, assetUriInfo.path, function(installError, newFilepath) {
           if (installError) {
             cb(installError);
           } else {
-            cb(null, combined, newFilepath);
+            cb(null, finalUri, newFilepath);
           }
         });
       }
     });
   } else {
-    cb(new Error("Asset not found: " + relativePathString.getValue()));
+    cb(new Error("Asset not found: " + uriFragments.path));
   }
 }
 

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
   "dependencies": {
     "archy": "^1.0.0",
     "deasync": "^0.1.3",
+    "debug": "^2.2.0",
     "fs-extra": "^0.24.0",
     "glob": "^5.0.15",
     "lodash.includes": "^3.1.3",
@@ -41,7 +42,6 @@
     "tmp": "0.0.28"
   },
   "devDependencies": {
-    "debug": "^2.2.0",
     "eslint": "^1.7.1",
     "eyeglass-dev-eslint": "^2.0.0",
     "grunt": "^0.4.5",

--- a/test/test_assets.js
+++ b/test/test_assets.js
@@ -454,4 +454,20 @@ describe("assets", function () {
     });
     done();
   });
+
+  it("should allow uri fragments", function (done) {
+    var input = "@import 'assets'; div { background-image: asset-url('images/foo.png?q=true');" +
+                "background-image: asset-url('images/foo.png#foo'); }";
+    var expected = "div {\n  background-image: url(/images/foo.png?q=true);\n" +
+                   "  background-image: url(/images/foo.png#foo); }\n";
+    var rootDir = testutils.fixtureDirectory("app_assets");
+    var eg = new Eyeglass({
+      root: rootDir,
+      data: input
+    }, sass);
+    // asset-url("images/foo.png") => url(public/assets/images/foo.png);
+    eg.assets.addSource(rootDir, {pattern: "images/**/*"});
+
+    testutils.assertCompiles(eg, expected, done);
+  });
 });


### PR DESCRIPTION
This allows `asset-url` uris to contain fragments (hash and query). These values get merged into the resulting url.