### PR TITLE
fixes for libsass 3.4 support

### DIFF
--- a/lib/functions/normalize-uri.js
+++ b/lib/functions/normalize-uri.js
@@ -9,8 +9,6 @@ module.exports = function(eyeglass, sass) {
       var uri = $uri.getValue();
       // normalize the uri for the given type
       uri = URI[type](uri);
-      // then normalize it to an escaped sass string
-      uri = URI.sass(uri);
       done(sass.types.String(uri));
     },
     "eyeglass-uri-preserve($uri)": function($uri, done) {

--- a/sass/assets.scss
+++ b/sass/assets.scss
@@ -30,8 +30,8 @@ $eg-registered-assets: () !default;
   $eg-registered-assets: map-merge($eg-registered-assets, (
     $module: map-merge($mod-assets, (
       $url: (
-        filepath: $path,
-        uri: $uri
+        filepath: quote($path),
+        uri: quote($uri)
       )
     ))
   )) !global;
@@ -90,7 +90,7 @@ $eg-registered-assets: () !default;
   $mod-assets: map-get($eg-registered-assets, $module) or ();
   @each $url, $path in $mod-assets {
     $url: if($module, $module + "/" + $url, $url);
-    $asset-urls: append($asset-urls, $url, comma);
+    $asset-urls: append($asset-urls, quote($url), comma);
   }
   @return $asset-urls;
 }

--- a/test/test_assets.js
+++ b/test/test_assets.js
@@ -282,7 +282,7 @@ describe("assets", function () {
                "$uri: 'assets/foo/bar.png');" +
                ".test { foo: inspect($eg-registered-assets); }";
     var filepath = path.join("images", "foo", "bar.png").replace(/\\/g, "\\\\");
-    var expected = '.test {\n  foo: (module-a: ("foo/bar.png": (' +
+    var expected = ".test {\n  foo: (module-a: (foo/bar.png: (" +
                    'filepath: "' + filepath + '", ' +
                    'uri: "assets/foo/bar.png"))); }\n';
     var rootDir = testutils.fixtureDirectory("app_assets");
@@ -863,9 +863,9 @@ describe("assets", function () {
     }
 
     function test(options, shouldNormalize, done) {
-      var expected = "/* \""
-      + escapeBackslash(shouldNormalize ? normalizedUri : otherUri)
-      + "\" */\n";
+      var expected = "/* "
+      + (shouldNormalize ? normalizedUri : otherUri)
+      + " */\n";
 
       options = merge({
         data: input,


### PR DESCRIPTION
The main change here is to not `quote()` the output directly in `eyeglass-normalize-uri`. This caused issues when the resulting value was set as a key on `$eg-registered-assets`. See https://github.com/sass/libsass/issues/2197

Minor updates to `assets.scss` and tests to account for this change in the output.

Verified tests passing with...

```
node-sass	3.10.0	(Wrapper)	[JavaScript]
libsass  	3.3.6	(Sass Compiler)	[C/C++]
```
and
```
node-sass	3.11.0	(Wrapper)	[JavaScript]
libsass  	3.4.0	(Sass Compiler)	[C/C++]
```

FWIW, this should have been resolvable by `unquote`ing the output when setting the key, but this still resulted in a quoted key, so this might still be an issue with `unquote` in libsass.

```scss
$eg-registered-assets: map-merge($eg-registered-assets, (
  $module: map-merge($mod-assets, (
    unquote($url): ...
```

/cc @xzyfer @chriseppstein 