### PR TITLE
whitelist files to include in published npm artifact

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,5 +53,9 @@
     "handlebars": "^4.0.5",
     "mocha": "^2.3.3",
     "should": "^7.1.0"
-  }
+  },
+  "files": [
+    "lib",
+    "sass"
+  ]
 }


### PR DESCRIPTION
Currently all files not excluded by `.gitignore` end up in the published npm artifact.

This explicitly whitelists the files to include in the published artifact.

Included files:
- `lib/*`
- `sass/*`

See for reference: https://docs.npmjs.com/files/package.json#files

Verified against a few different projects via `npm install ~/workspace/eyelgass`

```
$ npm install ~/workspace/eyeglass && tree -I "node_modules" node_modules/eyeglass
...
node_modules/eyeglass
├── LICENSE
├── README.md
├── lib
│   ├── assets
│   │   ├── Assets.js
│   │   ├── AssetsCollection.js
│   │   └── AssetsSource.js
│   ├── eyeglass-exports.js
│   ├── functions
│   │   ├── asset-uri.js
│   │   ├── fs.js
│   │   ├── index.js
│   │   ├── normalize-uri.js
│   │   └── version.js
│   ├── importers
│   │   ├── AssetImporter.js
│   │   ├── FSImporter.js
│   │   ├── ImportUtilities.js
│   │   └── ModuleImporter.js
│   ├── index.js
│   ├── modules
│   │   ├── EyeglassModule.js
│   │   ├── EyeglassModules.js
│   │   └── ModuleFunctions.js
│   └── util
│       ├── NameExpander.js
│       ├── Options.js
│       ├── URI.js
│       ├── debug.js
│       ├── deprecator.js
│       ├── files.js
│       ├── package.js
│       ├── resolve.js
│       ├── semverChecker.js
│       ├── strings.js
│       └── sync.js
├── package.json
└── sass
    ├── assets.scss
    └── fs.scss

7 directories, 33 files
```