### PR TITLE
cleanup some lint warnings

### DIFF
--- a/lib/functions/fs.js
+++ b/lib/functions/fs.js
@@ -43,40 +43,41 @@ module.exports = function(eyeglass, sass) {
   }
 
   function globFiles(directory, globPattern, includeFiles, includeDirectories, done) {
-      if (inSandbox(directory)) {
-        var globOpts = {
-          root: directory,
-          cwd: directory,
-          mark: true
-        };
-        glob(globPattern, globOpts, function(error, files) {
-          if (error) {
-            done(sass.types.Error(error.message));
-          } else {
-            var filesToReturn = [];
-            for (var i = 0; i < files.length; i++) {
-              var endsWithSlash = /\/$/.test(files[i]);
-              if (endsWithSlash && includeDirectories) {
-                if (!inSandbox(path.join(directory, files[i]))) {
-                  done(accessViolation(files[i]));
-                  return;
-                }
-                filesToReturn[filesToReturn.length] = files[i].slice(-files[i].length, -1);
-              }
-              if (!endsWithSlash && includeFiles) {
-                if (!inSandbox(path.join(directory, files[i]))) {
-                  done(accessViolation(files[i]));
-                  return;
-                }
-                filesToReturn[filesToReturn.length] = files[i];
-              }
+    if (inSandbox(directory)) {
+      var globOpts = {
+        root: directory,
+        cwd: directory,
+        mark: true
+      };
+      glob(globPattern, globOpts, function(error, files) {
+        if (error) {
+          done(sass.types.Error(error.message));
+          return;
+        }
+
+        var filesToReturn = [];
+        for (var i = 0; i < files.length; i++) {
+          var endsWithSlash = /\/$/.test(files[i]);
+          if (endsWithSlash && includeDirectories) {
+            if (!inSandbox(path.join(directory, files[i]))) {
+              done(accessViolation(files[i]));
+              return;
             }
-            done(sassUtils.castToSass(filesToReturn));
+            filesToReturn[filesToReturn.length] = files[i].slice(-files[i].length, -1);
           }
-        });
-      } else {
-        done(accessViolation(directory));
-      }
+          if (!endsWithSlash && includeFiles) {
+            if (!inSandbox(path.join(directory, files[i]))) {
+              done(accessViolation(files[i]));
+              return;
+            }
+            filesToReturn[filesToReturn.length] = files[i];
+          }
+        }
+        done(sassUtils.castToSass(filesToReturn));
+      });
+    } else {
+      done(accessViolation(directory));
+    }
   }
 
   return {

--- a/lib/importers/FSImporter.js
+++ b/lib/importers/FSImporter.js
@@ -1,8 +1,6 @@
 "use strict";
 
-var fs = require("fs");
 var path = require("path");
-var efs = require("../util/files");
 var ImportUtilities = require("./ImportUtilities");
 var fileUtils = require("../util/files");
 
@@ -14,20 +12,20 @@ function FSImporter(eyeglass, sass, options, fallbackImporter) {
     var match = uri.match(fsURI);
     if (match) {
       var identifier = match[1];
-      var absolute_path = null;
+      var absolutePath = null;
       if (identifier === "root") {
-        absolute_path = options.eyeglass.root;
+        absolutePath = options.eyeglass.root;
       } else if (!fileUtils.existsSync(prev)) {
-        absolute_path = path.resolve(".");
+        absolutePath = path.resolve(".");
       } else {
-        absolute_path = path.resolve(path.dirname(prev));
+        absolutePath = path.resolve(path.dirname(prev));
       }
-      if (absolute_path) {
-        var sassContents =
-          '@import "eyeglass/fs"; @include fs-register-path(' + identifier + ', "' + absolute_path + '");';
+      if (absolutePath) {
+        var sassContents = '@import "eyeglass/fs"; @include fs-register-path('
+                         + identifier + ', "' + absolutePath + '");';
         var data = {
           contents: sassContents,
-          file: "fs:" + identifier + ":" + absolute_path
+          file: "fs:" + identifier + ":" + absolutePath
         };
         importUtils.importOnce(data, done);
       } else {

--- a/package.json
+++ b/package.json
@@ -37,8 +37,7 @@
     "lodash.merge": "^3.3.2",
     "node-sass": "^3.8.0",
     "node-sass-utils": "^1.1.2",
-    "semver": "^5.0.3",
-    "tmp": "0.0.28"
+    "semver": "^5.0.3"
   },
   "devDependencies": {
     "eslint": "^1.7.1",

--- a/test/test_assets.js
+++ b/test/test_assets.js
@@ -86,7 +86,7 @@ describe("assets", function () {
                    "  app-assets: \"images/foo.png\", \"fonts/foo.woff\";\n" +
                    "  mod-assets: \"mod-one/mod-one.jpg\", \"mod-one/subdir/sub.png\"; }\n";
     var rootDir = testutils.fixtureDirectory("app_assets");
-    //var distDir = tmp.dirSync();
+
     var eg = new Eyeglass({
       file: path.join(rootDir, "sass", "uses_mod_1.scss"),
       eyeglass: {
@@ -138,7 +138,7 @@ describe("assets", function () {
                    "  background: url(\"/assets/images/foo.png\");\n" +
                    "  background: url(\"/assets/fonts/foo.woff\"); }\n";
     var rootDir = testutils.fixtureDirectory("app_assets");
-    //var distDir = tmp.dirSync();
+
     var eg = new Eyeglass({
       file: path.join(rootDir, "sass", "app_assets.scss"),
       eyeglass: {
@@ -164,7 +164,7 @@ describe("assets", function () {
                    "  background: url(\"/assets/mod-one/mod-one.jpg\");\n" +
                    "  background: url(\"/assets/mod-one/subdir/sub.png\"); }\n";
     var rootDir = testutils.fixtureDirectory("app_assets");
-    //var distDir = tmp.dirSync();
+
     var eg = new Eyeglass({
       file: path.join(rootDir, "sass", "both_assets.scss"),
       eyeglass: {
@@ -193,7 +193,7 @@ describe("assets", function () {
                    "  background: url(\"../mod-one/mod-one.jpg\");\n" +
                    "  background: url(\"../mod-one/subdir/sub.png\"); }\n";
     var rootDir = testutils.fixtureDirectory("app_assets");
-    //var distDir = tmp.dirSync();
+
     var eg = new Eyeglass({
       file: path.join(rootDir, "sass", "both_assets.scss"),
       eyeglass: {
@@ -223,7 +223,7 @@ describe("assets", function () {
                    "  background: url(\"../mod-one/mod-one.jpg\");\n" +
                    "  background: url(\"../mod-one/subdir/sub.png\"); }\n";
     var rootDir = testutils.fixtureDirectory("app_assets");
-    //var distDir = tmp.dirSync();
+
     var eg = new Eyeglass({
       file: path.join(rootDir, "sass", "both_assets.scss"),
       eyeglass: {
@@ -254,7 +254,7 @@ describe("assets", function () {
                    "  background: url(\"/assets/mod-one/mod-one.jpg\");\n" +
                    "  background: url(\"/assets/mod-one/subdir/sub.png\"); }\n";
     var rootDir = testutils.fixtureDirectory("app_assets");
-    //var distDir = tmp.dirSync();
+
     var eg = new Eyeglass({
       file: path.join(rootDir, "sass", "both_assets.scss"),
       eyeglass: {
@@ -349,7 +349,7 @@ describe("assets", function () {
                    "  background: url(\"/assets/mod-one/mod-one.jpg?12345678\");\n" +
                    "  background: url(\"/assets/mod-one/subdir/sub.png?12345678\"); }\n";
     var rootDir = testutils.fixtureDirectory("app_assets");
-    //var distDir = tmp.dirSync();
+
     var eg = new Eyeglass({
       file: path.join(rootDir, "sass", "both_assets.scss"),
       eyeglass: {
@@ -401,7 +401,7 @@ describe("assets", function () {
                    "  background: url(\"/assets/mod-one/mod-one.jpg?12345678\");\n" +
                    "  background: url(\"/assets/mod-one/subdir/sub.png?12345678\"); }\n";
     var rootDir = testutils.fixtureDirectory("app_assets");
-    //var distDir = tmp.dirSync();
+
     var eg = new Eyeglass({
       file: path.join(rootDir, "sass", "both_assets.scss"),
       eyeglass: {
@@ -486,7 +486,7 @@ describe("assets", function () {
                    "  background: url(\"/my-app/assets/mod-one/mod-one.jpg?12345678\");\n" +
                    "  background: url(\"/my-app/assets/mod-one/subdir/sub.png?12345678\"); }\n";
     var rootDir = testutils.fixtureDirectory("app_assets");
-    //var distDir = tmp.dirSync();
+
     var eg = new Eyeglass({
       file: path.join(rootDir, "sass", "both_assets.scss"),
       eyeglass: {

--- a/test/test_fs.js
+++ b/test/test_fs.js
@@ -2,11 +2,9 @@
 
 var sass = require("node-sass");
 var path = require("path");
-var tmp = require("tmp");
 var Eyeglass = require("../lib");
 var testutils = require("./testutils");
 var assert = require("assert");
-var fse = require("fs-extra");
 var fs = require("fs");
 
 describe("fs", function () {


### PR DESCRIPTION
This cleans up a few lint warnings:

```
[15:45:12] Starting 'lint'...

test/test_fs.js
  5:5  warning  "tmp" is defined but never used  no-unused-vars
  9:5  warning  "fse" is defined but never used  no-unused-vars

✖ 2 problems (0 errors, 2 warnings)

lib/importers/FSImporter.js
   3:5   warning  "fs" is defined but never used                   no-unused-vars
   5:5   warning  "efs" is defined but never used                  no-unused-vars
  17:11  warning  Identifier 'absolute_path' is not in camel case  camelcase
  19:9   warning  Identifier 'absolute_path' is not in camel case  camelcase
  21:9   warning  Identifier 'absolute_path' is not in camel case  camelcase
  23:9   warning  Identifier 'absolute_path' is not in camel case  camelcase
  25:11  warning  Identifier 'absolute_path' is not in camel case  camelcase
  27:1   warning  Line 27 exceeds the maximum line length of 100   max-len
  27:86  warning  Identifier 'absolute_path' is not in camel case  camelcase
  30:44  warning  Identifier 'absolute_path' is not in camel case  camelcase

✖ 10 problems (0 errors, 10 warnings)

lib/functions/fs.js
  60:17  warning  Blocks are nested too deeply (4)  max-depth
  67:17  warning  Blocks are nested too deeply (4)  max-depth

✖ 2 problems (0 errors, 2 warnings)
[15:45:13] Finished 'lint' after 855 ms
```