### PR TITLE
Optional eyeglass exports

### DIFF
--- a/lib/function_loader.js
+++ b/lib/function_loader.js
@@ -29,20 +29,25 @@ function checkConflicts(obj1, obj2) {
 
 module.exports = function(eyeglass, sass, options, existingFunctions) {
   var functions = eyeglass.modules.list.reduce(function(fns, mod) {
+    if (!mod.main) {
+      return fns;
+    }
+
     var obj = require(mod.main)(eyeglass, sass);
 
-    if (obj.functions) {
-      // log any functions found in this module
-      debug.functions(
-        "functions discovered in module %s:%s%s",
-        mod.name,
-        DELIM,
-        Object.keys(obj.functions).join(DELIM)
-      );
-      checkConflicts(fns, obj.functions);
-      return merge(fns, obj.functions);
+    if (!obj.functions) {
+      return fns;
     }
-    return fns;
+
+    // log any functions found in this module
+    debug.functions(
+      "functions discovered in module %s:%s%s",
+      mod.name,
+      DELIM,
+      Object.keys(obj.functions).join(DELIM)
+    );
+    checkConflicts(fns, obj.functions);
+    return merge(fns, obj.functions);
   }, {});
 
   checkConflicts(functions, existingFunctions);

--- a/lib/module_importer.js
+++ b/lib/module_importer.js
@@ -65,23 +65,25 @@ function makeImporter(eyeglass, sass, options, fallbackImporter) {
     var jsFile = eyeglass.modules.access(moduleName, isRealFile ? prev : root);
     var sassDir;
 
-    if (jsFile && jsFile.eyeglass.sassDir) {
-      sassDir = jsFile.eyeglass.sassDir;
-    } else if (jsFile && jsFile.main) {
-      var mod = require(jsFile.main)(eyeglass, sass);
-      sassDir = mod.sassDir;
-    }
+    if (jsFile) {
+      if (jsFile.eyeglass.sassDir) {
+        sassDir = jsFile.eyeglass.sassDir;
+      } else if (jsFile.main) {
+        var mod = require(jsFile.main)(eyeglass, sass);
+        sassDir = mod.sassDir;
+      }
 
-    if (jsFile && !(sassDir || isRealFile)) {
-      // No sass directory, give an error
-      importUtils.fallback(uri, prev, done, function() {
-        var missingMessage = "sassDir is not specified in " + jsFile.name + "'s package.json";
-        if (jsFile.main) {
-          missingMessage += " or " + jsFile.main;
-        }
-        done(new Error(missingMessage));
-      });
-      return;
+      if (!sassDir && !isRealFile) {
+        // No sass directory, give an error
+        importUtils.fallback(uri, prev, done, function() {
+          var missingMessage = "sassDir is not specified in " + jsFile.name + "'s package.json";
+          if (jsFile.main) {
+            missingMessage += " or " + jsFile.main;
+          }
+          done(new Error(missingMessage));
+        });
+        return;
+      }
     }
 
     if (sassDir) {

--- a/lib/module_importer.js
+++ b/lib/module_importer.js
@@ -63,18 +63,28 @@ function makeImporter(eyeglass, sass, options, fallbackImporter) {
     var moduleName = fragments[0];
     var relativePath = fragments.slice(1).join("/");
     var jsFile = eyeglass.modules.access(moduleName, isRealFile ? prev : root);
+    var sassDir;
 
-    if (jsFile && jsFile.main) {
-      // is eyeglass module
+    if (jsFile && jsFile.eyeglass.sassDir) {
+      sassDir = jsFile.eyeglass.sassDir;
+    } else if (jsFile && jsFile.main) {
       var mod = require(jsFile.main)(eyeglass, sass);
-      var sassDir = mod.sassDir;
-      if (!sassDir) {
-        importUtils.fallback(uri, prev, done, function() {
-          done(new Error("sassDir is not specified in " + jsFile.main));
-        });
-        return;
-      }
+      sassDir = mod.sassDir;
+    }
 
+    if (jsFile && !(sassDir || isRealFile)) {
+      // No sass directory, give an error
+      importUtils.fallback(uri, prev, done, function() {
+        var missingMessage = "sassDir is not specified in " + jsFile.name + "'s package.json";
+        if (jsFile.main) {
+          missingMessage += " or " + jsFile.main;
+        }
+        done(new Error(missingMessage));
+      });
+      return;
+    }
+
+    if (sassDir) {
       // read uri from location. pass no includePaths as this is an eyeglass module
       readAbstractFile(uri, prev, sassDir, [], function(err, data) {
         if (err) {

--- a/lib/util/eyeglass_modules.js
+++ b/lib/util/eyeglass_modules.js
@@ -381,9 +381,9 @@ function dedupeModules(modules) {
   * @param   {Object} pkg - the package.json reference
   * @returns {String} the name of the module
   */
-function getModuleName(pkg, pkgPath) {
+function getModuleName(pkg) {
   // check for `eyeglass.name` first, otherwise use `name`
-  return normalizeEyeglassOptions(pkg.data.eyeglass, pkgPath).name || pkg.data.name;
+  return normalizeEyeglassOptions(pkg.data.eyeglass).name || pkg.data.name;
 }
 
 /**
@@ -407,7 +407,7 @@ function normalizeEyeglassOptions(options, pkgPath) {
     normalizedOpts = options;
   }
 
-  if (normalizedOpts.sassDir) {
+  if (pkgPath && normalizedOpts.sassDir) {
     normalizedOpts.sassDir = path.resolve(pkgPath, normalizedOpts.sassDir);
   }
 
@@ -477,7 +477,7 @@ function resolveModule(pkgPath, isRoot) {
     // return a module reference
     var modulePath = path.dirname(pkg.path);
     return {
-      name: getModuleName(pkg, pkgPath),
+      name: getModuleName(pkg),
       rawName: pkg.data.name,
       path: modulePath,
       version: pkg.data.version,
@@ -487,7 +487,7 @@ function resolveModule(pkgPath, isRoot) {
         dir: modulePath,
         isRoot: isRoot
       }),
-      eyeglass: normalizeEyeglassOptions(pkg.data.eyeglass, pkgPath)
+      eyeglass: normalizeEyeglassOptions(pkg.data.eyeglass, modulePath)
     };
   }
 }

--- a/lib/util/eyeglass_modules.js
+++ b/lib/util/eyeglass_modules.js
@@ -381,25 +381,37 @@ function dedupeModules(modules) {
   * @param   {Object} pkg - the package.json reference
   * @returns {String} the name of the module
   */
-function getModuleName(pkg) {
+function getModuleName(pkg, pkgPath) {
   // check for `eyeglass.name` first, otherwise use `name`
-  return normalizeEyeglassOptions(pkg.data.eyeglass).name || pkg.data.name;
+  return normalizeEyeglassOptions(pkg.data.eyeglass, pkgPath).name || pkg.data.name;
 }
 
 /**
   * normalizes a given `eyeglass` reference from a package.json
   *
-  * @param   {Object} options - the eyeglass options from the package.json
+  * @param   {Object} options - The eyeglass options from the package.json
+  * @param   {String} pkgPath - The location of the package.json.
   * @returns {Object} the normalized options
   */
-function normalizeEyeglassOptions(options) {
+function normalizeEyeglassOptions(options, pkgPath) {
+  var normalizedOpts;
   // if it's a string, treat it as the export
   if (typeof options === "string") {
-    return {
+    normalizedOpts = {
       exports: options
     };
   }
-  return typeof options === "object" ? options : {};
+  if (typeof options !== "object") {
+    normalizedOpts = {};
+  } else {
+    normalizedOpts = options;
+  }
+
+  if (normalizedOpts.sassDir) {
+    normalizedOpts.sassDir = path.resolve(pkgPath, normalizedOpts.sassDir);
+  }
+
+  return normalizedOpts;
 }
 
 /**
@@ -421,7 +433,11 @@ function getExportsFileFromOptions(options) {
   */
 function getModuleExports(pkg, modulePath) {
   var exportsFile = getExportsFileFromOptions(pkg.eyeglass) || pkg.main;
-  return path.join(modulePath, exportsFile || "");
+  if (exportsFile) {
+    return path.join(modulePath, exportsFile);
+  } else {
+    return null;
+  }
 }
 
 /**
@@ -449,19 +465,19 @@ function getFinalModule(name) {
 /**
   * resolves the module and it's dependencies
   *
-  * @param   {String} pkg - the path to the modules package.json location
+  * @param   {String} pkgPath - the path to the modules package.json location
   * @param   {Boolean} isRoot - whether or not it's the root of the project
   * @returns {Object} the resolved module definition
   */
-function resolveModule(pkg, isRoot) {
-  pkg = packageUtils.getPackage(pkg);
+function resolveModule(pkgPath, isRoot) {
+  var pkg = packageUtils.getPackage(pkgPath);
   var isEyeglassMod = isEyeglassModule(pkg.data);
   // if the module is an eyeglass module OR it's the root project
   if (isEyeglassMod || (pkg.data && isRoot)) {
     // return a module reference
     var modulePath = path.dirname(pkg.path);
     return {
-      name: getModuleName(pkg),
+      name: getModuleName(pkg, pkgPath),
       rawName: pkg.data.name,
       path: modulePath,
       version: pkg.data.version,
@@ -471,7 +487,7 @@ function resolveModule(pkg, isRoot) {
         dir: modulePath,
         isRoot: isRoot
       }),
-      eyeglass: normalizeEyeglassOptions(pkg.data.eyeglass)
+      eyeglass: normalizeEyeglassOptions(pkg.data.eyeglass, pkgPath)
     };
   }
 }

--- a/site-src/docs/CHANGELOG.md
+++ b/site-src/docs/CHANGELOG.md
@@ -7,6 +7,8 @@
   like gulp which share options across compiles. Fixes #83, #65
 * Handle hash fragments in asset urls. Fixes #75.
 * Fixed an edge case when project name matches an eyeglass module name.
+* The `eyeglass-exports.js` file is now optional as long as the
+  `sassDir` of the project is specified in the `package.json` file.
 
 #### 0.7.1 (Nov 16, 2015)
 

--- a/site-src/docs/eyeglass_modules/index.md
+++ b/site-src/docs/eyeglass_modules/index.md
@@ -11,7 +11,7 @@ An eyeglass module consists of (at a minimum) the following:
 ```
 /my-eyeglass-module <directory>
   /package.json
-  /eyeglass-exports.js
+  /eyeglass-exports.js <optional>
   /scss <directory>
 ```
 
@@ -29,7 +29,8 @@ The next step is to add the `eyeglass` section to package.json. This gives eyegl
 // ...
   "eyeglass": {
     "needs": "<eyeglass version>",
-    "exports": "<optional: alternate exports>"
+    "exports": "<optional: alternate exports>",
+    "sassDir": "<relative path to your sass files' directory>"
   }
 ```
 
@@ -55,7 +56,12 @@ module.exports = function(eyeglass, sass) {
 
 The goal of `eyeglass-exports.js` is to create a module that is a function. The function receives `eyeglass` (the environment), and `sass` (the Sass utilities). When the function is called, it should return an object literal. All items in the return object are optional: these are the eyeglass features your module provides.
 
-* **sassDir**: A directory string. This is the path to your `.sass` or `.scss` files. Many developers use the `path` module and `__dirname` in combination, setting `sassDir: require("path").resolve(__dirname, "scss")` and letting node do all the work.
+* **sassDir**: A directory string. This is the path to your `.sass` or
+   `.scss` files. Many developers use the `path` module and `__dirname`
+  in combination, setting `sassDir: require("path").resolve(__dirname, "scss")`
+  and letting node do all the work. Note that if you specify the `sassDir` in package.json that will take
+  precedence over what is returned from your eyeglass exports file.
+
 * **functions**: An object collection. Functions in eyeglass work the same as in `node-sass`. We'll cover Custom Functions in more detail below.
 
 # Custom Mixins

--- a/test/fixtures/is_a_module/package.json
+++ b/test/fixtures/is_a_module/package.json
@@ -1,9 +1,6 @@
 {
   "name": "is_a_module",
   "main": "eyeglass-exports.js",
-  "eyeglass": {
-    "needs": "*"
-  },
   "keywords": ["eyeglass-module"],
   "private": true,
   "eyeglass": {

--- a/test/fixtures/simple_module/package.json
+++ b/test/fixtures/simple_module/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "simple_module",
+  "keywords": ["eyeglass-module"],
+  "private": true,
+  "eyeglass": {
+    "name": "simple-module",
+    "needs": "*",
+    "sassDir": "sass"
+  }
+}

--- a/test/fixtures/simple_module/sass/index.scss
+++ b/test/fixtures/simple_module/sass/index.scss
@@ -1,0 +1,3 @@
+.simple-module {
+  this: is a simple module;
+}

--- a/test/test_imports.js
+++ b/test/test_imports.js
@@ -233,7 +233,7 @@ describe("eyeglass importer", function () {
         root: rootDir,
         data: '@import "malformed_module"; .foo {}'
       };
-      var expectedError = "sassDir is not specified in " +
+      var expectedError = "sassDir is not specified in malformed_module's package.json or " +
         path.join(rootDir, "node_modules", "malformed_module", "eyeglass-exports.js");
 
       testutils.assertCompilationError(options, expectedError, done);
@@ -305,4 +305,12 @@ describe("eyeglass importer", function () {
     });
   });
 
+  it("should allow sassDir to be specified in the package.json", function(done) {
+     var options = {
+       root: testutils.fixtureDirectory("simple_module"),
+       data: '@import "simple-module";'
+     };
+    var expected = ".simple-module {\n  this: is a simple module; }\n";
+    testutils.assertCompiles(options, expected, done);
+  });
 });


### PR DESCRIPTION
This PR makes simple eyeglass modules even simpler by not requiring an eyeglass exports file. For those modules that only provide sass files, they can just set a relative path in their package.json file. I suspect this will ease adoption because a small addition to package.json feels a simpler than adding a new javascript file especially to people who don't know js.