### PR TITLE
Add gulp example to Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -460,7 +460,7 @@ var eyeglass = require("eyeglass");
  
 gulp.task('sass', function () {
   return gulp.src('./sass/**/*.scss')
-    .pipe(sass(eyeglass({sourceMap: true}).on('error', sass.logError))
+    .pipe(sass(eyeglass({sourceMap: true})).on('error', sass.logError))
     .pipe(gulp.dest('./css'));
 });
 ```

--- a/README.md
+++ b/README.md
@@ -451,6 +451,20 @@ sass: {
 ...
 ```
 
+### Example: integration with gulp and gulp-sass
+
+```js
+var gulp = require('gulp');
+var sass = require('gulp-sass');
+var eyeglass = require("eyeglass");
+ 
+gulp.task('sass', function () {
+  return gulp.src('./sass/**/*.scss')
+    .pipe(sass(eyeglass({sourceMap: true}).on('error', sass.logError))
+    .pipe(gulp.dest('./css'));
+});
+```
+
 # Writing an Eyeglass Module
 
 node-sass allows you to register custom functions for advanced


### PR DESCRIPTION
This was pretty simple but still took me a few minutes of poking around to figure out, partially because there are still references to the older `new Eyeglass().sassOptions()` API that I was trying to use initially.