### PR TITLE
Adjust example code to deprecations

### DIFF
--- a/site-src/docs/integrations/gulp.md
+++ b/site-src/docs/integrations/gulp.md
@@ -14,9 +14,8 @@ var sassOptions = {}; // put whatever eyeglass and node-sass options you need he
 
 var eyeglass = new Eyeglass(sassOptions);
 
-// Disable import once with gulp until we
-// figure out how to make them work together.
-eyeglass.options.enableImportOnce = false
+// import once can be disabled using the following line:
+// eyeglass.options.enableImportOnce = false
 
 gulp.task("sass", function () {
   gulp.src("./sass/**/*.scss")

--- a/site-src/docs/integrations/gulp.md
+++ b/site-src/docs/integrations/gulp.md
@@ -9,18 +9,18 @@ Additionally, to avoid any problems with `node-sass`, you should provide a defau
 ```js
 var gulp = require("gulp");
 var sass = require("gulp-sass");
-var Eyeglass = require("eyeglass").Eyeglass;
+var Eyeglass = require("eyeglass");
 var sassOptions = {}; // put whatever eyeglass and node-sass options you need here.
 
 var eyeglass = new Eyeglass(sassOptions);
 
 // Disable import once with gulp until we
 // figure out how to make them work together.
-eyeglass.enableImportOnce = false
+eyeglass.options.enableImportOnce = false
 
 gulp.task("sass", function () {
   gulp.src("./sass/**/*.scss")
-    .pipe(sass(eyeglass.sassOptions()).on("error", sass.logError))
+    .pipe(sass(eyeglass.options).on("error", sass.logError))
     .pipe(gulp.dest("./css"));
 });
 ```


### PR DESCRIPTION
This PR will fix usage of deprecated API in the example code for gulp integration.

For eyeglass in #master.