### PR TITLE
fix discoverModules context binding issue

### DIFF
--- a/lib/modules/EyeglassModules.js
+++ b/lib/modules/EyeglassModules.js
@@ -47,7 +47,7 @@ function EyeglassModules(dir, modules) {
       }), discoverModules.bind(this));
       dependencies[mod.name] = mod;
       return dependencies;
-    }, moduleTree.dependencies);
+    }.bind(this), moduleTree.dependencies);
   }
 
   // convert the tree into a flat collection of deduped modules


### PR DESCRIPTION
The wrapping function was not correctly binding the context of `this`, which caused the `discoverModules.bind(this)` to be invalid.