### PR TITLE
increase test coverage and thresholds

### DIFF
--- a/build/coverage.js
+++ b/build/coverage.js
@@ -3,8 +3,8 @@
 var istanbul = require("gulp-istanbul");
 var mocha = require("gulp-mocha");
 
-module.exports = function(gulp, depends) {
-  gulp.task("coverage", depends, function (cb) {
+module.exports = function(gulp, depends, name) {
+  gulp.task(name || "coverage", depends, function (cb) {
     gulp.src(["lib/**/*.js"])
     .pipe(istanbul()) // Covering files
     .pipe(istanbul.hookRequire()) // Force `require` to return covered files
@@ -15,18 +15,17 @@ module.exports = function(gulp, depends) {
       .pipe(istanbul.enforceThresholds({
         thresholds: {
           global: {
-            statements: 97.92,
-            branches: 93.81,
-            functions: 98.73,
-            lines: 97.92
+            statements: 98.79,
+            branches: 96.99,
+            functions: 100,
+            lines: 98.79
           }
-        }})) // Enforce a coverage of at least 90%
+        }
+      }))
       .on("end", cb)
       .on("error", function(e) {
-        console.error(e.toString());
-        /*eslint-disable */
+        console.log(e.toString());
         process.exit(1);
-        /*eslint-enable */
       });
     });
   });

