### PR TITLE
Clean up tests to use new API

### DIFF
--- a/lib/options.js
+++ b/lib/options.js
@@ -63,7 +63,7 @@ function migrateEyeglassOptionsFromSassOptions(sassOptions, eyeglassOptions, dep
         "  /* sassOptions */",
         "  ...",
         "  eyeglass: {",
-        "    option: ...",
+        "    " + option + ": ...",
         "  }",
         "});"
       ].join("\n  "));

--- a/lib/util/deprecator.js
+++ b/lib/util/deprecator.js
@@ -1,5 +1,7 @@
 "use strict";
+
 var semver = require("semver");
+var DEFAULT_VERSION = "0.0.0";
 
 function Deprecator(options) {
   this.ignoreDeprecations = options && options.eyeglass && options.eyeglass.ignoreDeprecations;
@@ -11,9 +13,9 @@ Deprecator.prototype.isEnabled = function(sinceVersion) {
     // if `disableDeprecations`, we fallback to the env variable
     if (this.ignoreDeprecations === undefined) {
       // return early and don't set `enabled`, as we'll check the env everytime
-      return !semver.lte(sinceVersion, process.env.EYEGLASS_DEPRECATIONS);
+      return !semver.lte(sinceVersion, process.env.EYEGLASS_DEPRECATIONS || DEFAULT_VERSION);
     }
-    this.enabled = !semver.lte(sinceVersion, this.ignoreDeprecations || "0.0.0");
+    this.enabled = !semver.lte(sinceVersion, this.ignoreDeprecations || DEFAULT_VERSION);
   }
 
   return this.enabled;

--- a/test/test_assets.js
+++ b/test/test_assets.js
@@ -2,7 +2,7 @@
 
 var sass = require("node-sass");
 var path = require("path");
-var Eyeglass = require("../lib").Eyeglass;
+var Eyeglass = require("../lib");
 var testutils = require("./testutils");
 var assert = require("assert");
 var fse = require("fs-extra");
@@ -29,9 +29,14 @@ describe("assets", function () {
                    "  font: url(/fonts/foo.woff); }\n";
     var rootDir = testutils.fixtureDirectory("app_assets");
     var eg = new Eyeglass({
-      root: rootDir,
-      data: input
-    }, sass);
+      data: input,
+      eyeglass: {
+        root: rootDir,
+        engines: {
+          sass: sass
+        }
+      }
+    });
     // asset-url("images/foo.png") => url(public/assets/images/foo.png);
     eg.assets.addSource(rootDir, {pattern: "images/**/*"});
     // asset-url("fonts/foo.ttf") => url(public/assets/fonts/foo.ttf);
@@ -46,7 +51,6 @@ describe("assets", function () {
                    "  importer: invoked; }\n";
     var rootDir = testutils.fixtureDirectory("app_assets");
     var eg = new Eyeglass({
-      root: rootDir,
       data: input,
       importer: function(uri, prev, importerDone) {
         if (uri === "custom") {
@@ -55,8 +59,14 @@ describe("assets", function () {
             file: "custom"
           });
         }
+      },
+      eyeglass: {
+        root: rootDir,
+        engines: {
+          sass: sass
+        }
       }
-    }, sass);
+    });
 
     testutils.assertCompiles(eg, expected, done);
   });
@@ -72,9 +82,14 @@ describe("assets", function () {
     var rootDir = testutils.fixtureDirectory("app_assets");
     //var distDir = tmp.dirSync();
     var eg = new Eyeglass({
-      root: rootDir,
-      file: path.join(rootDir, "sass", "uses_mod_1.scss")
-    }, sass);
+      file: path.join(rootDir, "sass", "uses_mod_1.scss"),
+      eyeglass: {
+        root: rootDir,
+        engines: {
+          sass: sass
+        }
+      }
+    });
 
     // asset-url("images/foo.png") => url(public/assets/images/foo.png);
     eg.assets.addSource(rootDir, {pattern: "images/**/*"});
@@ -91,9 +106,14 @@ describe("assets", function () {
     var rootDir = testutils.fixtureDirectory("app_assets");
     //var distDir = tmp.dirSync();
     var eg = new Eyeglass({
-      root: rootDir,
-      file: path.join(rootDir, "sass", "app_assets.scss")
-    }, sass);
+      file: path.join(rootDir, "sass", "app_assets.scss"),
+      eyeglass: {
+        root: rootDir,
+        engines: {
+          sass: sass
+        }
+      }
+    });
 
     // asset-url("images/foo.png") => url(public/assets/images/foo.png);
     eg.assets.addSource(rootDir, {pattern: "images/**/*", httpPrefix: "assets"});
@@ -112,10 +132,15 @@ describe("assets", function () {
     var rootDir = testutils.fixtureDirectory("app_assets");
     //var distDir = tmp.dirSync();
     var eg = new Eyeglass({
-      root: rootDir,
-      assetsHttpPrefix: "assets",
-      file: path.join(rootDir, "sass", "both_assets.scss")
-    }, sass);
+      file: path.join(rootDir, "sass", "both_assets.scss"),
+      eyeglass: {
+        root: rootDir,
+        assetsHttpPrefix: "assets",
+        engines: {
+          sass: sass
+        }
+      }
+    });
 
     // asset-url("images/foo.png") => url(public/assets/images/foo.png);
     eg.assets.addSource(rootDir, {pattern: "images/**/*"});
@@ -134,11 +159,16 @@ describe("assets", function () {
     var rootDir = testutils.fixtureDirectory("app_assets");
     //var distDir = tmp.dirSync();
     var eg = new Eyeglass({
-      root: rootDir,
-      assetsHttpPrefix: "assets",
       file: path.join(rootDir, "sass", "both_assets.scss"),
-      assetsRelativeTo: "/assets/subdir"
-    }, sass);
+      eyeglass: {
+        root: rootDir,
+        assetsHttpPrefix: "assets",
+        assetsRelativeTo: "/assets/subdir",
+        engines: {
+          sass: sass
+        }
+      }
+    });
 
     // asset-url("images/foo.png") => url(public/assets/images/foo.png);
     eg.assets.addSource(rootDir, {pattern: "images/**/*"});
