### PR TITLE
bump dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,11 +31,11 @@
     "archy": "^1.0.0",
     "deasync": "^0.1.4",
     "debug": "^2.2.0",
-    "fs-extra": "^0.24.0",
-    "glob": "^5.0.15",
-    "lodash.includes": "^3.1.3",
-    "lodash.merge": "^3.3.2",
-    "node-sass": "^3.8.0",
+    "fs-extra": "^0.30.0",
+    "glob": "^7.1.0",
+    "lodash.includes": "^4.3.0",
+    "lodash.merge": "^4.6.0",
+    "node-sass": "^3.10.1",
     "node-sass-utils": "^1.1.2",
     "semver": "^5.0.3"
   },
@@ -51,8 +51,8 @@
     "gulp-istanbul": "^0.10.1",
     "gulp-mocha": "^2.1.3",
     "handlebars": "^4.0.5",
-    "mocha": "^2.3.3",
-    "should": "^7.1.0"
+    "mocha": "^3.1.0",
+    "should": "^11.1.0"
   },
   "files": [
     "lib",


### PR DESCRIPTION
Keeping us up-to-date with latest dependencies.

Did not bump grunt/gulp/eslint dependencies.