### PR TITLE
Add Node.js 5 and 6 to Travis tests.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,8 @@ language: node_js
 node_js:
 - '0.12'
 - '4'
+- '5'
+- '6'
 #- iojs
 env:
 - COVERAGE=true


### PR DESCRIPTION
Travis tests should be run on Node.js 5 and on Node.js 6.