@@ -157,10 +187,15 @@ describe("assets", function () {
     var rootDir = testutils.fixtureDirectory("app_assets");
     //var distDir = tmp.dirSync();
     var eg = new Eyeglass({
-      root: rootDir,
-      assetsHttpPrefix: "assets",
-      file: path.join(rootDir, "sass", "both_assets.scss")
-    }, sass);
+      file: path.join(rootDir, "sass", "both_assets.scss"),
+      eyeglass: {
+        root: rootDir,
+        assetsHttpPrefix: "assets",
+        engines: {
+          sass: sass
+        }
+      }
+    });
 
     // asset-url("images/foo.png") => url(public/assets/images/foo.png);
     eg.assets.addSource(rootDir, {pattern: "images/**/*", httpPrefix: "whoa"});
@@ -179,9 +214,14 @@ describe("assets", function () {
                    'uri: "assets/foo/bar.png"))); }\n';
     var rootDir = testutils.fixtureDirectory("app_assets");
     var eg = new Eyeglass({
-      root: rootDir,
-      data: input
-    }, sass);
+      data: input,
+      eyeglass: {
+        root: rootDir,
+        engines: {
+          sass: sass
+        }
+      }
+    });
 
     testutils.assertCompiles(eg, expected, done);
   });
@@ -195,10 +235,15 @@ describe("assets", function () {
     var rootDir = testutils.fixtureDirectory("app_assets");
     //var distDir = tmp.dirSync();
     var eg = new Eyeglass({
-      root: rootDir,
-      assetsHttpPrefix: "assets",
-      file: path.join(rootDir, "sass", "both_assets.scss")
-    }, sass);
+      file: path.join(rootDir, "sass", "both_assets.scss"),
+      eyeglass: {
+        root: rootDir,
+        assetsHttpPrefix: "assets",
+        engines: {
+          sass: sass
+        }
+      }
+    });
 
     eg.assets.addSource(rootDir, {pattern: "images/**/*"});
     eg.assets.addSource(rootDir, {pattern: "fonts/**/*"});
@@ -226,10 +271,15 @@ describe("assets", function () {
     var rootDir = testutils.fixtureDirectory("app_assets");
     //var distDir = tmp.dirSync();
     var eg = new Eyeglass({
-      root: rootDir,
-      assetsHttpPrefix: "assets",
-      file: path.join(rootDir, "sass", "both_assets.scss")
-    }, sass);
+      file: path.join(rootDir, "sass", "both_assets.scss"),
+      eyeglass: {
+        root: rootDir,
+        assetsHttpPrefix: "assets",
+        engines: {
+          sass: sass
+        }
+      }
+    });
 
     eg.assets.addSource(rootDir, {pattern: "images/**/*"});
     eg.assets.addSource(rootDir, {pattern: "fonts/**/*"});
@@ -271,11 +321,16 @@ describe("assets", function () {
     var rootDir = testutils.fixtureDirectory("app_assets");
     //var distDir = tmp.dirSync();
     var eg = new Eyeglass({
-      root: rootDir,
-      buildDir: path.join(rootDir, "dist"),
-      assetsHttpPrefix: "assets",
-      file: path.join(rootDir, "sass", "both_assets.scss")
-    }, sass);
+      file: path.join(rootDir, "sass", "both_assets.scss"),
+      eyeglass: {
+        root: rootDir,
+        buildDir: path.join(rootDir, "dist"),
+        assetsHttpPrefix: "assets",
+        engines: {
+          sass: sass
+        }
+      }
+    });
 
     eg.assets.addSource(rootDir, {pattern: "images/**/*"});
     eg.assets.addSource(rootDir, {pattern: "fonts/**/*"});
@@ -314,12 +369,17 @@ describe("assets", function () {
     var rootDir = testutils.fixtureDirectory("app_assets");
     //var distDir = tmp.dirSync();
     var eg = new Eyeglass({
-      root: rootDir,
-      buildDir: path.join(rootDir, "dist"),
-      httpRoot: "/my-app",
-      assetsHttpPrefix: "assets",
-      file: path.join(rootDir, "sass", "both_assets.scss")
-    }, sass);
+      file: path.join(rootDir, "sass", "both_assets.scss"),
+      eyeglass: {
+        root: rootDir,
+        buildDir: path.join(rootDir, "dist"),
+        httpRoot: "/my-app",
+        assetsHttpPrefix: "assets",
+        engines: {
+          sass: sass
+        }
+      }
+    });
 
     eg.assets.addSource(rootDir, {pattern: "images/**/*"});
     eg.assets.addSource(rootDir, {pattern: "fonts/**/*"});
