### PR TITLE
fix: asset-uri should return the uri not wrapped in url()

### DIFF
--- a/sass/assets.scss
+++ b/sass/assets.scss
@@ -45,12 +45,12 @@ $eg-registered-assets: () !default;
 
 // Returns a URL to the asset wrapped.
 @function asset-uri($relative-path) {
-  @return url(eyeglass-asset-uri($eg-registered-assets, $relative-path));
+  @return eyeglass-asset-uri($eg-registered-assets, $relative-path);
 }
 
 // Returns a URL to the asset wrapped in the css url() function.
 @function asset-url($relative-path) {
-  @return url(eyeglass-asset-uri($eg-registered-assets, $relative-path));
+  @return url(asset-uri($relative-path));
 }
 
 // The full path to the file on disk specified by the relative path.

--- a/test/test_assets.js
+++ b/test/test_assets.js
@@ -470,4 +470,18 @@ describe("assets", function () {
 
     testutils.assertCompiles(eg, expected, done);
   });
+
+  it("asset-uri should return the uri only, not wrapped in url()", function (done) {
+    var input = "@import 'assets'; div { uri: asset-uri('images/foo.png'); }";
+    var expected = "div {\n  uri: /images/foo.png; }\n";
+    var rootDir = testutils.fixtureDirectory("app_assets");
+    var eg = new Eyeglass({
+      root: rootDir,
+      data: input
+    }, sass);
+    // asset-url("images/foo.png") => url(public/assets/images/foo.png);
+    eg.assets.addSource(rootDir, {pattern: "images/**/*"});
+
+    testutils.assertCompiles(eg, expected, done);
+  });
 });


### PR DESCRIPTION
`asset-uri` and `asset-url` currently both return `url(...)`

I'd expect `asset-uri` to return only the uri, not wrapped in `url(...)`

This also simplifies `asset-url` to leverage `asset-uri` to get the uri.