### PR TITLE
throw error if invalid module path is provided

### DIFF
--- a/lib/modules/EyeglassModule.js
+++ b/lib/modules/EyeglassModule.js
@@ -19,6 +19,12 @@ function EyeglassModule(mod, discoverModules, isRoot) {
   // if we were given a path, resolve it to the package.json
   if (mod.path) {
     var pkg = packageUtils.getPackage(mod.path);
+
+    // if pkg.data is empty, this is an invalid path, so throw an error
+    if (!pkg.data) {
+      throw new Error("Could not find a valid package.json at " + mod.path);
+    }
+
     var modulePath = fs.realpathSync(path.dirname(pkg.path));
     mod.path = modulePath;
 

--- a/test/test_modules.js
+++ b/test/test_modules.js
@@ -91,4 +91,20 @@ describe("EyeglassModules", function () {
     });
 
   });
+
+  it("throws when an invalid module path is provided", function(done) {
+    var rootDir = testutils.fixtureDirectory("simple_module");
+    var invalidPath = testutils.fixtureDirectory("does_not_exist");
+    var expectedError = "Could not find a valid package.json at " + invalidPath;
+    var options = {
+      data: "// should not compile",
+      eyeglass: {
+        root: rootDir,
+        modules: [{
+          path: invalidPath
+        }]
+      }
+    };
+    testutils.assertCompilationError(options, expectedError, done);
+  });
 });


### PR DESCRIPTION
This adds a more useful error message when an invalid module path is encountered.