### PR TITLE
POC cache modules, the same way node’s require caches modules.

### DIFF
--- a/lib/modules/EyeglassModules.js
+++ b/lib/modules/EyeglassModules.js
@@ -410,17 +410,35 @@ function getFinalModule(name) {
   * @param   {Boolean} isRoot - whether or not it's the root of the project
   * @returns {Object} the resolved module definition
   */
+
+var MODULE_CACHE = Object.create(null);
+
 function resolveModule(pkgPath, isRoot) {
+  var key = "" + pkgPath  + "!" + isRoot;
+
+  if (key in MODULE_CACHE) {
+    return MODULE_CACHE[key];
+  }
+
   var pkg = packageUtils.getPackage(pkgPath);
   var isEyeglassMod = EyeglassModule.isEyeglassModule(pkg.data);
+  var mod;
+
   // if the module is an eyeglass module OR it's the root project
   if (isEyeglassMod || (pkg.data && isRoot)) {
     // return a module reference
-    return new EyeglassModule({
+    mod = new EyeglassModule({
       isEyeglassModule: isEyeglassMod,
       path: path.dirname(pkg.path)
     }, discoverModules.bind(this), isRoot);
+
+  } else {
+    mod = undefined;
   }
+
+  MODULE_CACHE[key] = mod;
+
+  return mod;
 }
 
 /**


### PR DESCRIPTION
This yields a pretty non-trivial improvement. But obviously needs to be implemented more carefully. Today (in this spike) the `this` in `resolveModule` is not properly considered, and may lead to issue…


Opening this to further conversation on the topic.

- [ ] ensure this doesn't actually screw anything up
- [ ] implement properly
- [ ] tests
- [ ] cache purge, maybe something similar to `require.entries`