### PR TITLE
Cache scss generated to register assets

### DIFF
--- a/lib/assets/Assets.js
+++ b/lib/assets/Assets.js
@@ -200,6 +200,13 @@ Assets.prototype.installer = function(installer) {
   };
 };
 
+/**
+  * @see AssetsCollection#resetCache
+  */
+Assets.prototype.resetCache = function() {
+  this.collection.resetCache();
+};
+
 function resolveAssetDefaults(registeredAssetsMap, relativePath) {
   registeredAssetsMap = this.sassUtils.handleEmptyMap(registeredAssetsMap);
   this.sassUtils.assertType(registeredAssetsMap, "map");

--- a/lib/assets/AssetsCollection.js
+++ b/lib/assets/AssetsCollection.js
@@ -28,8 +28,8 @@ AssetsCollection.prototype.addSource = function(src, opts) {
   * @param    {String} name - the namespace to use
   * @returns  {String} the scss representation of the asset registration
   */
-AssetsCollection.prototype.asAssetImport = function (name) {
-  //  if the sources are all the same as what's in cache, send that back
+AssetsCollection.prototype.asAssetImport = function(name) {
+  // if this has already been generated, return it from cache
   var cacheKey = this.sources.reduce(function(cacheStr, source) {
     return cacheStr + ":" + source.cacheKey(name);
   }, "sources");
@@ -63,6 +63,13 @@ AssetsCollection.prototype.asAssetImport = function (name) {
 
   assetCache[cacheKey] = generatedScss;
   return generatedScss;
+};
+
+/**
+  * Clears the cache of scss generated to register assets
+  */
+AssetsCollection.prototype.resetCache = function() {
+  assetCache = {};
 };
 
 module.exports = AssetsCollection;

--- a/lib/assets/AssetsCollection.js
+++ b/lib/assets/AssetsCollection.js
@@ -6,6 +6,8 @@ var URI = require("../util/URI");
 
 var assetRegisterTmpl = "@include asset-register(${namespace}, ${name}, ${sourcePath}, ${uri});\n";
 
+var assetCache = {};
+
 function AssetsCollection() {
   this.sources = [];
 }
@@ -27,6 +29,14 @@ AssetsCollection.prototype.addSource = function(src, opts) {
   * @returns  {String} the scss representation of the asset registration
   */
 AssetsCollection.prototype.asAssetImport = function (name) {
+  //  if the sources are all the same as what's in cache, send that back
+  var cacheKey = this.sources.reduce(function(cacheStr, source) {
+    return cacheStr + ":" + source.cacheKey(name);
+  }, "sources");
+  if (assetCache[cacheKey] !== undefined) {
+    return assetCache[cacheKey];
+  }
+
   // builds the scss to register all the assets
   // this will look something like...
   //  @import "eyeglass/assets";
@@ -36,7 +46,7 @@ AssetsCollection.prototype.asAssetImport = function (name) {
   //    "/absolute/namespace/path/to/foo.png",
   //    "namespace/path/to/foo.png"
   //  );
-  return this.sources.reduce(function(importStr, source) {
+  var generatedScss = this.sources.reduce(function(importStr, source) {
     // get the assets for the entry
     var assets = source.getAssets(name);
     var namespace = (stringUtils.quote(assets.namespace) || "null");
@@ -50,6 +60,9 @@ AssetsCollection.prototype.asAssetImport = function (name) {
       });
     }, "");
   }, '@import "eyeglass/assets";\n');
+
+  assetCache[cacheKey] = generatedScss;
+  return generatedScss;
 };
 
 module.exports = AssetsCollection;

--- a/lib/assets/AssetsSource.js
+++ b/lib/assets/AssetsSource.js
@@ -103,5 +103,4 @@ AssetsSource.prototype.cacheKey = function(namespace) {
     "]";
 };
 
-
 module.exports = AssetsSource;

--- a/lib/assets/AssetsSource.js
+++ b/lib/assets/AssetsSource.js
@@ -82,4 +82,26 @@ AssetsSource.prototype.toString = function() {
   return this.srcPath + "/" + this.pattern;
 };
 
+/**
+  * Build a string suitable for caching this asset
+  * @returns {String} the cache key
+  */
+AssetsSource.prototype.cacheKey = function(namespace) {
+  function skipSomeKeys(key, value) {
+    if (key === "cwd" || key === "root") {
+      return undefined;
+    }
+    return value;
+  }
+
+  return "[" +
+    "httpPrefix=" + (this.httpPrefix ? this.httpPrefix : "") +
+    ";name=" + (this.name ? this.name : (namespace ? namespace : "")) +
+    ";srcPath=" + this.srcPath +
+    ";pattern=" + this.pattern +
+    ";opts=" + JSON.stringify(this.globOpts, skipSomeKeys) +
+    "]";
+};
+
+
 module.exports = AssetsSource;

--- a/lib/assets/AssetsSource.js
+++ b/lib/assets/AssetsSource.js
@@ -88,7 +88,14 @@ AssetsSource.prototype.toString = function() {
   */
 AssetsSource.prototype.cacheKey = function(namespace) {
   function skipSomeKeys(key, value) {
+    // these are set to this.srcPath, which is already included in the cacheKey
     if (key === "cwd" || key === "root") {
+      return undefined;
+    }
+    // these are added inside glob and always set to true, which happens after this string
+    // is created when glob.sync() is run in #getAssets()
+    // (see #setopts() in glob/common.js)
+    if (key === "nonegate" || key === "nocomment") {
       return undefined;
     }
     return value;

--- a/lib/index.js
+++ b/lib/index.js
@@ -132,6 +132,10 @@ Eyeglass.prototype.sassOptions = function() {
   return this.options;
 };
 
+Eyeglass.prototype.resetAssetCache = function() {
+  this.assets.resetCache();
+};
+
 module.exports.Eyeglass = function(options, deprecatedNodeSassArg) {
   var eyeglass = new Eyeglass(options, deprecatedNodeSassArg);
   deprecateMethodWarning.call(eyeglass, "Eyeglass");

--- a/package.json
+++ b/package.json
@@ -53,7 +53,8 @@
     "gulp-mocha": "^2.1.3",
     "handlebars": "^4.0.5",
     "mocha": "^3.1.0",
-    "should": "^11.1.0"
+    "should": "^11.1.0",
+    "touch": "^3.1.0"
   },
   "files": [
     "lib",

--- a/test/fixtures/app_assets/sass/caching_assets.scss
+++ b/test/fixtures/app_assets/sass/caching_assets.scss
@@ -1,0 +1,5 @@
+@import "assets";
+
+.all-assets {
+  app-assets: asset-list();
+}

--- a/test/test_assets.js
+++ b/test/test_assets.js
@@ -983,6 +983,71 @@ describe("assets", function () {
           });
         });
       });
+
+      describe("caching generated Scss", function() {
+        var rootDir = testutils.fixtureDirectory("app_assets");
+        var rootDir2 = testutils.fixtureDirectory("app_assets_odd_names");
+
+        it("generates different cacheKey for different httpPrefix", function(done) {
+          var source1 = new AssetsSource(rootDir, {
+            httpPrefix: "foo",
+          });
+          var source2 = new AssetsSource(rootDir, {
+            httpPrefix: "bar",
+          });
+          assert.notEqual(source1.cacheKey(), source2.cacheKey());
+          done();
+        });
+
+        it("generates different cacheKey for different name", function(done) {
+          var source1 = new AssetsSource(rootDir, {
+            name: "foo",
+          });
+          var source2 = new AssetsSource(rootDir, {
+            name: "bar",
+          });
+          assert.notEqual(source1.cacheKey(), source2.cacheKey());
+          done();
+        });
+
+        it("generates different cacheKey for different namespace", function(done) {
+          var source1 = new AssetsSource(rootDir, {
+          });
+          assert.notEqual(source1.cacheKey("foo"), source1.cacheKey("bar"));
+          done();
+        });
+
+        it("generates different cacheKey for different srcPath", function(done) {
+          var source1 = new AssetsSource(rootDir, {});
+          var source2 = new AssetsSource(rootDir2, {});
+          assert.notEqual(source1.cacheKey(), source2.cacheKey());
+          done();
+        });
+
+        it("generates different cacheKey for different pattern", function(done) {
+          var source1 = new AssetsSource(rootDir, {
+            pattern: "images/**/*",
+          });
+          var source2 = new AssetsSource(rootDir, {
+            pattern: "images/**/*.jpg",
+          });
+          assert.notEqual(source1.cacheKey(), source2.cacheKey());
+          done();
+        });
+
+        it("generates different cacheKey for different globOpts", function(done) {
+          var source1 = new AssetsSource(rootDir, {
+          });
+          var source2 = new AssetsSource(rootDir, {
+            globOpts: {
+              dot: true
+            }
+          });
+          assert.notEqual(source1.cacheKey(), source2.cacheKey());
+          done();
+        });
+
+      });
     });
   });
 });


### PR DESCRIPTION
## Problem

Every time `@import "module/assets"` is rendered, the code to register the assets is generated from scratch. In a large codebase where the same modules are used 100s of times, this wastes a lot of time doing the same thing over and over.

## Solution

Cache the generated code the first time, and return that for any subsequent `@import`s that are using the same module and options.