--- a/build/coverage.js
+++ b/build/coverage.js
@@ -15,10 +15,10 @@ module.exports = function(gulp, depends, name) {
       .pipe(istanbul.enforceThresholds({
         thresholds: {
           global: {
-            statements: 98.79,
-            branches: 96.99,
+            statements: 99.8,
+            branches: 99.25,
             functions: 100,
-            lines: 98.79
+            lines: 99.8
           }
         }
       }))

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -9,3 +9,5 @@ require("./build/coverage")(gulp);
 require("./build/site")(gulp, null, __dirname);
 
 gulp.task("default", ["test"]);
+
+require("./build/coverage")(gulp, ["lint"], "test:all");

--- a/lib/assets/AssetsSource.js
+++ b/lib/assets/AssetsSource.js
@@ -28,7 +28,7 @@ function AssetsSource(srcPath, options) {
     throw new Error("Expected " + srcPath + " to be a directory.");
   }
 
-  // TODO - what is this for? needs a test
+  // TODO (test) - what is this for? needs a test
   this.name = options.name || null;
   this.httpPrefix = options.httpPrefix || this.name;
   this.srcPath = URI.system(srcPath);

--- a/lib/functions/fs.js
+++ b/lib/functions/fs.js
@@ -27,19 +27,22 @@ module.exports = function(eyeglass, sass) {
 
   function inSandbox(fsPath) {
     var sandbox = eyeglass.options.eyeglass.fsSandbox;
+    // if there are no sandbox restrictions, return true
     if (!sandbox) {
       return true;
     }
+    // if we have an array of sanboxes...
     if (Array.isArray(sandbox)) {
+      // iterate over them and return true if we find one that is valid
       return sandbox.some(function(sb) {
         if (pathInSandboxDir(fsPath, sb)) {
           return true;
         }
       });
-    } else {
-      throw new Error("unknown value for sandbox");
     }
-    return false;
+
+    // if we got here, `fsSandbox` was invalid so throw an error
+    throw new Error("unknown value for sandbox");
   }
 
   function globFiles(directory, globPattern, includeFiles, includeDirectories, done) {

--- a/lib/functions/fs.js
+++ b/lib/functions/fs.js
@@ -53,6 +53,7 @@ module.exports = function(eyeglass, sass) {
         mark: true
       };
       glob(globPattern, globOpts, function(error, files) {
+        /* istanbul ignore if - we do not need to simulate a glob error here */
         if (error) {
           done(sass.types.Error(error.message));
           return;
@@ -95,7 +96,7 @@ module.exports = function(eyeglass, sass) {
           var resolved = path.resolve.apply(null, segments);
           done(sass.types.String(resolved));
         } else {
-          done(new Error("No path is registered for " + pathId));
+          done(sass.types.Error("No path is registered for " + pathId));
         }
       },
     "eyeglass-fs-join($segments...)": function(segments, done) {
@@ -141,6 +142,7 @@ module.exports = function(eyeglass, sass) {
 
       if (inSandbox(filename)) {
         fs.stat(filename, function(err, stats) {
+          /* istanbul ignore if - we do not need to simulate an fs error here */
           if (err) {
             done(sass.types.Error(err.message));
           } else {
@@ -158,6 +160,7 @@ module.exports = function(eyeglass, sass) {
               })
               );
             } catch (e) {
+              /* istanbul ignore next - we do not need to simulate an fs error here */
               done(sass.types.Error(e.message));
             }
           }
@@ -171,6 +174,7 @@ module.exports = function(eyeglass, sass) {
 
       if (inSandbox(filename)) {
         fs.readFile(filename, function(err, contents) {
+          /* istanbul ignore if - we do not need to simulate an fs error here */
           if (err) {
             done(sass.types.Error(err.message));
           } else {

--- a/lib/importers/FSImporter.js
+++ b/lib/importers/FSImporter.js
@@ -29,7 +29,7 @@ function FSImporter(eyeglass, sass, options, fallbackImporter) {
         };
         importUtils.importOnce(data, done);
       } else {
-        // TODO - how do we get here? needs test case
+        // TODO (test) - how do we get here? needs test case
         done(new Error("Cannot resolve filesystem location of " + prev));
       }
     } else {

--- a/lib/importers/FSImporter.js
+++ b/lib/importers/FSImporter.js
@@ -29,6 +29,7 @@ function FSImporter(eyeglass, sass, options, fallbackImporter) {
         };
         importUtils.importOnce(data, done);
       } else {
+        // TODO - how do we get here? needs test case
         done(new Error("Cannot resolve filesystem location of " + prev));
       }
     } else {

--- a/lib/importers/ImportUtilities.js
+++ b/lib/importers/ImportUtilities.js
@@ -55,6 +55,7 @@ ImportUtilities.prototype.fallback = function(uri, prev, done, noFallback) {
 function fallbackNth(uri, prev, index, done, noFallback) {
   var fallbackImporter = this.fallbackImporter[index];
 
+  // TODO - how do we get into this condition? needs a test case
   if (!fallbackImporter) {
     noFallback.call(this.context);
   } else {

--- a/lib/importers/ImportUtilities.js
+++ b/lib/importers/ImportUtilities.js
@@ -55,7 +55,7 @@ ImportUtilities.prototype.fallback = function(uri, prev, done, noFallback) {
 function fallbackNth(uri, prev, index, done, noFallback) {
   var fallbackImporter = this.fallbackImporter[index];
 
-  // TODO - how do we get into this condition? needs a test case
+  // TODO (test) - how do we get into this condition? needs a test case
   if (!fallbackImporter) {
     noFallback.call(this.context);
   } else {

--- a/lib/modules/EyeglassModules.js
+++ b/lib/modules/EyeglassModules.js
@@ -442,6 +442,7 @@ function discoverModules(options) {
   var dependencies = {};
 
   // if there's package.json contents...
+  /* istanbul ignore else - defensive conditional, don't care about else-case */
   if (pkg.data) {
     merge(
       dependencies,

--- a/lib/util/NameExpander.js
+++ b/lib/util/NameExpander.js
@@ -23,6 +23,7 @@ function NameExpander(uri) {
   * @param   {String} location - the location path the expand the URI against
   */
 NameExpander.prototype.addLocation = function(location) {
+  /* istanbul ignore else - defensive conditional, don't care about else-case */
   if (location && location !== "stdin") {
     // get the full path to the uri
     var fullLocation = path.join(location, this.uri);

--- a/lib/util/package.js
+++ b/lib/util/package.js
@@ -10,6 +10,7 @@ function getPackageData(pkgPath) {
   try {
     return require(pkgPath);
   } catch (e) {
+    /* istanbul ignore next - not really worth writing a test for */
     return null;
   }
 }

--- a/test/test_options.js
+++ b/test/test_options.js
@@ -157,6 +157,63 @@ describe("options", function() {
     });
   });
 
+  it("should use default verion of `0.0.0` if `ignoreDeprecations: false`", function(done) {
+    testutils.assertStderr(function(checkStderr) {
+      var rootDir = testutils.fixtureDirectory("basic_modules");
+      var options = {
+        root: rootDir,
+        assetsHttpPrefix: "foo",
+        assetsRelativeTo: "/styles/main.css",
+        eyeglass: {
+          ignoreDeprecations: false
+        }
+      };
+      var eyeglass = new Eyeglass.Eyeglass(options);
+      /* eslint no-unused-vars:0 */
+      var sassopts = eyeglass.sassOptions();
+      checkStderr([
+        "[eyeglass:deprecation] (deprecated in 0.8.0, will be removed in 0.9.0) `root` " +
+        "should be passed into the eyeglass options rather than the sass options:",
+        "  var options = eyeglass({",
+        "    /* sassOptions */",
+        "    ...",
+        "    eyeglass: {",
+        "      root: ...",
+        "    }",
+        "  });",
+        "[eyeglass:deprecation] (deprecated in 0.8.0, will be removed in 0.9.0) " +
+        "`assetsHttpPrefix` has been renamed to `httpPrefix` and should be passed into " +
+        "the eyeglass asset options rather than the sass options:",
+        "  var options = eyeglass({",
+        "    /* sassOptions */",
+        "    ...",
+        "    eyeglass: {",
+        "      assets: {",
+        "        httpPrefix: ...",
+        "      }",
+        "    }",
+        "  });",
+        "[eyeglass:deprecation] (deprecated in 0.8.0, will be removed in 0.9.0) " +
+        "`assetsRelativeTo` has been renamed to `relativeTo` and should be passed into " +
+        "the eyeglass asset options rather than the sass options:",
+        "  var options = eyeglass({",
+        "    /* sassOptions */",
+        "    ...",
+        "    eyeglass: {",
+        "      assets: {",
+        "        relativeTo: ...",
+        "      }",
+        "    }",
+        "  });",
+        "[eyeglass:deprecation] (deprecated in 0.8.0, will be removed in 0.9.0) " +
+        "`require('eyeglass').Eyeglass` is deprecated. Instead, use `require('eyeglass')`",
+        "[eyeglass:deprecation] (deprecated in 0.8.0, will be removed in 0.9.0) " +
+        "#sassOptions() is deprecated. Instead, you should access the sass options on #options\n"
+      ].join("\n"));
+      done();
+    });
+  });
+
   describe("deprecated interface", function() {
     it("should support `new Eyeglass.Eyeglass` with warning", function(done) {
       testutils.assertStderr(function(checkStderr) {

--- a/test/test_semver.js
+++ b/test/test_semver.js
@@ -65,4 +65,16 @@ describe("semver checking", function () {
       done();
     });
   });
+
+  it("should be silent if strictModuleVersions is disabled (false)", function (done) {
+    var options = {
+      data: "#hello { greeting: hello(Chris); }",
+      eyeglass: {
+        root: testutils.fixtureDirectory("bad_engine"),
+        strictModuleVersions: false
+      }
+    };
+
+    testutils.assertCompiles(options, "#hello {\n  greeting: hello(Chris); }\n", done);
+  });
 });

--- a/test/test_utils.js
+++ b/test/test_utils.js
@@ -1,7 +1,8 @@
 "use strict";
 
 var assert = require("assert");
-var unquote = require("../lib/util/strings").unquote;
+var stringUtils = require("../lib/util/strings");
+var unquote = stringUtils.unquote;
 var sync = require("../lib/util/sync");
 var sass = require("node-sass");
 var testutils = require("./testutils");
@@ -78,5 +79,17 @@ describe("utilities", function () {
    var resultB = syncFnB();
    assert.equal(resultA, expected, "handles async functions with callbacks");
    assert.equal(resultB, expected, "handles sync functions without callbacks");
+ });
+
+ it("quote handles Sass strings", function(done) {
+   assert.equal('"asdf"', stringUtils.quote(sass.types.String("asdf")).getValue());
+   done();
+ });
+
+ it("tmpl should preserve placeholders if not in data", function(done) {
+   var tmpl = "${foo} ${bar}";
+   var result = stringUtils.tmpl(tmpl, {}); // no data
+   assert.equal(tmpl, result);
+   done();
  });
 });


### PR DESCRIPTION
This includes:

- several more test cases
- several `istanbul ignore` statements for things like `fs` and `glob` error handling which probably isn't worth writing test coverage for right now
- `gulp test:all` task that will run lint and test coverage in one pass so I don't have to run both individually
- `TODO` comments where we still need a test case

Test coverage before:
```
----------------------|----------|----------|----------|----------|----------------|
File                  |  % Stmts | % Branch |  % Funcs |  % Lines |Uncovered Lines |
----------------------|----------|----------|----------|----------|----------------|
 lib/                 |      100 |      100 |      100 |      100 |                |
  eyeglass-exports.js |      100 |      100 |      100 |      100 |                |
  index.js            |      100 |      100 |      100 |      100 |                |
 lib/assets/          |      100 |      100 |      100 |      100 |                |
  Assets.js           |      100 |      100 |      100 |      100 |                |
  AssetsCollection.js |      100 |      100 |      100 |      100 |                |
  AssetsSource.js     |      100 |      100 |      100 |      100 |                |
 lib/functions/       |       90 |    82.61 |      100 |       90 |                |
  asset-uri.js        |      100 |      100 |      100 |      100 |                |
  fs.js               |    86.05 |    78.95 |      100 |    86.05 |... 158,172,178 |
  index.js            |      100 |      100 |      100 |      100 |                |
  normalize-uri.js    |      100 |      100 |      100 |      100 |                |
  version.js          |      100 |      100 |      100 |      100 |                |
 lib/importers/       |    98.75 |    95.95 |      100 |    98.75 |                |
  AssetImporter.js    |      100 |      100 |      100 |      100 |                |
  FSImporter.js       |    95.83 |     87.5 |      100 |    95.83 |             32 |
  ImportUtilities.js  |    97.44 |       95 |      100 |    97.44 |             59 |
  ModuleImporter.js   |      100 |    96.15 |      100 |      100 |                |
 lib/modules/         |      100 |    99.23 |      100 |      100 |                |
  EyeglassModule.js   |      100 |      100 |      100 |      100 |                |
  EyeglassModules.js  |      100 |    98.82 |      100 |      100 |                |
  ModuleFunctions.js  |      100 |      100 |      100 |      100 |                |
 lib/util/            |    98.62 |    94.39 |      100 |    98.62 |                |
  NameExpander.js     |      100 |       90 |      100 |      100 |                |
  Options.js          |    98.59 |    96.88 |      100 |    98.59 |            185 |
  URI.js              |      100 |      100 |      100 |      100 |                |
  debug.js            |      100 |      100 |      100 |      100 |                |
  deprecator.js       |      100 |    92.31 |      100 |      100 |                |
  files.js            |      100 |      100 |      100 |      100 |                |
  package.js          |    95.83 |      100 |      100 |    95.83 |             13 |
  resolve.js          |      100 |      100 |      100 |      100 |                |
  semverChecker.js    |    95.65 |    92.31 |      100 |    95.65 |             15 |
  strings.js          |    93.75 |    81.82 |      100 |    93.75 |             19 |
  sync.js             |      100 |      100 |      100 |      100 |                |
----------------------|----------|----------|----------|----------|----------------|
All files             |    98.18 |    95.49 |      100 |    98.18 |                |
----------------------|----------|----------|----------|----------|----------------|


=============================== Coverage summary ===============================
Statements   : 98.18% ( 973/991 ), 1 ignored
Branches     : 95.49% ( 381/399 )
Functions    : 100% ( 213/213 )
Lines        : 98.18% ( 973/991 )
================================================================================
```

Test coverage after:
```
----------------------|----------|----------|----------|----------|----------------|
File                  |  % Stmts | % Branch |  % Funcs |  % Lines |Uncovered Lines |
----------------------|----------|----------|----------|----------|----------------|
 lib/                 |      100 |      100 |      100 |      100 |                |
  eyeglass-exports.js |      100 |      100 |      100 |      100 |                |
  index.js            |      100 |      100 |      100 |      100 |                |
 lib/assets/          |      100 |      100 |      100 |      100 |                |
  Assets.js           |      100 |      100 |      100 |      100 |                |
  AssetsCollection.js |      100 |      100 |      100 |      100 |                |
  AssetsSource.js     |      100 |      100 |      100 |      100 |                |
 lib/functions/       |      100 |      100 |      100 |      100 |                |
  asset-uri.js        |      100 |      100 |      100 |      100 |                |
  fs.js               |      100 |      100 |      100 |      100 |                |
  index.js            |      100 |      100 |      100 |      100 |                |
  normalize-uri.js    |      100 |      100 |      100 |      100 |                |
  version.js          |      100 |      100 |      100 |      100 |                |
 lib/importers/       |    98.75 |    95.95 |      100 |    98.75 |                |
  AssetImporter.js    |      100 |      100 |      100 |      100 |                |
  FSImporter.js       |    95.83 |     87.5 |      100 |    95.83 |             33 |
  ImportUtilities.js  |    97.44 |       95 |      100 |    97.44 |             60 |
  ModuleImporter.js   |      100 |    96.15 |      100 |      100 |                |
 lib/modules/         |      100 |      100 |      100 |      100 |                |
  EyeglassModule.js   |      100 |      100 |      100 |      100 |                |
  EyeglassModules.js  |      100 |      100 |      100 |      100 |                |
  ModuleFunctions.js  |      100 |      100 |      100 |      100 |                |
 lib/util/            |      100 |      100 |      100 |      100 |                |
  NameExpander.js     |      100 |      100 |      100 |      100 |                |
  Options.js          |      100 |      100 |      100 |      100 |                |
  URI.js              |      100 |      100 |      100 |      100 |                |
  debug.js            |      100 |      100 |      100 |      100 |                |
  deprecator.js       |      100 |      100 |      100 |      100 |                |
  files.js            |      100 |      100 |      100 |      100 |                |
  package.js          |      100 |      100 |      100 |      100 |                |
  resolve.js          |      100 |      100 |      100 |      100 |                |
  semverChecker.js    |      100 |      100 |      100 |      100 |                |
  strings.js          |      100 |      100 |      100 |      100 |                |
  sync.js             |      100 |      100 |      100 |      100 |                |
----------------------|----------|----------|----------|----------|----------------|
All files             |     99.8 |    99.25 |      100 |     99.8 |                |
----------------------|----------|----------|----------|----------|----------------|


=============================== Coverage summary ===============================
Statements   : 99.8% ( 988/990 ), 7 ignored
Branches     : 99.25% ( 396/399 ), 5 ignored
Functions    : 100% ( 213/213 )
Lines        : 99.8% ( 988/990 )
================================================================================
```