@@ -352,8 +412,10 @@ describe("assets", function () {
   it("should handle an error in a resolver", function (done) {
     var rootDir = testutils.fixtureDirectory("app_assets");
     var eg = new Eyeglass({
-        root: rootDir,
-        data: '@import "assets"; .bg { background: asset-url("images/foo.png"); }'
+      data: '@import "assets"; .bg { background: asset-url("images/foo.png"); }',
+      eyeglass: {
+        root: rootDir
+      }
     });
 
     eg.assets.addSource(rootDir, {pattern: "images/**/*"});
@@ -374,8 +436,10 @@ describe("assets", function () {
   it("should handle a sass error in a resolver", function (done) {
     var rootDir = testutils.fixtureDirectory("app_assets");
     var eg = new Eyeglass({
-        root: rootDir,
-        data: '@import "assets"; .bg { background: asset-url("images/foo.png"); }'
+      data: '@import "assets"; .bg { background: asset-url("images/foo.png"); }',
+      eyeglass: {
+        root: rootDir
+      }
     });
 
     eg.assets.addSource(rootDir, {pattern: "images/**/*"});
@@ -396,8 +460,10 @@ describe("assets", function () {
   it("should give an error when a module does not have assets", function (done) {
     testutils.assertStderr(function(checkStderr) {
       var options = {
-        root: testutils.fixtureDirectory("app_assets"),
-        data: '@import "non-asset-mod/assets";'
+        data: '@import "non-asset-mod/assets";',
+        eyeglass: {
+          root: testutils.fixtureDirectory("app_assets")
+        }
       };
       var expectedError = "No assets specified for eyeglass plugin non-asset-mod";
       testutils.assertCompilationError(options, expectedError, function() {
@@ -410,8 +476,10 @@ describe("assets", function () {
   it("should give an error when a module does not exist", function (done) {
     testutils.assertStderr(function(checkStderr) {
       var options = {
-        root: testutils.fixtureDirectory("app_assets"),
-        data: '@import "no-such-mod/assets";'
+        data: '@import "no-such-mod/assets";',
+        eyeglass: {
+          root: testutils.fixtureDirectory("app_assets")
+        }
       };
       var expectedError = "No eyeglass plugin named: no-such-mod";
       testutils.assertCompilationError(options, expectedError, function() {
@@ -423,7 +491,11 @@ describe("assets", function () {
 
   it("can pretty print an asset path entry", function(done) {
     var rootDir = testutils.fixtureDirectory("app_assets");
-    var eyeglass = new Eyeglass({root: rootDir});
+    var eyeglass = new Eyeglass({
+      eyeglass: {
+        root: rootDir
+      }
+    });
     var AssetPathEntry = eyeglass.assets.AssetPathEntry;
     var entry = new AssetPathEntry(rootDir, {
       pattern: "images/**/*"
@@ -434,7 +506,11 @@ describe("assets", function () {
 
   it("can assign custom glob opts to an asset path entry", function(done) {
     var rootDir = testutils.fixtureDirectory("app_assets");
-    var eyeglass = new Eyeglass({root: rootDir});
+    var eyeglass = new Eyeglass({
+      eyeglass: {
+        root: rootDir
+      }
+    });
     var AssetPathEntry = eyeglass.assets.AssetPathEntry;
     var entry = new AssetPathEntry(rootDir, {
       pattern: "images/**/*",
@@ -446,7 +522,11 @@ describe("assets", function () {
 
   it("asset path entries must be directories", function(done) {
     var rootDir = testutils.fixtureDirectory("app_assets");
-    var eyeglass = new Eyeglass({root: rootDir});
+    var eyeglass = new Eyeglass({
+      eyeglass: {
+        root: rootDir
+      }
+    });
     var AssetPathEntry = eyeglass.assets.AssetPathEntry;
     assert.throws(function() {
       var ape = new AssetPathEntry(path.join(rootDir, "package.json"));
@@ -462,9 +542,14 @@ describe("assets", function () {
                    "  background-image: url(/images/foo.png#foo); }\n";
     var rootDir = testutils.fixtureDirectory("app_assets");
     var eg = new Eyeglass({
-      root: rootDir,
-      data: input
-    }, sass);
+      data: input,
+      eyeglass: {
+        root: rootDir,
+        engines: {
+          sass: sass
+        }
+      }
+    });
     // asset-url("images/foo.png") => url(public/assets/images/foo.png);
     eg.assets.addSource(rootDir, {pattern: "images/**/*"});
 
@@ -476,9 +561,14 @@ describe("assets", function () {
     var expected = "div {\n  uri: /images/foo.png; }\n";
     var rootDir = testutils.fixtureDirectory("app_assets");
     var eg = new Eyeglass({
-      root: rootDir,
-      data: input
-    }, sass);
+      data: input,
+      eyeglass: {
+        root: rootDir,
+        engines: {
+          sass: sass
+        }
+      }
+    });
     // asset-url("images/foo.png") => url(public/assets/images/foo.png);
     eg.assets.addSource(rootDir, {pattern: "images/**/*"});
 

--- a/test/test_deprecate.js
+++ b/test/test_deprecate.js
@@ -1,0 +1,61 @@
+"use strict";
+
+var Deprecator = require("../lib/util/deprecator");
+var testutils = require("./testutils");
+
+describe("deprecate", function() {
+  beforeEach(function(done) {
+    process.env.EYEGLASS_DEPRECATIONS = "";
+    done();
+  });
+
+  it("should log warning when no options set", function(done) {
+    var deprecate = new Deprecator();
+    testutils.assertStderr(function(checkStderr) {
+      deprecate("0.0.1", "0.1.0", "deprecated message");
+
+      checkStderr(
+        "[eyeglass:deprecation] (deprecated in 0.0.1, will be removed in 0.1.0) " +
+        "deprecated message\n"
+      );
+      done();
+    });
+  });
+
+  it("should ignore warnings when version out of range", function(done) {
+    var deprecate = new Deprecator({
+      eyeglass: {
+        ignoreDeprecations: "0.1.0"
+      }
+    });
+    testutils.assertStderr(function(checkStderr) {
+      deprecate("0.0.1", "0.1.0", "deprecated message");
+      checkStderr("");
+      done();
+    });
+  });
+
+  it("should default to EYEGLASS_DEPRECATIONS environment var", function(done) {
+    process.env.EYEGLASS_DEPRECATIONS = "0.1.0";
+    var deprecate = new Deprecator();
+    testutils.assertStderr(function(checkStderr) {
+      deprecate("0.0.1", "0.1.0", "deprecated message");
+      checkStderr("");
+      done();
+    });
+  });
+
+  it("should check EYEGLASS_DEPRECATIONS environment var each run", function(done) {
+    var deprecate = new Deprecator();
+    testutils.assertStderr(function(checkStderr) {
+      deprecate("0.0.1", "0.1.0", "deprecated message 1");
+      process.env.EYEGLASS_DEPRECATIONS = "0.1.0";
+      deprecate("0.0.1", "0.1.0", "deprecated message 2");
+      checkStderr(
+        "[eyeglass:deprecation] (deprecated in 0.0.1, will be removed in 0.1.0) " +
+        "deprecated message 1\n"
+      );
+      done();
+    });
+  });
+});

--- a/test/test_function_loading.js
+++ b/test/test_function_loading.js
@@ -4,15 +4,17 @@ var assert = require("assert");
 var sass = require("node-sass");
 var testutils = require("./testutils");
 
-var eyeglass = require("../lib").decorate;
+var eyeglass = require("../lib");
 
 describe("function loading", function () {
 
   it("should discover sass functions", function (done) {
     var options = {
-      root: testutils.fixtureDirectory("function_modules"),
       data: "#hello { greeting: hello(Chris); }\n" +
-            "#transitive { is: transitive(); }\n"
+            "#transitive { is: transitive(); }\n",
+      eyeglass: {
+        root: testutils.fixtureDirectory("function_modules")
+      }
     };
     var expected = "#hello {\n  greeting: Hello, Chris!; }\n\n" +
                    "#transitive {\n  is: transitive; }\n";
@@ -21,8 +23,10 @@ describe("function loading", function () {
 
   it("should include devDependencies in its list", function (done) {
     var options = {
-      root: testutils.fixtureDirectory("function_modules"),
-      data: "#hello { greeting: hellob(Chris); }\n"
+      data: "#hello { greeting: hellob(Chris); }\n",
+      eyeglass: {
+        root: testutils.fixtureDirectory("function_modules")
+      }
     };
     var expected = "#hello {\n  greeting: Hello, Chris!; }\n";
     testutils.assertCompiles(options, expected, done);
@@ -32,12 +36,14 @@ describe("function loading", function () {
     var input = "#hello { greeting: hello(Chris); }\n" +
                 "#mine { something: add-one(3em); }\n";
     var options = {
-      root: testutils.fixtureDirectory("function_modules"),
       data: input,
       functions: {
         "add-one($number)": function(number) {
           return sass.types.Number(number.getValue() + 1, number.getUnit());
         }
+      },
+      eyeglass: {
+        root: testutils.fixtureDirectory("function_modules")
       }
     };
     var expected = "#hello {\n  greeting: Hello, Chris!; }\n\n" +
@@ -50,12 +56,14 @@ describe("function loading", function () {
       var input = "#hello { greeting: hello(Chris); }\n";
       var expectedOutput = "#hello {\n  greeting: Goodbye, Chris!; }\n";
       var options = {
-        root: testutils.fixtureDirectory("function_modules"),
         data: input,
         functions: {
           "hello($name: \"World\")": function(name) {
             return sass.types.String("Goodbye, " + name.getValue() + "!");
           }
+        },
+        eyeglass: {
+          root: testutils.fixtureDirectory("function_modules")
         }
       };
       testutils.assertCompiles(options, expectedOutput, function() {
@@ -69,12 +77,14 @@ describe("function loading", function () {
     testutils.assertStderr(function(checkStderr) {
       var input = "#hello { greeting: hello(Chris); }\n";
       var options = {
-        root: testutils.fixtureDirectory("function_modules"),
         data: input,
         functions: {
           "hello($name: 'Sucker')": function(name) {
             return sass.types.String("Goodbye, " + name.getValue() + "!");
           }
+        },
+        eyeglass: {
+          root: testutils.fixtureDirectory("function_modules")
         }
       };
       var expectedOutput = "#hello {\n  greeting: Goodbye, Chris!; }\n";
@@ -90,8 +100,10 @@ describe("function loading", function () {
   it("load functions from modules if they are themselves a npm eyeglass module.",
   function (done) {
     var options = {
-      root: testutils.fixtureDirectory("is_a_module"),
-      data: "#hello { greeting: hello(); }\n"
+      data: "#hello { greeting: hello(); }\n",
+      eyeglass: {
+        root: testutils.fixtureDirectory("is_a_module")
+      }
     };
     var expectedOutput = "#hello {\n  greeting: Hello, Myself!; }\n";
     testutils.assertCompiles(options, expectedOutput, done);
@@ -102,8 +114,10 @@ describe("function loading", function () {
     var input = "#hello { greeting: hello(); }\n";
     var expected = "#hello {\n  greeting: Hello, Myself!; }\n";
     var result = sass.renderSync(eyeglass({
-      root: testutils.fixtureDirectory("is_a_module"),
-      data: input
+      data: input,
+      eyeglass: {
+        root: testutils.fixtureDirectory("is_a_module")
+      }
     }));
     assert.equal(expected, result.css);
     done();
@@ -112,8 +126,10 @@ describe("function loading", function () {
   it("unversioned modules should return `unversioned` from `eyeglass-version()`",
   function (done) {
     var options = {
-      root: testutils.fixtureDirectory("is_a_module"),
-      data: "/* #{eyeglass-version(is-a-module)} */\n"
+      data: "/* #{eyeglass-version(is-a-module)} */\n",
+      eyeglass: {
+        root: testutils.fixtureDirectory("is_a_module")
+      }
     };
     var expectedOutput = "/* unversioned */\n";
     testutils.assertCompiles(options, expectedOutput, done);

--- a/test/test_imports.js
+++ b/test/test_imports.js
@@ -366,7 +366,8 @@ describe("eyeglass importer", function () {
     testutils.assertCompiles(options, expected, done);
   });
 
-  it("should allow sassDir to be specified in the package.json with main and no exports", function(done) {
+  it("should allow sassDir to be specified in " +
+  "the package.json with main and no exports", function(done) {
     var options = {
       data: '@import "simple-module-with-main";',
       eyeglass: {

--- a/test/test_imports.js
+++ b/test/test_imports.js
@@ -1,7 +1,7 @@
 "use strict";
 
 var sass = require("node-sass");
-var Eyeglass = require("../lib").Eyeglass;
+var Eyeglass = require("../lib");
 var testutils = require("./testutils");
 var path = require("path");
 var assert = require("assert");
@@ -21,9 +21,14 @@ describe("core api", function () {
                    "  color: red; }\n";
     var rootDir = testutils.fixtureDirectory("app_assets");
     var eg = new Eyeglass({
-      root: rootDir,
-      file: path.join(rootDir, "sass", "no_includePaths.scss")
-    }, sass);
+      file: path.join(rootDir, "sass", "no_includePaths.scss"),
+      eyeglass: {
+        root: rootDir,
+        engines: {
+          sass: sass
+        }
+      }
+    });
 
     testutils.assertCompiles(eg, expected, done);
   });
@@ -33,14 +38,19 @@ describe("core api", function () {
                    "  color: #112358; }\n";
     var rootDir = testutils.fixtureDirectory("app_assets");
     var eg = new Eyeglass({
-      root: rootDir,
       includePaths: [
         "this-folder-does-not-exist",
         "../includable_scss",
         "this-does-not-exist-either"
       ],
-      file: path.join(rootDir, "sass", "uses_includePaths.scss")
-    }, sass);
+      file: path.join(rootDir, "sass", "uses_includePaths.scss"),
+      eyeglass: {
+        root: rootDir,
+        engines: {
+          sass: sass
+        }
+      }
+    });
 
     testutils.assertCompiles(eg, expected, done);
   });
@@ -50,10 +60,15 @@ describe("core api", function () {
                     "  color: #333; }\n";
      var rootDir = testutils.fixtureDirectory("app_assets");
      var eg = new Eyeglass({
-       root: rootDir,
        includePaths: ["../includable_scss"],
-       file: path.join(rootDir, "sass", "advanced_includePaths.scss")
-     }, sass);
+       file: path.join(rootDir, "sass", "advanced_includePaths.scss"),
+        eyeglass: {
+          root: rootDir,
+          engines: {
+            sass: sass
+          }
+        }
+     });
 
      testutils.assertCompiles(eg, expected, done);
    });
@@ -64,10 +79,15 @@ describe("core api", function () {
                     "  color: #eee; }\n";
      var rootDir = testutils.fixtureDirectory("app_assets");
      var eg = new Eyeglass({
-       root: rootDir,
        includePaths: ["../includable_scss"],
-       file: path.join(rootDir, "sass", "dot_include.scss")
-     }, sass);
+       file: path.join(rootDir, "sass", "dot_include.scss"),
+        eyeglass: {
+          root: rootDir,
+          engines: {
+            sass: sass
+          }
+        }
+     });
 
      testutils.assertCompiles(eg, expected, done);
    });
@@ -119,8 +139,10 @@ describe("eyeglass importer", function () {
 
   it("lets you import sass files from npm modules", function (done) {
     var options = {
-      root: testutils.fixtureDirectory("basic_modules"),
-      data: '@import "module_a";'
+      data: '@import "module_a";',
+      eyeglass: {
+        root: testutils.fixtureDirectory("basic_modules")
+      }
     };
     var expected = ".module-a {\n  greeting: hello world; }\n\n" +
                    ".sibling-in-module-a {\n  sibling: yes; }\n";
@@ -129,8 +151,10 @@ describe("eyeglass importer", function () {
 
   it("lets you import sass files from dev dependencies", function (done) {
     var options = {
-      root: testutils.fixtureDirectory("dev_deps"),
-      data: '@import "module_a";'
+      data: '@import "module_a";',
+      eyeglass: {
+        root: testutils.fixtureDirectory("dev_deps")
+      }
     };
     var expected = ".module-a {\n  greeting: hello world; }\n\n" +
                    ".sibling-in-module-a {\n  sibling: yes; }\n";
@@ -139,8 +163,10 @@ describe("eyeglass importer", function () {
 
   it("lets you import from a subdir in a npm module", function (done) {
     var options = {
-      root: testutils.fixtureDirectory("basic_modules"),
-      data: '@import "module_a/submodule";'
+      data: '@import "module_a/submodule";',
+      eyeglass: {
+        root: testutils.fixtureDirectory("basic_modules")
+      }
     };
     var expected = ".submodule {\n  hello: world; }\n";
     testutils.assertCompiles(options, expected, done);
@@ -148,8 +174,10 @@ describe("eyeglass importer", function () {
 
   it("lets you import explicitly from a subdir in a module", function (done) {
     var options = {
-      root: testutils.fixtureDirectory("basic_modules"),
-      data: '@import "module_a/submodule/_index.scss";'
+      data: '@import "module_a/submodule/_index.scss";',
+      eyeglass: {
+        root: testutils.fixtureDirectory("basic_modules")
+      }
     };
     var expected = ".submodule {\n  hello: world; }\n";
     testutils.assertCompiles(options, expected, done);
@@ -157,8 +185,10 @@ describe("eyeglass importer", function () {
 
   it("lets you import css files", function (done) {
     var options = {
-      root: testutils.fixtureDirectory("basic_modules"),
-      data: '@import "module_a/css_file";'
+      data: '@import "module_a/css_file";',
+      eyeglass: {
+        root: testutils.fixtureDirectory("basic_modules")
+      }
     };
     var expected = ".css-file {\n  hello: world; }\n";
     testutils.assertCompiles(options, expected, done);
@@ -166,8 +196,10 @@ describe("eyeglass importer", function () {
 
   it("lets you import sass files from a transitive dependency", function (done) {
     var options = {
-      root: testutils.fixtureDirectory("basic_modules"),
-      data: '@import "module_a/transitive_imports";'
+      data: '@import "module_a/transitive_imports";',
+      eyeglass: {
+        root: testutils.fixtureDirectory("basic_modules")
+      }
     };
     var expected = ".transitive_module {\n  hello: world; }\n";
     testutils.assertCompiles(options, expected, done);
@@ -176,9 +208,11 @@ describe("eyeglass importer", function () {
   it("does not let you import transitive sass files", function (done) {
     testutils.assertStderr(function(checkStderr) {
       var options = {
-        root: testutils.fixtureDirectory("basic_modules"),
         file: "wubwubwub.scss",
-        data: '@import "transitive_module";'
+        data: '@import "transitive_module";',
+        eyeglass: {
+          root: testutils.fixtureDirectory("basic_modules")
+        }
       };
       // TODO This should not be a successful compile (libsass issue?)
       // TODO Shouldn't the file path be relative to `options.root`?
@@ -190,8 +224,10 @@ describe("eyeglass importer", function () {
 
   it("only imports a module dependency once.", function (done) {
     var options = {
-      root: testutils.fixtureDirectory("basic_modules"),
-      data: '@import "module_a"; @import "module_a";'
+      data: '@import "module_a"; @import "module_a";',
+      eyeglass: {
+        root: testutils.fixtureDirectory("basic_modules")
+      }
     };
     var expected = ".module-a {\n  greeting: hello world; }\n\n" +
                    ".sibling-in-module-a {\n  sibling: yes; }\n";
@@ -199,18 +235,22 @@ describe("eyeglass importer", function () {
   });
 
   it("imports modules if they are themselves a npm eyeglass module.", function(done) {
-     var options = {
-       root: testutils.fixtureDirectory("is_a_module"),
-       data: '@import "is-a-module";'
-     };
+    var options = {
+      data: '@import "is-a-module";',
+      eyeglass: {
+        root: testutils.fixtureDirectory("is_a_module")
+      }
+    };
     var expected = ".is-a-module {\n  this: is a module; }\n";
     testutils.assertCompiles(options, expected, done);
   });
 
   it("imports for modules such as foo/bar/_foo.scss wanting foo/bar (#37)", function (done) {
     var options = {
-      root: testutils.fixtureDirectory("redundantly_named_modules"),
-      data: '@import "module_a";'
+      data: '@import "module_a";',
+      eyeglass: {
+        root: testutils.fixtureDirectory("redundantly_named_modules")
+      }
     };
     var expected = ".nested-module-a {\n  greeting: hello world; }\n";
     testutils.assertCompiles(options, expected, done);
@@ -219,8 +259,10 @@ describe("eyeglass importer", function () {
   it("eyeglass exports can be specified through the " +
   " eyeglass property of package.json.", function (done) {
     var options = {
-      root: testutils.fixtureDirectory("has_a_main_already"),
-      data: '@import "has_a_main_already";'
+      data: '@import "has_a_main_already";',
+      eyeglass: {
+        root: testutils.fixtureDirectory("has_a_main_already")
+      }
     };
     var expected = ".has-a-main {\n  main: already; }\n";
     testutils.assertCompiles(options, expected, done);
@@ -230,8 +272,10 @@ describe("eyeglass importer", function () {
     testutils.assertStderr(function(checkStderr) {
       var rootDir = testutils.fixtureDirectory("app_with_malformed_module");
       var options = {
-        root: rootDir,
-        data: '@import "malformed_module"; .foo {}'
+        data: '@import "malformed_module"; .foo {}',
+        eyeglass: {
+          root: rootDir
+        }
       };
       var expectedError = "sassDir is not specified in malformed_module's package.json or " +
         path.join(rootDir, "node_modules", "malformed_module", "eyeglass-exports.js");
@@ -244,8 +288,10 @@ describe("eyeglass importer", function () {
     testutils.assertStderr(function(checkStderr) {
       var rootDir = testutils.fixtureDirectory("missing_module");
       var options = {
-        root: rootDir,
-        data: "/* test */"
+        data: "/* test */",
+        eyeglass: {
+          root: rootDir
+        }
       };
       var expectedOutput = "/* test */\n";
       testutils.assertCompiles(options, expectedOutput, function() {
@@ -268,9 +314,11 @@ describe("eyeglass importer", function () {
     };
 
     var options = {
-     root: testutils.fixtureDirectory("basic_modules"),
-     data: '@import "OMG";',
-     importer: [importerMiss, importerHit]
+      data: '@import "OMG";',
+      importer: [importerMiss, importerHit],
+      eyeglass: {
+        root: testutils.fixtureDirectory("basic_modules")
+      }
     };
     var expected = ".foo {\n  color: red; }\n";
     testutils.assertCompiles(options, expected, function() {
@@ -281,8 +329,10 @@ describe("eyeglass importer", function () {
 
   it("handle project name that conflicts with eyeglass module name", function(done) {
     var options = {
-     root: testutils.fixtureDirectory("project_name_is_dep_name"),
-     data: '@import "my-package";'
+      data: '@import "my-package";',
+      eyeglass: {
+        root: testutils.fixtureDirectory("project_name_is_dep_name")
+      }
     };
     var expected = ".foo {\n  color: red; }\n";
     testutils.assertCompiles(options, expected, done);
@@ -306,19 +356,23 @@ describe("eyeglass importer", function () {
   });
 
   it("should allow sassDir to be specified in the package.json", function(done) {
-     var options = {
-       root: testutils.fixtureDirectory("simple_module"),
-       data: '@import "simple-module";'
-     };
+    var options = {
+      data: '@import "simple-module";',
+      eyeglass: {
+        root: testutils.fixtureDirectory("simple_module")
+      }
+    };
     var expected = ".simple-module {\n  this: is a simple module; }\n";
     testutils.assertCompiles(options, expected, done);
   });
 
   it("should allow sassDir to be specified in the package.json with main and no exports", function(done) {
-     var options = {
-       root: testutils.fixtureDirectory("simple_module_with_main"),
-       data: '@import "simple-module-with-main";'
-     };
+    var options = {
+      data: '@import "simple-module-with-main";',
+      eyeglass: {
+        root: testutils.fixtureDirectory("simple_module_with_main")
+      }
+    };
     var expected = ".simple-module {\n  this: is a simple module;\n  exports: nothing; }\n";
     testutils.assertCompiles(options, expected, done);
   });
@@ -326,9 +380,11 @@ describe("eyeglass importer", function () {
   it("should resolve includePaths against the root directory", function(done) {
     var rootDir = testutils.fixtureDirectory("app_with_include_paths");
     var options = {
-      root: rootDir,
       file: path.join(rootDir, "scss", "main.scss"),
-      includePaths: ["more_scss"]
+      includePaths: ["more_scss"],
+      eyeglass: {
+        root: rootDir
+      }
     };
     var expected = ".from {\n  include: path; }\n";
     testutils.assertCompiles(options, expected, done);

--- a/test/test_options.js
+++ b/test/test_options.js
@@ -1,6 +1,6 @@
 "use strict";
 
-var Eyeglass = require("../lib").Eyeglass;
+var Eyeglass = require("../lib");
 var VERSION = require("../lib").VERSION;
 var assert = require("assert");
 var testutils = require("./testutils");
@@ -17,7 +17,7 @@ describe("options", function() {
     var rootDir = testutils.fixtureDirectory("app_with_malformed_module");
     var options = {root: rootDir};
     var eyeglass = new Eyeglass(options);
-    var sassopts = eyeglass.sassOptions();
+    var sassopts = eyeglass.options;
     assert(sassopts.eyeglass);
     assert.notEqual(eyeglass, sassopts.eyeglass);
     done();
@@ -29,7 +29,7 @@ describe("options", function() {
     var rootDir = testutils.fixtureDirectory("basic_modules");
     var options = {root: rootDir};
     var eyeglass = new Eyeglass(options);
-    var sassopts = eyeglass.sassOptions();
+    var sassopts = eyeglass.options;
     assert.equal(sassopts.includePaths[0], path.resolve(process.cwd(), "foo"));
     assert.equal(sassopts.includePaths[1], path.resolve(process.cwd(), "bar"));
     assert.equal(sassopts.includePaths[2], path.resolve(process.cwd(), "baz"));
@@ -41,7 +41,7 @@ describe("options", function() {
     var rootDir = testutils.fixtureDirectory("basic_modules");
     var options = {root: rootDir};
     var eyeglass = new Eyeglass(options);
-    var sassopts = eyeglass.sassOptions();
+    var sassopts = eyeglass.options;
     assert.equal(sassopts.includePaths.length, 0);
     done();
   });
@@ -53,7 +53,7 @@ describe("options", function() {
     var eyeglass = new Eyeglass(options);
     var expectedOutput = ".foo {\n  bar: baz; }\n";
 
-    testutils.assertCompiles(eyeglass.sassOptions(), expectedOutput, done);
+    testutils.assertCompiles(eyeglass.options, expectedOutput, done);
   });
 
   it("should normalize includePaths", function () {
@@ -63,7 +63,7 @@ describe("options", function() {
       root: rootDir,
       includePaths: includePaths.join(":")
     });
-    var sassopts = eyeglass.sassOptions();
+    var sassopts = eyeglass.options;
     assert(sassopts);
     assert.deepEqual(sassopts.includePaths, includePaths.map(function(p){
       return path.resolve(rootDir, p);
@@ -80,6 +80,7 @@ describe("options", function() {
         }
       };
       var eyeglass = new Eyeglass(options);
+      /* eslint no-unused-vars:0 */
       var sassopts = eyeglass.sassOptions();
       checkStderr("");
       done();
@@ -95,11 +96,12 @@ describe("options", function() {
           ignoreDeprecations: "0.7.1"
         }
       };
-      var eyeglass = new Eyeglass(options);
+      var eyeglass = new Eyeglass.Eyeglass(options);
+      /* eslint no-unused-vars:0 */
       var sassopts = eyeglass.sassOptions();
       checkStderr([
-        "[eyeglass:deprecation] (deprecated in 0.8.0, will be removed in 0.9.0) `root` should be passed into the"+
-        " eyeglass options rather than the sass options:",
+        "[eyeglass:deprecation] (deprecated in 0.8.0, will be removed in 0.9.0) `root` " +
+        "should be passed into the eyeglass options rather than the sass options:",
         "  var options = eyeglass({",
         "    /* sassOptions */",
         "    ...",
@@ -107,10 +109,10 @@ describe("options", function() {
         "      option: ...",
         "    }",
         "  });",
-        "[eyeglass:deprecation] (deprecated in 0.8.0, will be removed in 0.9.0) `require('eyeglass').Eyeglass` is deprecated. " +
-        "Instead, use `require('eyeglass')`",
-        "[eyeglass:deprecation] (deprecated in 0.8.0, will be removed in 0.9.0) #sassOptions() is deprecated. " +
-        "Instead, you should access the sass options on #options\n"
+        "[eyeglass:deprecation] (deprecated in 0.8.0, will be removed in 0.9.0) " +
+        "`require('eyeglass').Eyeglass` is deprecated. Instead, use `require('eyeglass')`",
+        "[eyeglass:deprecation] (deprecated in 0.8.0, will be removed in 0.9.0) " +
+        "#sassOptions() is deprecated. Instead, you should access the sass options on #options\n"
       ].join("\n"));
       done();
     });

--- a/test/test_options.js
+++ b/test/test_options.js
@@ -1,7 +1,7 @@
 "use strict";
 
 var Eyeglass = require("../lib");
-var VERSION = require("../lib").VERSION;
+var VERSION = Eyeglass.VERSION;
 var assert = require("assert");
 var testutils = require("./testutils");
 var path = require("path");
@@ -79,7 +79,7 @@ describe("options", function() {
           ignoreDeprecations: semver.inc(VERSION, "minor")
         }
       };
-      var eyeglass = new Eyeglass(options);
+      var eyeglass = new Eyeglass.Eyeglass(options);
       /* eslint no-unused-vars:0 */
       var sassopts = eyeglass.sassOptions();
       checkStderr("");

--- a/test/test_options.js
+++ b/test/test_options.js
@@ -106,7 +106,7 @@ describe("options", function() {
         "    /* sassOptions */",
         "    ...",
         "    eyeglass: {",
-        "      option: ...",
+        "      root: ...",
         "    }",
         "  });",
         "[eyeglass:deprecation] (deprecated in 0.8.0, will be removed in 0.9.0) " +
@@ -115,6 +115,115 @@ describe("options", function() {
         "#sassOptions() is deprecated. Instead, you should access the sass options on #options\n"
       ].join("\n"));
       done();
+    });
+  });
+
+  describe("deprecated interface", function() {
+    it("should support `new Eyeglass.Eyeglass` with warning", function(done) {
+      testutils.assertStderr(function(checkStderr) {
+        var eyeglass = new Eyeglass.Eyeglass();
+        checkStderr(
+          "[eyeglass:deprecation] (deprecated in 0.8.0, will be removed in 0.9.0) " +
+          "`require('eyeglass').Eyeglass` is deprecated. Instead, use `require('eyeglass')`\n"
+        );
+        done();
+      });
+    });
+
+    it("should support `Eyeglass.decorate` with warning", function(done) {
+      testutils.assertStderr(function(checkStderr) {
+        var eyeglass = Eyeglass.decorate();
+        checkStderr(
+          "[eyeglass:deprecation] (deprecated in 0.8.0, will be removed in 0.9.0) " +
+          "`require('eyeglass').decorate` is deprecated. Instead, use `require('eyeglass')`\n"
+        );
+        done();
+      });
+    });
+
+    it("should support `#sassOptions` method with warning", function(done) {
+      testutils.assertStderr(function(checkStderr) {
+        var eyeglass = new Eyeglass();
+        /* eslint no-unused-vars:0 */
+        var options = eyeglass.sassOptions();
+        checkStderr(
+          "[eyeglass:deprecation] (deprecated in 0.8.0, will be removed in 0.9.0) " +
+          "#sassOptions() is deprecated. Instead, you should access the sass options on #options\n"
+        );
+        done();
+      });
+    });
+
+    it("should warn on eyeglass options not in namespace", function(done) {
+      function expectedOptionsWarning(option) {
+        return [
+          "[eyeglass:deprecation] (deprecated in 0.8.0, will be removed in 0.9.0) `" +
+          option + "` should be passed into the eyeglass options rather than the sass options:",
+          "var options = eyeglass({",
+          "  /* sassOptions */",
+          "  ...",
+          "  eyeglass: {",
+          "    " + option + ": ...",
+          "  }",
+          "});"
+        ].join("\n  ");
+      }
+
+      testutils.assertStderr(function(checkStderr) {
+        var eyeglass = new Eyeglass({
+          root: __dirname,
+          cacheDir: ".cache",
+          buildDir: "dist",
+          httpRoot: "root",
+          assetsHttpPrefix: "prefix",
+          assetsRelativeTo: "relative",
+          strictModuleVersions: true
+        });
+        checkStderr([
+          expectedOptionsWarning("root"),
+          expectedOptionsWarning("cacheDir"),
+          expectedOptionsWarning("buildDir"),
+          expectedOptionsWarning("httpRoot"),
+          expectedOptionsWarning("assetsHttpPrefix"),
+          expectedOptionsWarning("assetsRelativeTo"),
+          expectedOptionsWarning("strictModuleVersions")
+        ].join("\n") + "\n");
+        done();
+      });
+    });
+
+    it("should warn when setting properties directly on eyeglass instance", function(done) {
+      function expectedOptionsWarning(option) {
+        return [
+          "[eyeglass:deprecation] (deprecated in 0.8.0, will be removed in 0.9.0) `" +
+          option + "` should be passed into the eyeglass options rather than the sass options:",
+          "var options = eyeglass({",
+          "  /* sassOptions */",
+          "  ...",
+          "  eyeglass: {",
+          "    " + option + ": ...",
+          "  }",
+          "});"
+        ].join("\n  ");
+      }
+
+      testutils.assertStderr(function(checkStderr) {
+        var eyeglass = new Eyeglass();
+        eyeglass.enableImportOnce = false;
+        checkStderr([
+          "[eyeglass:deprecation] (deprecated in 0.8.0, will be removed in 0.9.0) " +
+          "The property `enableImportOnce` should no longer be set directly on eyeglass. " +
+          "Instead, you should pass this as an option to eyeglass:",
+          "  var options = eyeglass({",
+          "    /* sassOptions */",
+          "    ...",
+          "    eyeglass: {",
+          "      enableImportOnce: ...",
+          "    }",
+          "  });"
+        ].join("\n") + "\n");
+        done();
+      });
     });
   });
 });

--- a/test/test_semver.js
+++ b/test/test_semver.js
@@ -3,14 +3,16 @@
 var assert = require("assert");
 var testutils = require("./testutils");
 
-var eyeglass = require("../lib").decorate;
+var eyeglass = require("../lib");
 var eyeglassSemverChecker = require("../lib/semver_checker");
 
 describe("semver checking", function () {
   it("will not let a module through with an engine violation", function (done) {
     var options = {
-      root: testutils.fixtureDirectory("bad_engine"),
-      data: "#hello { greeting: hello(Chris); }"
+      data: "#hello { greeting: hello(Chris); }",
+      eyeglass: {
+        root: testutils.fixtureDirectory("bad_engine")
+      }
     };
 
     testutils.assertStderr(function(check) {
@@ -25,8 +27,10 @@ describe("semver checking", function () {
 
   it("gives a nice error when missing eyeglass version dep", function (done) {
     var options = {
-      root: testutils.fixtureDirectory("old_engine"),
-      data: "#hello { greeting: hello(Chris); }"
+      data: "#hello { greeting: hello(Chris); }",
+      eyeglass: {
+        root: testutils.fixtureDirectory("old_engine")
+      }
     };
 
     testutils.assertStderr(function(check) {
@@ -41,9 +45,11 @@ describe("semver checking", function () {
 
   it("will throw if strictModuleVersions is set", function (done) {
     var options = {
-      root: testutils.fixtureDirectory("bad_engine"),
       data: "#hello { greeting: hello(Chris); }",
-      strictModuleVersions: true
+      eyeglass: {
+        root: testutils.fixtureDirectory("bad_engine"),
+        strictModuleVersions: true
+      }
     };
 
     testutils.assertStderr(function(check) {

--- a/test/test_version.js
+++ b/test/test_version.js
@@ -1,6 +1,5 @@
 "use strict";
 
-var path = require("path");
 var testutils = require("./testutils");
 var Eyeglass = require("../lib/index");
 

--- a/test/testutils.js
+++ b/test/testutils.js
@@ -2,7 +2,7 @@
 
 // disable eyeglass deprecations until tests are rewritten without deprecated methods
 process.env.EYEGLASS_DEPRECATIONS = "0.8.0";
-var eyeglass = require("../lib").decorate;
+var eyeglass = require("../lib");
 var sass = require("node-sass");
 var path = require("path");
 var assert = require("assert");
@@ -59,7 +59,9 @@ module.exports = {
     return sass.renderSync(this.sassOptions(options));
   },
   sassOptions: function(options) {
-    if (typeof options.sassOptions === "function") {
+    if (typeof options.options === "object") {
+      return options.options;
+    } else if (typeof options.sassOptions === "function") {
       return options.sassOptions();
     } else {
       return eyeglass(options);

--- a/test/testutils.js
+++ b/test/testutils.js
@@ -1,7 +1,5 @@
 "use strict";
 
-// disable eyeglass deprecations until tests are rewritten without deprecated methods
-process.env.EYEGLASS_DEPRECATIONS = "0.8.0";
 var eyeglass = require("../lib");
 var sass = require("node-sass");
 var path = require("path");
@@ -61,7 +59,8 @@ module.exports = {
   sassOptions: function(options) {
     if (typeof options.options === "object") {
       return options.options;
-    } else if (typeof options.sassOptions === "function") {
+    }
+    if (typeof options.sassOptions === "function") {
       return options.sassOptions();
     } else {
       return eyeglass(options);


### PR DESCRIPTION
Per #94, this updates the test cases to use the new simplified API.

This also adds tests for deprecation warnings and tests for back-compat API support.