### PR TITLE
Generate cache keys for sources and collections

### DIFF
--- a/lib/assets/Assets.js
+++ b/lib/assets/Assets.js
@@ -14,6 +14,8 @@ function Assets(eyeglass, sass) {
   this.eyeglass = eyeglass;
   // create a master collection
   this.collection = new AssetsCollection();
+  // and keep a list of module collections
+  this.moduleCollections = [];
 
   // Expose these temporarily for back-compat reasons
   function deprecate(method) {
@@ -57,6 +59,7 @@ Assets.prototype.addSource = function(src, opts) {
   */
 Assets.prototype.export = function(src, opts) {
   var assets = new AssetsCollection();
+  this.moduleCollections.push(assets);
   return assets.addSource(src, opts);
 };
 

--- a/lib/assets/AssetsCollection.js
+++ b/lib/assets/AssetsCollection.js
@@ -57,9 +57,9 @@ AssetsCollection.prototype.asAssetImport = function (name) {
   * @returns {String} the cache key
   */
 AssetsCollection.prototype.cacheKey = function(name) {
-  return this.sources.reduce(function(cacheStr, source) {
-    return cacheStr + ":" + source.cacheKey(name);
-  }, "sources");
+  return this.sources.map(function(source) {
+    return source.cacheKey(name);
+  }).sort().join(":");
 };
 
 module.exports = AssetsCollection;

--- a/lib/assets/AssetsCollection.js
+++ b/lib/assets/AssetsCollection.js
@@ -52,4 +52,14 @@ AssetsCollection.prototype.asAssetImport = function (name) {
   }, '@import "eyeglass/assets";\n');
 };
 
+/**
+  * Build a string suitable for caching an instance of this
+  * @returns {String} the cache key
+  */
+AssetsCollection.prototype.cacheKey = function(name) {
+  return this.sources.reduce(function(cacheStr, source) {
+    return cacheStr + ":" + source.cacheKey(name);
+  }, "sources");
+};
+
 module.exports = AssetsCollection;

--- a/lib/assets/AssetsSource.js
+++ b/lib/assets/AssetsSource.js
@@ -6,6 +6,7 @@ var path = require("path");
 var merge = require("lodash.merge");
 var URI = require("../util/URI");
 var fileUtils = require("../util/files");
+var stringify = require("json-stable-stringify");
 
 /* class AssetsSource
  *
@@ -82,31 +83,33 @@ AssetsSource.prototype.toString = function() {
   return this.srcPath + "/" + this.pattern;
 };
 
+// don't include these globOpts in the cacheKey
+function skipSomeKeys(key, value) {
+  // these are set to this.srcPath, which is already included in the cacheKey
+  if (key === "cwd" || key === "root") {
+    return undefined;
+  }
+  // these are added inside glob and always set to true, which happens after this string
+  // is created when glob.sync() is run in #getAssets()
+  // (see #setopts() in glob/common.js)
+  if (key === "nonegate" || key === "nocomment") {
+    return undefined;
+  }
+  return value;
+}
+
 /**
   * Build a string suitable for caching an instance of this
   * @returns {String} the cache key
   */
 AssetsSource.prototype.cacheKey = function(namespace) {
-  function skipSomeKeys(key, value) {
-    // these are set to this.srcPath, which is already included in the cacheKey
-    if (key === "cwd" || key === "root") {
-      return undefined;
-    }
-    // these are added inside glob and always set to true, which happens after this string
-    // is created when glob.sync() is run in #getAssets()
-    // (see #setopts() in glob/common.js)
-    if (key === "nonegate" || key === "nocomment") {
-      return undefined;
-    }
-    return value;
-  }
-
   return "[" +
     "httpPrefix=" + (this.httpPrefix ? this.httpPrefix : "") +
     ";name=" + (this.name ? this.name : (namespace ? namespace : "")) +
     ";srcPath=" + this.srcPath +
     ";pattern=" + this.pattern +
-    ";opts=" + JSON.stringify(this.globOpts, skipSomeKeys) +
+    // json-stable-stringify orders keys when stringifying (JSON.stringify does not)
+    ";opts=" + stringify(this.globOpts, {replacer: skipSomeKeys}) +
     "]";
 };
 

--- a/lib/assets/AssetsSource.js
+++ b/lib/assets/AssetsSource.js
@@ -83,7 +83,7 @@ AssetsSource.prototype.toString = function() {
 };
 
 /**
-  * Build a string suitable for caching this asset
+  * Build a string suitable for caching an instance of this
   * @returns {String} the cache key
   */
 AssetsSource.prototype.cacheKey = function(namespace) {

--- a/lib/assets/AssetsSource.js
+++ b/lib/assets/AssetsSource.js
@@ -82,4 +82,32 @@ AssetsSource.prototype.toString = function() {
   return this.srcPath + "/" + this.pattern;
 };
 
+/**
+  * Build a string suitable for caching this asset
+  * @returns {String} the cache key
+  */
+AssetsSource.prototype.cacheKey = function(namespace) {
+  function skipSomeKeys(key, value) {
+    // these are set to this.srcPath, which is already included in the cacheKey
+    if (key === "cwd" || key === "root") {
+      return undefined;
+    }
+    // these are added inside glob and always set to true, which happens after this string
+    // is created when glob.sync() is run in #getAssets()
+    // (see #setopts() in glob/common.js)
+    if (key === "nonegate" || key === "nocomment") {
+      return undefined;
+    }
+    return value;
+  }
+
+  return "[" +
+    "httpPrefix=" + (this.httpPrefix ? this.httpPrefix : "") +
+    ";name=" + (this.name ? this.name : (namespace ? namespace : "")) +
+    ";srcPath=" + this.srcPath +
+    ";pattern=" + this.pattern +
+    ";opts=" + JSON.stringify(this.globOpts, skipSomeKeys) +
+    "]";
+};
+
 module.exports = AssetsSource;

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "ensure-symlink": "^1.0.0",
     "fs-extra": "^0.30.0",
     "glob": "^7.1.0",
+    "json-stable-stringify": "^1.0.1",
     "lodash.includes": "^4.3.0",
     "lodash.merge": "^4.6.0",
     "node-sass": "^4.0.0 || ^3.10.1",

--- a/test/test_assets.js
+++ b/test/test_assets.js
@@ -9,6 +9,7 @@ var glob = require("glob");
 
 var Eyeglass = require("../lib");
 var AssetsSource = require("../lib/assets/AssetsSource");
+var AssetsCollection = require("../lib/assets/AssetsCollection");
 
 function escapeBackslash(str) {
   return str.replace(/\\/g, "\\\\");
@@ -984,68 +985,103 @@ describe("assets", function () {
         });
       });
 
-      describe("cache key", function() {
+      describe("cache keys", function() {
         var rootDir = testutils.fixtureDirectory("app_assets");
         var rootDir2 = testutils.fixtureDirectory("app_assets_odd_names");
 
-        it("generates different cacheKey for different httpPrefix", function(done) {
+        it("Assets.cacheKey includes httpPrefix", function(done) {
           var source1 = new AssetsSource(rootDir, {
             httpPrefix: "foo",
           });
           var source2 = new AssetsSource(rootDir, {
+            httpPrefix: "foo",
+          });
+          var source3 = new AssetsSource(rootDir, {
             httpPrefix: "bar",
           });
-          assert.notEqual(source1.cacheKey(), source2.cacheKey());
+          assert.equal(source1.cacheKey(), source2.cacheKey());
+          assert.notEqual(source1.cacheKey(), source3.cacheKey());
           done();
         });
 
-        it("generates different cacheKey for different name", function(done) {
+        it("Assets.cacheKey includes name", function(done) {
           var source1 = new AssetsSource(rootDir, {
             name: "foo",
           });
           var source2 = new AssetsSource(rootDir, {
+            name: "foo",
+          });
+          var source3 = new AssetsSource(rootDir, {
             name: "bar",
           });
-          assert.notEqual(source1.cacheKey(), source2.cacheKey());
+          assert.equal(source1.cacheKey(), source2.cacheKey());
+          assert.notEqual(source1.cacheKey(), source3.cacheKey());
           done();
         });
 
-        it("generates different cacheKey for different namespace", function(done) {
-          var source1 = new AssetsSource(rootDir, {
-          });
-          assert.notEqual(source1.cacheKey("foo"), source1.cacheKey("bar"));
-          done();
-        });
-
-        it("generates different cacheKey for different srcPath", function(done) {
+        it("Assets.cacheKey includes namespace", function(done) {
           var source1 = new AssetsSource(rootDir, {});
-          var source2 = new AssetsSource(rootDir2, {});
-          assert.notEqual(source1.cacheKey(), source2.cacheKey());
+          var source2 = new AssetsSource(rootDir, {});
+          assert.equal(source1.cacheKey("foo"), source2.cacheKey("foo"));
+          assert.notEqual(source1.cacheKey("foo"), source2.cacheKey("bar"));
           done();
         });
 
-        it("generates different cacheKey for different pattern", function(done) {
+        it("Assets.cacheKey includes srcPath", function(done) {
+          var source1 = new AssetsSource(rootDir, {});
+          var source2 = new AssetsSource(rootDir, {});
+          var source3 = new AssetsSource(rootDir2, {});
+          assert.equal(source1.cacheKey(), source2.cacheKey());
+          assert.notEqual(source1.cacheKey(), source3.cacheKey());
+          done();
+        });
+
+        it("Assets.cacheKey includes pattern", function(done) {
           var source1 = new AssetsSource(rootDir, {
             pattern: "images/**/*",
           });
           var source2 = new AssetsSource(rootDir, {
+            pattern: "images/**/*",
+          });
+          var source3 = new AssetsSource(rootDir, {
             pattern: "images/**/*.jpg",
           });
-          assert.notEqual(source1.cacheKey(), source2.cacheKey());
+          assert.equal(source1.cacheKey(), source2.cacheKey());
+          assert.notEqual(source1.cacheKey(), source3.cacheKey());
           done();
         });
 
-        it("generates different cacheKey for different globOpts", function(done) {
-          var source1 = new AssetsSource(rootDir, {
-          });
-          var source2 = new AssetsSource(rootDir, {
+        it("Assets.cacheKey includes globOpts", function(done) {
+          var source1 = new AssetsSource(rootDir, {});
+          var source2 = new AssetsSource(rootDir, {});
+          var source3 = new AssetsSource(rootDir, {
             globOpts: {
               dot: true
             }
           });
-          assert.notEqual(source1.cacheKey(), source2.cacheKey());
+          assert.equal(source1.cacheKey(), source2.cacheKey());
+          assert.notEqual(source1.cacheKey(), source3.cacheKey());
           done();
         });
+
+        it("AssetsCollection.cacheKey includes collection sources", function(done) {
+          var collection1 = new AssetsCollection();
+          var collection2 = new AssetsCollection();
+          var collection3 = new AssetsCollection();
+          var collection4 = new AssetsCollection();
+
+          collection1.addSource(rootDir);
+          collection2.addSource(rootDir);
+          collection3.addSource(rootDir2);
+          collection4.addSource(rootDir);
+          collection4.addSource(rootDir2);
+
+          assert.equal(collection1.cacheKey(), collection2.cacheKey());
+          assert.notEqual(collection1.cacheKey(), collection3.cacheKey());
+          assert.notEqual(collection1.cacheKey(), collection4.cacheKey());
+          done();
+        });
+
       });
     });
   });

--- a/test/test_assets.js
+++ b/test/test_assets.js
@@ -1064,6 +1064,23 @@ describe("assets", function () {
           done();
         });
 
+        it("Assets.cacheKey ignores globOpts that are overridden", function(done) {
+          var source1 = new AssetsSource(rootDir, {});
+          var source2 = new AssetsSource(rootDir, {
+            globOpts: {
+              nonegate: false
+            }
+          });
+          var source3 = new AssetsSource(rootDir, {
+            globOpts: {
+              nonegate: true
+            }
+          });
+          assert.equal(source1.cacheKey(), source2.cacheKey());
+          assert.equal(source1.cacheKey(), source3.cacheKey());
+          done();
+        });
+
         it("AssetsCollection.cacheKey includes collection sources", function(done) {
           var collection1 = new AssetsCollection();
           var collection2 = new AssetsCollection();

--- a/test/test_assets.js
+++ b/test/test_assets.js
@@ -875,6 +875,26 @@ describe("assets", function () {
         testutils.assertCompiles(eg, expected, done);
       });
 
+      it("should keep track of module collections", function() {
+        var rootDir = testutils.fixtureDirectory("app_assets");
+
+        var egMod = new Eyeglass({
+          // file containing '@import "mod-one/assets"'
+          file: path.join(rootDir, "sass", "uses_mod_1.scss"),
+          eyeglass: {
+            root: rootDir,
+            installWithSymlinks: installWithSymlinks,
+            engines: {
+              sass: sass
+            }
+          }
+        });
+
+        assert.ok(egMod.assets.moduleCollections !== undefined);
+        assert.ok(Array.isArray(egMod.assets.moduleCollections));
+        assert.equal(egMod.assets.moduleCollections.length, 1);
+      });
+
       describe("path separator normalization", function() {
         var originalEnv = process.env.EYEGLASS_NORMALIZE_PATHS;
         var merge = require("lodash.merge");
@@ -989,7 +1009,7 @@ describe("assets", function () {
         var rootDir = testutils.fixtureDirectory("app_assets");
         var rootDir2 = testutils.fixtureDirectory("app_assets_odd_names");
 
-        it("Assets.cacheKey includes httpPrefix", function(done) {
+        it("Assets.cacheKey includes httpPrefix", function() {
           var source1 = new AssetsSource(rootDir, {
             httpPrefix: "foo",
           });
@@ -1001,10 +1021,9 @@ describe("assets", function () {
           });
           assert.equal(source1.cacheKey(), source2.cacheKey());
           assert.notEqual(source1.cacheKey(), source3.cacheKey());
-          done();
         });
 
-        it("Assets.cacheKey includes name", function(done) {
+        it("Assets.cacheKey includes name", function() {
           var source1 = new AssetsSource(rootDir, {
             name: "foo",
           });
@@ -1016,27 +1035,24 @@ describe("assets", function () {
           });
           assert.equal(source1.cacheKey(), source2.cacheKey());
           assert.notEqual(source1.cacheKey(), source3.cacheKey());
-          done();
         });
 
-        it("Assets.cacheKey includes namespace", function(done) {
+        it("Assets.cacheKey includes namespace", function() {
           var source1 = new AssetsSource(rootDir, {});
           var source2 = new AssetsSource(rootDir, {});
           assert.equal(source1.cacheKey("foo"), source2.cacheKey("foo"));
           assert.notEqual(source1.cacheKey("foo"), source2.cacheKey("bar"));
-          done();
         });
 
-        it("Assets.cacheKey includes srcPath", function(done) {
+        it("Assets.cacheKey includes srcPath", function() {
           var source1 = new AssetsSource(rootDir, {});
           var source2 = new AssetsSource(rootDir, {});
           var source3 = new AssetsSource(rootDir2, {});
           assert.equal(source1.cacheKey(), source2.cacheKey());
           assert.notEqual(source1.cacheKey(), source3.cacheKey());
-          done();
         });
 
-        it("Assets.cacheKey includes pattern", function(done) {
+        it("Assets.cacheKey includes pattern", function() {
           var source1 = new AssetsSource(rootDir, {
             pattern: "images/**/*",
           });
@@ -1048,10 +1064,9 @@ describe("assets", function () {
           });
           assert.equal(source1.cacheKey(), source2.cacheKey());
           assert.notEqual(source1.cacheKey(), source3.cacheKey());
-          done();
         });
 
-        it("Assets.cacheKey includes globOpts", function(done) {
+        it("Assets.cacheKey includes globOpts", function() {
           var source1 = new AssetsSource(rootDir, {});
           var source2 = new AssetsSource(rootDir, {});
           var source3 = new AssetsSource(rootDir, {
@@ -1061,10 +1076,9 @@ describe("assets", function () {
           });
           assert.equal(source1.cacheKey(), source2.cacheKey());
           assert.notEqual(source1.cacheKey(), source3.cacheKey());
-          done();
         });
 
-        it("Assets.cacheKey ignores globOpts that are overridden", function(done) {
+        it("Assets.cacheKey ignores globOpts that are overridden", function() {
           var source1 = new AssetsSource(rootDir, {});
           var source2 = new AssetsSource(rootDir, {
             globOpts: {
@@ -1078,10 +1092,25 @@ describe("assets", function () {
           });
           assert.equal(source1.cacheKey(), source2.cacheKey());
           assert.equal(source1.cacheKey(), source3.cacheKey());
-          done();
         });
 
-        it("AssetsCollection.cacheKey includes collection sources", function(done) {
+        it("Assets.cacheKey globOpts order doesn't matter", function() {
+          var source1 = new AssetsSource(rootDir, {
+            globOpts: {
+              dot: true,
+              nonull: true
+            }
+          });
+          var source2 = new AssetsSource(rootDir, {
+            globOpts: {
+              nonull: true,
+              dot: true
+            }
+          });
+          assert.equal(source1.cacheKey(), source2.cacheKey());
+        });
+
+        it("AssetsCollection.cacheKey includes collection sources", function() {
           var collection1 = new AssetsCollection();
           var collection2 = new AssetsCollection();
           var collection3 = new AssetsCollection();
@@ -1096,7 +1125,19 @@ describe("assets", function () {
           assert.equal(collection1.cacheKey(), collection2.cacheKey());
           assert.notEqual(collection1.cacheKey(), collection3.cacheKey());
           assert.notEqual(collection1.cacheKey(), collection4.cacheKey());
-          done();
+        });
+
+        it("AssetsCollection.cacheKey source order doesn't matter", function() {
+          var collection1 = new AssetsCollection();
+          var collection2 = new AssetsCollection();
+
+          collection1.addSource(rootDir);
+          collection1.addSource(rootDir2);
+
+          collection2.addSource(rootDir2);
+          collection2.addSource(rootDir);
+
+          assert.equal(collection1.cacheKey(), collection2.cacheKey());
         });
 
       });

--- a/test/test_assets.js
+++ b/test/test_assets.js
@@ -983,6 +983,70 @@ describe("assets", function () {
           });
         });
       });
+
+      describe("cache key", function() {
+        var rootDir = testutils.fixtureDirectory("app_assets");
+        var rootDir2 = testutils.fixtureDirectory("app_assets_odd_names");
+
+        it("generates different cacheKey for different httpPrefix", function(done) {
+          var source1 = new AssetsSource(rootDir, {
+            httpPrefix: "foo",
+          });
+          var source2 = new AssetsSource(rootDir, {
+            httpPrefix: "bar",
+          });
+          assert.notEqual(source1.cacheKey(), source2.cacheKey());
+          done();
+        });
+
+        it("generates different cacheKey for different name", function(done) {
+          var source1 = new AssetsSource(rootDir, {
+            name: "foo",
+          });
+          var source2 = new AssetsSource(rootDir, {
+            name: "bar",
+          });
+          assert.notEqual(source1.cacheKey(), source2.cacheKey());
+          done();
+        });
+
+        it("generates different cacheKey for different namespace", function(done) {
+          var source1 = new AssetsSource(rootDir, {
+          });
+          assert.notEqual(source1.cacheKey("foo"), source1.cacheKey("bar"));
+          done();
+        });
+
+        it("generates different cacheKey for different srcPath", function(done) {
+          var source1 = new AssetsSource(rootDir, {});
+          var source2 = new AssetsSource(rootDir2, {});
+          assert.notEqual(source1.cacheKey(), source2.cacheKey());
+          done();
+        });
+
+        it("generates different cacheKey for different pattern", function(done) {
+          var source1 = new AssetsSource(rootDir, {
+            pattern: "images/**/*",
+          });
+          var source2 = new AssetsSource(rootDir, {
+            pattern: "images/**/*.jpg",
+          });
+          assert.notEqual(source1.cacheKey(), source2.cacheKey());
+          done();
+        });
+
+        it("generates different cacheKey for different globOpts", function(done) {
+          var source1 = new AssetsSource(rootDir, {
+          });
+          var source2 = new AssetsSource(rootDir, {
+            globOpts: {
+              dot: true
+            }
+          });
+          assert.notEqual(source1.cacheKey(), source2.cacheKey());
+          done();
+        });
+      });
     });
   });
 });


### PR DESCRIPTION
Adds a few things to allow build tools to cache the Scss generated in asAssetImport(), since otherwise this is done over and over:

- keeps a list of references to the AssetsCollections produced for modules
- adds functions to produce cache keys for AssetsSource and AssetsCollection