### PR TITLE
Handle eyeglass module dependencies of symlinked node modules

### DIFF
--- a/lib/modules/EyeglassModule.js
+++ b/lib/modules/EyeglassModule.js
@@ -4,6 +4,7 @@ var packageUtils = require("../util/package");
 var merge = require("lodash.merge");
 var includes = require("lodash.includes");
 var path = require("path");
+var fs = require("fs");
 var rInvalidName = /\.(?:sass|s?css)$/;
 
 var EYEGLASS_KEYWORD = "eyeglass-module";
@@ -18,7 +19,7 @@ function EyeglassModule(mod, discoverModules, isRoot) {
   // if we were given a path, resolve it to the package.json
   if (mod.path) {
     var pkg = packageUtils.getPackage(mod.path);
-    var modulePath = path.dirname(pkg.path);
+    var modulePath = fs.realpathSync(path.dirname(pkg.path));
     mod.path = modulePath;
 
     mod = merge(

--- a/test/fixtures/symlinked_modules/mymodule/node_modules/shared_dep/package.json
+++ b/test/fixtures/symlinked_modules/mymodule/node_modules/shared_dep/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "shared_dep",
+  "version": "1.1.0",
+  "description": "this is a shared module",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "keywords": [
+    "eyeglass-module"
+  ],
+  "author": "",
+  "license": "UNLICENSED",
+  "eyeglass": {
+    "exports": false,
+    "sassDir": "sass",
+    "needs": "*"
+  }
+}

--- a/test/fixtures/symlinked_modules/mymodule/node_modules/shared_dep/sass/index.scss
+++ b/test/fixtures/symlinked_modules/mymodule/node_modules/shared_dep/sass/index.scss
@@ -1,0 +1,4 @@
+.shared {
+  float: upside-down;
+  version: eyeglass-version("shared_dep");
+}

--- a/test/fixtures/symlinked_modules/mymodule/package.json
+++ b/test/fixtures/symlinked_modules/mymodule/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "mymodule",
+  "version": "1.0.0",
+  "description": "this is my module",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "keywords": [
+    "eyeglass-module"
+  ],
+  "author": "",
+  "license": "UNLICENSED",
+  "eyeglass": {
+    "exports": false,
+    "sassDir": "sass",
+    "needs": "*"
+  },
+  "dependencies": {
+    "shared_dep": "*"
+  }
+}

--- a/test/fixtures/symlinked_modules/mymodule/sass/index.scss
+++ b/test/fixtures/symlinked_modules/mymodule/sass/index.scss
@@ -1,0 +1,4 @@
+@import "shared_dep";
+.mymodule {
+  color: red;
+}

--- a/test/fixtures/symlinked_modules/project/node_modules/shared_dep/package.json
+++ b/test/fixtures/symlinked_modules/project/node_modules/shared_dep/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "shared_dep",
+  "version": "1.2.0",
+  "description": "this is a shared module",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "keywords": [
+    "eyeglass-module"
+  ],
+  "author": "",
+  "license": "UNLICENSED",
+  "eyeglass": {
+    "exports": false,
+    "sassDir": "sass",
+    "needs": "*"
+  }
+}

--- a/test/fixtures/symlinked_modules/project/node_modules/shared_dep/sass/index.scss
+++ b/test/fixtures/symlinked_modules/project/node_modules/shared_dep/sass/index.scss
@@ -1,0 +1,4 @@
+.shared {
+  float: upside-down;
+  version: eyeglass-version("shared_dep");
+}

--- a/test/fixtures/symlinked_modules/project/package.json
+++ b/test/fixtures/symlinked_modules/project/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "myproject",
+  "version": "0.0.1",
+  "main": "package.json",
+  "private": true,
+  "dependencies": {
+    "mymodule": "*",
+    "shared_dep": "*"
+  }
+}


### PR DESCRIPTION
When an eyeglass module was being developed on and being used in another project via `npm link`, the linked module would not find its import dependencies because the symlink dir was being compared to the realpath in some cases. We now always use the real path of an eyeglass module for that modules root `path`.