### PR TITLE
allow eyeglass to be imported from anywhere

### DIFF
--- a/lib/util/eyeglass_modules.js
+++ b/lib/util/eyeglass_modules.js
@@ -269,6 +269,11 @@ function findBranchesByPath(tree, dir) {
   * @returns {Boolean} whether or not access is permitted
   */
 function canAccessModule(name, origin) {
+  // eyeglass can be imported by anyone, regardless of the dependency tree
+  if (name === "eyeglass") {
+    return true;
+  }
+
   // find the nearest package for the origin
   var pkg = packageUtils.findNearestPackage(origin);
 
@@ -288,7 +293,7 @@ function canAccessModule(name, origin) {
   var canAccess = branches.some(function(branch) {
     // if the reference is to itself (branch.name)
     // OR it's an immediate dependency (branch.dependencies[name])
-    if (branch.name === name || branch.dependencies[name]) {
+    if (branch.name === name || branch.dependencies && branch.dependencies[name]) {
       return true;
     }
   });

--- a/test/fixtures/module_imports_eyeglass/node_modules/module_a/package.json
+++ b/test/fixtures/module_imports_eyeglass/node_modules/module_a/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "module_a",
+  "keywords": ["eyeglass-module"],
+  "private": true,
+  "eyeglass": {
+    "name": "module_a",
+    "needs": "*",
+    "sassDir": "sass"
+  }
+}

--- a/test/fixtures/module_imports_eyeglass/node_modules/module_a/sass/index.scss
+++ b/test/fixtures/module_imports_eyeglass/node_modules/module_a/sass/index.scss
@@ -1,0 +1,3 @@
+@import "eyeglass/assets";
+
+/* function-exists(asset-url): #{function-exists(asset-url)} */

--- a/test/fixtures/module_imports_eyeglass/package.json
+++ b/test/fixtures/module_imports_eyeglass/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "module-imports-eyeglass",
+  "private": true,
+  "dependencies": {
+    "module_a": "*"
+  }
+}

--- a/test/test_imports.js
+++ b/test/test_imports.js
@@ -431,4 +431,15 @@ describe("eyeglass importer", function () {
       done();
     }, done);
   });
+
+  it("should be allowed to import from eyeglass without a declared depenedency", function(done) {
+    var options = {
+      data: '@import "module_a";',
+      eyeglass: {
+        root: testutils.fixtureDirectory("module_imports_eyeglass")
+      }
+    };
+    var expected = "/* function-exists(asset-url): true */\n";
+    testutils.assertCompiles(options, expected, done);
+  });
 });


### PR DESCRIPTION
This issue was uncovered in https://github.com/sass-eyeglass/eyeglass-spriting/pull/19 where `eyeglass-spriting` tries to `@import "eyeglass/assets"` but doesn't declare `eyeglass` as a direct dependency.