### PR TITLE
README clearification

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Once installed via npm, an eyeglass module can:
 * Provide stylesheets that you can import with special node_module syntax.
 * Add additional custom functions to Sass that are written in javascript.
 
-In Sass files, you can reference the eyeglass module with standard Sass import syntax: `@import "my_eyeglass_module/file";`. The `my_eyeglass_module` will be resolved to the correct directory in your node modules, and the file will then resolve using the standard import rules for Sass.
+If your build-tool is [eyeglass-aware](#building-sass-files-with-eyeglass-support), you can reference the eyeglass module with standard Sass import syntax: `@import "my_eyeglass_module/file";`. The `my_eyeglass_module` will be resolved to the correct directory in your node modules, and the file will then resolve using the standard import rules for Sass.
 
 # Working with assets
 


### PR DESCRIPTION
This was keeping me much to long from using eyeglass! After reading the README, I thought that eyeglass would automatically hook into node-sass. I thought that my modules where not discovered for some reason. It took me ages to understand that the issue was that node-sass is not "eyeglass-aware".

In short: I think this change makes it much easier for people to start using eyeglass. Kind of related: https://github.com/sass/node-sass/pull/1617

**Note**: The link only works on github. Should I change it to an absolute URL?