### PR TITLE
Adds failing test for importing a regular .sass partial

### DIFF
--- a/test/fixtures/sass_indented_import/sass/_part.sass
+++ b/test/fixtures/sass_indented_import/sass/_part.sass
@@ -1,0 +1,2 @@
+body
+  background: #FFF

--- a/test/fixtures/sass_indented_import/sass/main.sass
+++ b/test/fixtures/sass_indented_import/sass/main.sass
@@ -1,0 +1,4 @@
+@import "part"
+
+h1
+  font-family: Georgia

--- a/test/fixtures/sass_indented_import/scss/_part.scss
+++ b/test/fixtures/sass_indented_import/scss/_part.scss
@@ -1,0 +1,3 @@
+body {
+  background: #FFF;  
+}

--- a/test/fixtures/sass_indented_import/scss/main.scss
+++ b/test/fixtures/sass_indented_import/scss/main.scss
@@ -1,0 +1,5 @@
+@import "part";
+
+h1 {
+  font-family: Georgia;
+}

--- a/test/test_sass_indented.js
+++ b/test/test_sass_indented.js
@@ -1,0 +1,40 @@
+"use strict";
+
+var path = require("path");
+var sass = require("node-sass");
+var testutils = require("./testutils");
+var Eyeglass = require("../lib");
+
+describe("sass indented syntax", function (done) {
+  var rootDir = testutils.fixtureDirectory("sass_indented_import");
+  var expected = "body {\n" +
+                 "  background: #FFF; }\n\n" +
+                 "h1 {\n" +
+                 "  font-family: Georgia; }\n";
+  var options = {
+    root: rootDir,
+    engines: {
+      sass: sass
+    }
+  };
+
+  it("shouldn’t interfere with .scss partial", function (done) {
+    var eg = new Eyeglass({
+      file: path.join(rootDir, "scss", "main.scss"),
+      eyeglass: options
+    });
+
+    testutils.assertCompiles(eg, expected, done);
+  });
+
+
+  it("shouldn’t interfere with .sass syntax partial", function (done) {
+    var eg = new Eyeglass({
+      file: path.join(rootDir, "sass", "main.sass"),
+      eyeglass: options
+    });
+
+    testutils.assertCompiles(eg, expected, done);
+  });
+
+});


### PR DESCRIPTION
Here’s the issue [I mentioned](https://twitter.com/kennethormandy/status/684961843744387072) on Twitter. After testing it a bit more, it seems like Eyeglass is just interfering with or not processing with files with `.sass` indented syntax partials:

__Expected__

I can import a `.sass` and/or `.scss` partials, from `.sass` or `.scss` files, while using Eyeglass with Node-sass.

__Actual__

I can import `.scss` partials from `.sass` or `.scss` files, while using Eyeglass with Node-sass. If I import a `.sass` partial from either a `.sass` file or a `.scss` file, there is not CSS outputted from Node-sass.

This pull request adds one passing test for `.scss`, and one failing test for `.sass` demonstrating this. Hopefully it is just some oversight on my part regarding `.sass` syntax, but I can’t seem to get around this.

![1](https://cloud.githubusercontent.com/assets/1581276/12207678/e1297202-b5fc-11e5-97f0-e10642e23be1.gif)

