### PR TITLE
add module discovery caching per #187

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,24 @@ Manually added eyeglass modules will only be able to be imported by the
 main application's sass files. Dependencies between such manual modules
 are not currently supported.
 
+## Module Caching
+
+By default, eyeglass uses a global module cache to help improve the performance of module discovery. This should be safe for almost all use cases, but if you modify your `node_modules` directory and/or `package.json` dependencies during build time, this may cause issues. You can opt-out of the by passing the eyeglass option `useGlobalModuleCache: false`.
+
+```js
+eyeglass({
+  // sass options
+  // ...
+  eyeglass: {
+    // eyeglass options
+    // ...
+    useGlobalModuleCache: false
+  }
+});
+```
+
+Alternatively, you can programmatically purge the global cache using `eyeglass.modules.cache.modules.purge()`.
+
 # Working with assets
 
 It's quite common to need to refer to assets from within your

--- a/lib/assets/Assets.js
+++ b/lib/assets/Assets.js
@@ -124,7 +124,8 @@ Assets.prototype.resolveAsset = function($assetsMap, $uri, cb) {
             cb(error);
           } else {
             if (file) {
-              debug.assets(
+              /* istanbul ignore next - don't test debug */
+              debug.assets && debug.assets(
                 "%s resolved to %s with URI %s",
                 originalUri,
                 path.relative(options.root, file),

--- a/lib/importers/FSImporter.js
+++ b/lib/importers/FSImporter.js
@@ -20,6 +20,7 @@ function FSImporter(eyeglass, sass, options, fallbackImporter) {
       } else {
         absolutePath = path.resolve(path.dirname(prev));
       }
+      /* istanbul ignore else - TODO: revisit this */
       if (absolutePath) {
         var sassContents = '@import "eyeglass/fs"; @include fs-register-path('
                          + identifier + ', "' + absolutePath + '");';

--- a/lib/importers/ImportUtilities.js
+++ b/lib/importers/ImportUtilities.js
@@ -28,7 +28,8 @@ ImportUtilities.createImporter = function(importer) {
 ImportUtilities.prototype.importOnce = function(data, done) {
   if (this.options.eyeglass.enableImportOnce && this.context.eyeglass.imported[data.file]) {
     // log that we've already imported this file
-    debug.import("%s was already imported", data.file);
+    /* istanbul ignore next - don't test debug */
+    debug.import && debug.import("%s was already imported", data.file);
     done({contents: "", file: "already-imported:" + data.file});
   } else {
     this.context.eyeglass.imported[data.file] = true;

--- a/lib/index.js
+++ b/lib/index.js
@@ -23,7 +23,11 @@ function Eyeglass(options, deprecatedNodeSassArg) {
 
   this.options = new Options(options, this.deprecate, deprecatedNodeSassArg);
   this.assets = new Assets(this, this.options.eyeglass.engines.sass);
-  this.modules = new EyeglassModules(this.options.eyeglass.root, this.options.eyeglass.modules);
+  this.modules = new EyeglassModules(
+    this.options.eyeglass.root,
+    this.options.eyeglass.modules,
+    this.options.eyeglass.useGlobalModuleCache
+  );
 
   fs.mkdirpSync(this.options.eyeglass.cacheDir);
 

--- a/lib/modules/EyeglassModules.js
+++ b/lib/modules/EyeglassModules.js
@@ -12,14 +12,17 @@ var archy = require("archy");
 var fs = require("fs");
 var URI = require("../util/URI");
 
+var globalModuleCache = new SimpleCache();
+
 /**
   * Discovers all of the modules for a given directory
   *
   * @constructor
   * @param   {String} dir - the directory to discover modules in
   * @param   {Array} modules - the explicit modules to include
+  * @param   {Boolean} useGlobalModuleCache - whether or not to use the global module cache
   */
-function EyeglassModules(dir, modules) {
+function EyeglassModules(dir, modules, useGlobalModuleCache) {
   this.issues = {
     dependencies: {
       versions: [],
@@ -33,7 +36,7 @@ function EyeglassModules(dir, modules) {
 
   this.cache = {
     access: new SimpleCache(),
-    modules: new SimpleCache()
+    modules: useGlobalModuleCache ? globalModuleCache : new SimpleCache()
   };
 
   // find the nearest package.json for the given directory
@@ -260,11 +263,7 @@ function canAccessModule(name, origin) {
   var canAccessFrom = function canAccessFrom(origin) {
     // find the nearest package for the origin
     var pkg = packageUtils.findNearestPackage(origin);
-    var cacheKey = JSON.stringify({
-      pkg: pkg,
-      origin: origin
-    });
-
+    var cacheKey = pkg + "!" + origin;
     return this.cache.access.getOrElse(cacheKey, function() {
       // find all the branches that match the origin
       var branches = findBranchesByPath({
@@ -410,16 +409,19 @@ function getFinalModule(name) {
   * @returns {Object} the resolved module definition
   */
 function resolveModule(pkgPath, isRoot) {
-  var pkg = packageUtils.getPackage(pkgPath);
-  var isEyeglassMod = EyeglassModule.isEyeglassModule(pkg.data);
-  // if the module is an eyeglass module OR it's the root project
-  if (isEyeglassMod || (pkg.data && isRoot)) {
-    // return a module reference
-    return new EyeglassModule({
-      isEyeglassModule: isEyeglassMod,
-      path: path.dirname(pkg.path)
-    }, discoverModules.bind(this), isRoot);
-  }
+  var cacheKey = "resolveModule~" + pkgPath + "!" + isRoot;
+  return this.cache.modules.getOrElse(cacheKey, function() {
+    var pkg = packageUtils.getPackage(pkgPath);
+    var isEyeglassMod = EyeglassModule.isEyeglassModule(pkg.data);
+    // if the module is an eyeglass module OR it's the root project
+    if (isEyeglassMod || (pkg.data && isRoot)) {
+      // return a module reference
+      return new EyeglassModule({
+        isEyeglassModule: isEyeglassMod,
+        path: path.dirname(pkg.path)
+      }, discoverModules.bind(this), isRoot);
+    }
+  }.bind(this));
 }
 
 /**
@@ -441,10 +443,13 @@ function getEyeglassSelf() {
   *
   * @see resolve()
   */
-function resolveModulePackage() {
-  try {
-    return resolve.apply(null, arguments);
-  } catch (e) {}
+function resolveModulePackage(id, parent, parentDir) {
+  var cacheKey = "resolveModulePackage~" + id + "!" + parent + "!" + parentDir;
+  return this.cache.modules.getOrElse(cacheKey, function() {
+    try {
+      return resolve(id, parent, parentDir);
+    } catch (e) {}
+  });
 }
 
 /**
@@ -453,58 +458,52 @@ function resolveModulePackage() {
   * @param    {Object} options - the options to use
   * @returns  {Object} the discovered modules
   */
- function discoverModules(options) {
+function discoverModules(options) {
   var pkg = options.pkg || packageUtils.getPackage(options.dir);
-  var cacheKey = JSON.stringify({
-    options: options,
-    pkg: pkg
-  });
+  var dependencies = {};
 
-  return this.cache.modules.getOrElse(cacheKey, function() {
-    var dependencies = {};
+  // if there's package.json contents...
+  /* istanbul ignore else - defensive conditional, don't care about else-case */
+  if (pkg.data) {
+    merge(
+      dependencies,
+      // always include the `dependencies` and `peerDependencies`
+      pkg.data.dependencies,
+      pkg.data.peerDependencies,
+      // only include the `devDependencies` if isRoot
+      options.isRoot && pkg.data.devDependencies
+    );
+  }
 
-    // if there's package.json contents...
-    /* istanbul ignore else - defensive conditional, don't care about else-case */
-    if (pkg.data) {
-      merge(
-        dependencies,
-        // always include the `dependencies` and `peerDependencies`
-        pkg.data.dependencies,
-        pkg.data.peerDependencies,
-        // only include the `devDependencies` if isRoot
-        options.isRoot && pkg.data.devDependencies
-      );
-    }
-
-    // for each dependency...
-    dependencies = Object.keys(dependencies).reduce(function(modules, dependency) {
-      // resolve the package.json
-      var resolvedPkg = resolveModulePackage(
-        packageUtils.getPackagePath(dependency),
-        pkg.path,
-        URI.system(options.dir)
-      );
-      if (!resolvedPkg) {
-        // if it didn't resolve, they likely didn't `npm install` it correctly
-        this.issues.dependencies.missing.push(dependency);
-      } else {
-        // otherwise, set it onto our collection
-        var resolvedModule = resolveModule.call(this, resolvedPkg);
-        if (resolvedModule) {
-          modules[resolvedModule.name] = resolvedModule;
-        }
+  // for each dependency...
+  dependencies = Object.keys(dependencies).reduce(function(modules, dependency) {
+    // resolve the package.json
+    var resolvedPkg = resolveModulePackage.call(
+      this,
+      packageUtils.getPackagePath(dependency),
+      pkg.path,
+      URI.system(options.dir)
+    );
+    if (!resolvedPkg) {
+      // if it didn't resolve, they likely didn't `npm install` it correctly
+      this.issues.dependencies.missing.push(dependency);
+    } else {
+      // otherwise, set it onto our collection
+      var resolvedModule = resolveModule.call(this, resolvedPkg);
+      if (resolvedModule) {
+        modules[resolvedModule.name] = resolvedModule;
       }
-      return modules;
-    }.bind(this), {});
-
-    // if it's the root...
-    if (options.isRoot) {
-      // ensure eyeglass itself is a direct dependency
-      dependencies.eyeglass = dependencies.eyeglass || getEyeglassSelf.call(this, options);
     }
+    return modules;
+  }.bind(this), {});
 
-    return Object.keys(dependencies).length ? dependencies : null;
-  }.bind(this));
+  // if it's the root...
+  if (options.isRoot) {
+    // ensure eyeglass itself is a direct dependency
+    dependencies.eyeglass = dependencies.eyeglass || getEyeglassSelf.call(this, options);
+  }
+
+  return Object.keys(dependencies).length ? dependencies : null;
 }
 
 module.exports = EyeglassModules;

--- a/lib/modules/EyeglassModules.js
+++ b/lib/modules/EyeglassModules.js
@@ -409,7 +409,7 @@ function getFinalModule(name) {
   * @returns {Object} the resolved module definition
   */
 function resolveModule(pkgPath, isRoot) {
-  var cacheKey = "resolveModule~" + pkgPath + "!" + isRoot;
+  var cacheKey = "resolveModule~" + pkgPath + "!" + !!isRoot;
   return this.cache.modules.getOrElse(cacheKey, function() {
     var pkg = packageUtils.getPackage(pkgPath);
     var isEyeglassMod = EyeglassModule.isEyeglassModule(pkg.data);

--- a/lib/modules/EyeglassModules.js
+++ b/lib/modules/EyeglassModules.js
@@ -3,6 +3,7 @@
 var resolve = require("../util/resolve");
 var packageUtils = require("../util/package");
 var EyeglassModule = require("./EyeglassModule");
+var SimpleCache = require("../util/SimpleCache");
 var debug = require("../util/debug");
 var path = require("path");
 var merge = require("lodash.merge");
@@ -31,7 +32,8 @@ function EyeglassModules(dir, modules) {
   };
 
   this.cache = {
-    access: {}
+    access: new SimpleCache(),
+    modules: new SimpleCache()
   };
 
   // find the nearest package.json for the given directory
@@ -70,7 +72,8 @@ function EyeglassModules(dir, modules) {
   // check for any issues we may have encountered
   checkForIssues.call(this);
 
-  debug.modules("discovered modules\n\t" + this.getGraph().replace(/\n/g, "\n\t"));
+  /* istanbul ignore next - don't test debug */
+  debug.modules && debug.modules("discovered modules\n\t" + this.getGraph().replace(/\n/g, "\n\t"));
 }
 
 /**
@@ -257,39 +260,34 @@ function canAccessModule(name, origin) {
   var canAccessFrom = function canAccessFrom(origin) {
     // find the nearest package for the origin
     var pkg = packageUtils.findNearestPackage(origin);
-
-    var cache = this.cache.access;
-    cache[name] = cache[name] || {};
-
-    // check for cached result
-    if (cache[name][pkg] !== undefined) {
-      return cache[name][pkg];
-    }
-
-    // find all the branches that match the origin
-    var branches = findBranchesByPath({
-      dependencies: this.tree
-    }, pkg);
-
-    var canAccess = branches.some(function(branch) {
-      // if the reference is to itself (branch.name)
-      // OR it's an immediate dependency (branch.dependencies[name])
-      if (branch.name === name || branch.dependencies && branch.dependencies[name]) {
-        return true;
-      }
+    var cacheKey = JSON.stringify({
+      pkg: pkg,
+      origin: origin
     });
 
-    debug.import(
-      "%s can%s be imported from %s",
-      name,
-      (canAccess ? "" : "not"),
-      origin
-    );
+    return this.cache.access.getOrElse(cacheKey, function() {
+      // find all the branches that match the origin
+      var branches = findBranchesByPath({
+        dependencies: this.tree
+      }, pkg);
 
-    // cache it for future lookups
-    cache[name][pkg] = canAccess;
+      var canAccess = branches.some(function(branch) {
+        // if the reference is to itself (branch.name)
+        // OR it's an immediate dependency (branch.dependencies[name])
+        if (branch.name === name || branch.dependencies && branch.dependencies[name]) {
+          return true;
+        }
+      });
 
-    return canAccess;
+      /* istanbul ignore next - don't test debug */
+      debug.import && debug.import(
+        "%s can%s be imported from %s",
+        name,
+        (canAccess ? "" : "not"),
+        origin
+      );
+      return canAccess;
+    }.bind(this));
   }.bind(this);
 
   // check if we can access from the origin...
@@ -346,7 +344,8 @@ function getDependencyVersionIssues(modules, finalModule) {
   return modules.map(function(mod) {
     // if the versions are not identical, log it
     if (mod.version !== finalModule.version) {
-      debug.modules(
+      /* istanbul ignore next - don't test debug */
+      debug.modules && debug.modules(
         "asked for %s@%s but using %s",
         mod.name,
         mod.version,
@@ -454,53 +453,58 @@ function resolveModulePackage() {
   * @param    {Object} options - the options to use
   * @returns  {Object} the discovered modules
   */
-function discoverModules(options) {
+ function discoverModules(options) {
   var pkg = options.pkg || packageUtils.getPackage(options.dir);
+  var cacheKey = JSON.stringify({
+    options: options,
+    pkg: pkg
+  });
 
-  // get the collection of dependencies
-  var dependencies = {};
+  return this.cache.modules.getOrElse(cacheKey, function() {
+    var dependencies = {};
 
-  // if there's package.json contents...
-  /* istanbul ignore else - defensive conditional, don't care about else-case */
-  if (pkg.data) {
-    merge(
-      dependencies,
-      // always include the `dependencies` and `peerDependencies`
-      pkg.data.dependencies,
-      pkg.data.peerDependencies,
-      // only include the `devDependencies` if isRoot
-      options.isRoot && pkg.data.devDependencies
-    );
-  }
-
-  // for each dependency...
-  dependencies = Object.keys(dependencies).reduce(function(modules, dependency) {
-    // resolve the package.json
-    var resolvedPkg = resolveModulePackage(
-      packageUtils.getPackagePath(dependency),
-      pkg.path,
-      URI.system(options.dir)
-    );
-    if (!resolvedPkg) {
-      // if it didn't resolve, they likely didn't `npm install` it correctly
-      this.issues.dependencies.missing.push(dependency);
-    } else {
-      // otherwise, set it onto our collection
-      var resolvedModule = resolveModule.call(this, resolvedPkg);
-      if (resolvedModule) {
-        modules[resolvedModule.name] = resolvedModule;
-      }
+    // if there's package.json contents...
+    /* istanbul ignore else - defensive conditional, don't care about else-case */
+    if (pkg.data) {
+      merge(
+        dependencies,
+        // always include the `dependencies` and `peerDependencies`
+        pkg.data.dependencies,
+        pkg.data.peerDependencies,
+        // only include the `devDependencies` if isRoot
+        options.isRoot && pkg.data.devDependencies
+      );
     }
-    return modules;
-  }.bind(this), {});
 
-  // if it's the root...
-  if (options.isRoot) {
-    // ensure eyeglass itself is a direct dependency
-    dependencies.eyeglass = dependencies.eyeglass || getEyeglassSelf.call(this, options);
-  }
+    // for each dependency...
+    dependencies = Object.keys(dependencies).reduce(function(modules, dependency) {
+      // resolve the package.json
+      var resolvedPkg = resolveModulePackage(
+        packageUtils.getPackagePath(dependency),
+        pkg.path,
+        URI.system(options.dir)
+      );
+      if (!resolvedPkg) {
+        // if it didn't resolve, they likely didn't `npm install` it correctly
+        this.issues.dependencies.missing.push(dependency);
+      } else {
+        // otherwise, set it onto our collection
+        var resolvedModule = resolveModule.call(this, resolvedPkg);
+        if (resolvedModule) {
+          modules[resolvedModule.name] = resolvedModule;
+        }
+      }
+      return modules;
+    }.bind(this), {});
 
-  return Object.keys(dependencies).length ? dependencies : null;
+    // if it's the root...
+    if (options.isRoot) {
+      // ensure eyeglass itself is a direct dependency
+      dependencies.eyeglass = dependencies.eyeglass || getEyeglassSelf.call(this, options);
+    }
+
+    return Object.keys(dependencies).length ? dependencies : null;
+  }.bind(this));
 }
 
 module.exports = EyeglassModules;

--- a/lib/modules/ModuleFunctions.js
+++ b/lib/modules/ModuleFunctions.js
@@ -44,7 +44,8 @@ function ModuleFunctions(eyeglass, sass, options, existingFunctions) {
     }
 
     // log any functions found in this module
-    debug.functions(
+    /* istanbul ignore next - don't test debug */
+    debug.functions && debug.functions(
       "functions discovered in module %s:%s%s",
       mod.name,
       DELIM,
@@ -60,7 +61,8 @@ function ModuleFunctions(eyeglass, sass, options, existingFunctions) {
   functions = syncFn.all(functions);
 
   // log all the functions we discovered
-  debug.functions(
+  /* istanbul ignore next - don't test debug */
+  debug.functions && debug.functions(
     "all discovered functions:%s%s",
     DELIM,
     Object.keys(functions).join(DELIM)

--- a/lib/util/Options.js
+++ b/lib/util/Options.js
@@ -124,6 +124,9 @@ function defaultEyeglassOptions(options) {
   // default enableImportOnce
   options.enableImportOnce = defaultValue(options.enableImportOnce, true);
 
+  // use global module caching by default
+  options.useGlobalModuleCache = defaultValue(options.useGlobalModuleCache, true);
+
   return options;
 }
 

--- a/lib/util/SimpleCache.js
+++ b/lib/util/SimpleCache.js
@@ -1,0 +1,64 @@
+"use strict";
+
+/**
+  * A simple caching implementation
+  */
+function SimpleCache() {
+  this.cache = {};
+}
+
+/**
+  * Returns the current cached value
+  *
+  * @param   {String} key - they cache key to lookup
+  * @returns {*} the cached value
+  */
+SimpleCache.prototype.get = function(key) {
+  return this.cache[key];
+};
+
+/**
+  * Sets the cached value
+  *
+  * @param    {String} key - they cache key to update
+  * @param    {*} value - they value to store
+  */
+SimpleCache.prototype.set = function(key, value) {
+  this.cache[key] = value;
+};
+
+/**
+  * Whether or not the cache has a value for a given key
+  *
+  * @param    {String} key - they cache key to lookup
+  * @returns  {Boolean} whether or not the key is set
+  */
+SimpleCache.prototype.has = function(key) {
+  return this.cache.hasOwnProperty(key);
+};
+
+/**
+  * Gets the current value from the cache (if it exists), otherwise invokes the callback
+  *
+  * @param    {String} key - they cache key lookup
+  * @param    {Function} callback - the callback to be invoked when the key is not in the cache
+  * @returns
+  */
+SimpleCache.prototype.getOrElse = function(key, callback) {
+  // if we do not yet have a result, generate it and store it in the cache
+  if (!this.has(key)) {
+    this.set(key, callback());
+  }
+
+  // return the result from the cache
+  return this.get(key);
+};
+
+/**
+  * Purges the cache
+  */
+SimpleCache.prototype.purge = function(key) {
+  this.cache = {};
+};
+
+module.exports = SimpleCache;

--- a/lib/util/debug.js
+++ b/lib/util/debug.js
@@ -4,6 +4,10 @@ var debug = require("debug");
 var PREFIX = "eyeglass:";
 
 module.exports = ["import", "modules", "functions", "assets"].reduce(function(obj, item) {
-  obj[item] = debug(PREFIX + item);
+  var namespace = PREFIX + item;
+  /* istanbul ignore if - don't test debug */
+  if (debug.enabled(namespace)) {
+    obj[item] = debug(namespace);
+  }
   return obj;
 }, {});

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,19116 @@
+{
+  "name": "eyeglass",
+  "version": "1.2.1",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "ansi-gray": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/ansi-gray/-/ansi-gray-0.1.1.tgz",
+      "integrity": "sha1-KWLPVOyXksSFEKPetSRDaGHvclE=",
+      "dev": true,
+      "requires": {
+        "ansi-wrap": "0.1.0"
+      }
+    },
+    "ansi-wrap": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/ansi-wrap/-/ansi-wrap-0.1.0.tgz",
+      "integrity": "sha1-qCJQ3bABXponyoLoLqYDu/pF768=",
+      "dev": true
+    },
+    "archy": {
+      "version": "1.0.0",
+      "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/archy/-/archy-1.0.0.tgz",
+      "integrity": "sha1-+cjBN1fMHde8N5rHeyxipcKGjEA="
+    },
+    "color-support": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/color-support/-/color-support-1.1.3.tgz",
+      "integrity": "sha512-qiBjkpbMLO/HL68y+lh4q0/O1MZFj2RX6X/KmMa3+gJD3z+WwI1ZzDHysvqHGS3mP6mznPckpXmw1nI9cJjyRg==",
+      "dev": true
+    },
+    "deasync": {
+      "version": "0.1.8",
+      "resolved": "https://registry.npmjs.org/deasync/-/deasync-0.1.8.tgz",
+      "integrity": "sha1-3lP+/f3f9muQGzQAZsLSPNbwZcY=",
+      "requires": {
+        "bindings": "1.2.1",
+        "nan": "2.4.0"
+      },
+      "dependencies": {
+        "bindings": {
+          "version": "1.2.1",
+          "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.2.1.tgz",
+          "integrity": "sha1-FK1hE4EtLTfXLme0ystLtyZQXxE="
+        },
+        "nan": {
+          "version": "2.4.0",
+          "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/nan/-/nan-2.4.0.tgz",
+          "integrity": "sha1-+zxZ1F/k7/4hXwuJD4rfbrMtIjI="
+        }
+      }
+    },
+    "debug": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
+      "integrity": "sha1-+HBX6ZWxofauaklgZkE3vFbwOdo=",
+      "requires": {
+        "ms": "0.7.1"
+      },
+      "dependencies": {
+        "ms": {
+          "version": "0.7.1",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
+          "integrity": "sha1-nNE8A62/8ltl7/3nzoZO6VIBcJg="
+        }
+      }
+    },
+    "eslint": {
+      "version": "1.10.3",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-1.10.3.tgz",
+      "integrity": "sha1-+xmpGxPBWAgrvKKUsX2Xm8g1Ogo=",
+      "dev": true,
+      "requires": {
+        "chalk": "1.1.3",
+        "concat-stream": "1.5.2",
+        "debug": "2.2.0",
+        "doctrine": "0.7.2",
+        "escape-string-regexp": "1.0.5",
+        "escope": "3.6.0",
+        "espree": "2.2.5",
+        "estraverse": "4.2.0",
+        "estraverse-fb": "1.3.1",
+        "esutils": "2.0.2",
+        "file-entry-cache": "1.3.1",
+        "glob": "5.0.15",
+        "globals": "8.18.0",
+        "handlebars": "4.0.5",
+        "inquirer": "0.11.4",
+        "is-my-json-valid": "2.15.0",
+        "is-resolvable": "1.0.0",
+        "js-yaml": "3.4.5",
+        "json-stable-stringify": "1.0.1",
+        "lodash.clonedeep": "3.0.2",
+        "lodash.merge": "3.3.2",
+        "lodash.omit": "3.1.0",
+        "minimatch": "3.0.3",
+        "mkdirp": "0.5.1",
+        "object-assign": "4.1.0",
+        "optionator": "0.6.0",
+        "path-is-absolute": "1.0.1",
+        "path-is-inside": "1.0.2",
+        "shelljs": "0.5.3",
+        "strip-json-comments": "1.0.4",
+        "text-table": "0.2.0",
+        "user-home": "2.0.0",
+        "xml-escape": "1.0.0"
+      },
+      "dependencies": {
+        "chalk": {
+          "version": "1.1.3",
+          "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/chalk/-/chalk-1.1.3.tgz",
+          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "2.2.1",
+            "escape-string-regexp": "1.0.5",
+            "has-ansi": "2.0.0",
+            "strip-ansi": "3.0.1",
+            "supports-color": "2.0.0"
+          },
+          "dependencies": {
+            "ansi-styles": {
+              "version": "2.2.1",
+              "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/ansi-styles/-/ansi-styles-2.2.1.tgz",
+              "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+              "dev": true
+            },
+            "has-ansi": {
+              "version": "2.0.0",
+              "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/has-ansi/-/has-ansi-2.0.0.tgz",
+              "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
+              "dev": true,
+              "requires": {
+                "ansi-regex": "2.0.0"
+              },
+              "dependencies": {
+                "ansi-regex": {
+                  "version": "2.0.0",
+                  "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/ansi-regex/-/ansi-regex-2.0.0.tgz",
+                  "integrity": "sha1-xQYbbg74qBd15Q9dZhUb9r83EQc=",
+                  "dev": true
+                }
+              }
+            },
+            "strip-ansi": {
+              "version": "3.0.1",
+              "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/strip-ansi/-/strip-ansi-3.0.1.tgz",
+              "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+              "dev": true,
+              "requires": {
+                "ansi-regex": "2.0.0"
+              },
+              "dependencies": {
+                "ansi-regex": {
+                  "version": "2.0.0",
+                  "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/ansi-regex/-/ansi-regex-2.0.0.tgz",
+                  "integrity": "sha1-xQYbbg74qBd15Q9dZhUb9r83EQc=",
+                  "dev": true
+                }
+              }
+            },
+            "supports-color": {
+              "version": "2.0.0",
+              "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/supports-color/-/supports-color-2.0.0.tgz",
+              "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+              "dev": true
+            }
+          }
+        },
+        "concat-stream": {
+          "version": "1.5.2",
+          "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.5.2.tgz",
+          "integrity": "sha1-cIl4Yk2FavQaWnQd790mHadSwmY=",
+          "dev": true,
+          "requires": {
+            "inherits": "2.0.3",
+            "readable-stream": "2.0.6",
+            "typedarray": "0.0.6"
+          },
+          "dependencies": {
+            "inherits": {
+              "version": "2.0.3",
+              "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/inherits/-/inherits-2.0.3.tgz",
+              "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+              "dev": true
+            },
+            "readable-stream": {
+              "version": "2.0.6",
+              "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/readable-stream/-/readable-stream-2.0.6.tgz",
+              "integrity": "sha1-j5A0HmilPMySh4jaz80Rs265t44=",
+              "dev": true,
+              "requires": {
+                "core-util-is": "1.0.2",
+                "inherits": "2.0.3",
+                "isarray": "1.0.0",
+                "process-nextick-args": "1.0.7",
+                "string_decoder": "0.10.31",
+                "util-deprecate": "1.0.2"
+              },
+              "dependencies": {
+                "core-util-is": {
+                  "version": "1.0.2",
+                  "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/core-util-is/-/core-util-is-1.0.2.tgz",
+                  "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
+                  "dev": true
+                },
+                "isarray": {
+                  "version": "1.0.0",
+                  "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/isarray/-/isarray-1.0.0.tgz",
+                  "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+                  "dev": true
+                },
+                "process-nextick-args": {
+                  "version": "1.0.7",
+                  "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
+                  "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M=",
+                  "dev": true
+                },
+                "string_decoder": {
+                  "version": "0.10.31",
+                  "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+                  "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
+                  "dev": true
+                },
+                "util-deprecate": {
+                  "version": "1.0.2",
+                  "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/util-deprecate/-/util-deprecate-1.0.2.tgz",
+                  "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
+                  "dev": true
+                }
+              }
+            },
+            "typedarray": {
+              "version": "0.0.6",
+              "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
+              "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
+              "dev": true
+            }
+          }
+        },
+        "doctrine": {
+          "version": "0.7.2",
+          "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-0.7.2.tgz",
+          "integrity": "sha1-fLhgNZujvpDgQLJrcpzkv6ZUxSM=",
+          "dev": true,
+          "requires": {
+            "esutils": "1.1.6",
+            "isarray": "0.0.1"
+          },
+          "dependencies": {
+            "esutils": {
+              "version": "1.1.6",
+              "resolved": "https://registry.npmjs.org/esutils/-/esutils-1.1.6.tgz",
+              "integrity": "sha1-wBzKqa5LiXxtDD4hCuUvPHqEQ3U=",
+              "dev": true
+            },
+            "isarray": {
+              "version": "0.0.1",
+              "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+              "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
+              "dev": true
+            }
+          }
+        },
+        "escape-string-regexp": {
+          "version": "1.0.5",
+          "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+          "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+          "dev": true
+        },
+        "escope": {
+          "version": "3.6.0",
+          "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/escope/-/escope-3.6.0.tgz",
+          "integrity": "sha1-4Bl16BJ4GhY6ba392AOY3GTIicM=",
+          "dev": true,
+          "requires": {
+            "es6-map": "0.1.4",
+            "es6-weak-map": "2.0.1",
+            "esrecurse": "4.1.0",
+            "estraverse": "4.2.0"
+          },
+          "dependencies": {
+            "es6-map": {
+              "version": "0.1.4",
+              "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/es6-map/-/es6-map-0.1.4.tgz",
+              "integrity": "sha1-o0sUe+IkdzpNfagHJ5TO+jYyuJc=",
+              "dev": true,
+              "requires": {
+                "d": "0.1.1",
+                "es5-ext": "0.10.12",
+                "es6-iterator": "2.0.0",
+                "es6-set": "0.1.4",
+                "es6-symbol": "3.1.0",
+                "event-emitter": "0.3.4"
+              },
+              "dependencies": {
+                "d": {
+                  "version": "0.1.1",
+                  "resolved": "https://registry.npmjs.org/d/-/d-0.1.1.tgz",
+                  "integrity": "sha1-2hhMU10Y2O57oqoim5FACfrhEwk=",
+                  "dev": true,
+                  "requires": {
+                    "es5-ext": "0.10.12"
+                  }
+                },
+                "es5-ext": {
+                  "version": "0.10.12",
+                  "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/es5-ext/-/es5-ext-0.10.12.tgz",
+                  "integrity": "sha1-qoRkHU23a2Krul5F/YBey6sUAEc=",
+                  "dev": true,
+                  "requires": {
+                    "es6-iterator": "2.0.0",
+                    "es6-symbol": "3.1.0"
+                  }
+                },
+                "es6-iterator": {
+                  "version": "2.0.0",
+                  "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/es6-iterator/-/es6-iterator-2.0.0.tgz",
+                  "integrity": "sha1-vZaFZ9YWNeM8C4BydhPJy0sJa6w=",
+                  "dev": true,
+                  "requires": {
+                    "d": "0.1.1",
+                    "es5-ext": "0.10.12",
+                    "es6-symbol": "3.1.0"
+                  }
+                },
+                "es6-set": {
+                  "version": "0.1.4",
+                  "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/es6-set/-/es6-set-0.1.4.tgz",
+                  "integrity": "sha1-lRa2dhwpZLkv9HlFYjOiR9xwfOg=",
+                  "dev": true,
+                  "requires": {
+                    "d": "0.1.1",
+                    "es5-ext": "0.10.12",
+                    "es6-iterator": "2.0.0",
+                    "es6-symbol": "3.1.0",
+                    "event-emitter": "0.3.4"
+                  }
+                },
+                "es6-symbol": {
+                  "version": "3.1.0",
+                  "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/es6-symbol/-/es6-symbol-3.1.0.tgz",
+                  "integrity": "sha1-lEgcZV56fK2C66gy2X1UM0ltf/o=",
+                  "dev": true,
+                  "requires": {
+                    "d": "0.1.1",
+                    "es5-ext": "0.10.12"
+                  }
+                },
+                "event-emitter": {
+                  "version": "0.3.4",
+                  "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/event-emitter/-/event-emitter-0.3.4.tgz",
+                  "integrity": "sha1-jWPd+0z+H647MsomXExyAiIIC7U=",
+                  "dev": true,
+                  "requires": {
+                    "d": "0.1.1",
+                    "es5-ext": "0.10.12"
+                  }
+                }
+              }
+            },
+            "es6-weak-map": {
+              "version": "2.0.1",
+              "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/es6-weak-map/-/es6-weak-map-2.0.1.tgz",
+              "integrity": "sha1-DSu9iCfrX7S6j5f7/qUNQ9sh6oE=",
+              "dev": true,
+              "requires": {
+                "d": "0.1.1",
+                "es5-ext": "0.10.12",
+                "es6-iterator": "2.0.0",
+                "es6-symbol": "3.1.0"
+              },
+              "dependencies": {
+                "d": {
+                  "version": "0.1.1",
+                  "resolved": "https://registry.npmjs.org/d/-/d-0.1.1.tgz",
+                  "integrity": "sha1-2hhMU10Y2O57oqoim5FACfrhEwk=",
+                  "dev": true,
+                  "requires": {
+                    "es5-ext": "0.10.12"
+                  }
+                },
+                "es5-ext": {
+                  "version": "0.10.12",
+                  "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/es5-ext/-/es5-ext-0.10.12.tgz",
+                  "integrity": "sha1-qoRkHU23a2Krul5F/YBey6sUAEc=",
+                  "dev": true,
+                  "requires": {
+                    "es6-iterator": "2.0.0",
+                    "es6-symbol": "3.1.0"
+                  }
+                },
+                "es6-iterator": {
+                  "version": "2.0.0",
+                  "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/es6-iterator/-/es6-iterator-2.0.0.tgz",
+                  "integrity": "sha1-vZaFZ9YWNeM8C4BydhPJy0sJa6w=",
+                  "dev": true,
+                  "requires": {
+                    "d": "0.1.1",
+                    "es5-ext": "0.10.12",
+                    "es6-symbol": "3.1.0"
+                  }
+                },
+                "es6-symbol": {
+                  "version": "3.1.0",
+                  "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/es6-symbol/-/es6-symbol-3.1.0.tgz",
+                  "integrity": "sha1-lEgcZV56fK2C66gy2X1UM0ltf/o=",
+                  "dev": true,
+                  "requires": {
+                    "d": "0.1.1",
+                    "es5-ext": "0.10.12"
+                  }
+                }
+              }
+            },
+            "esrecurse": {
+              "version": "4.1.0",
+              "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/esrecurse/-/esrecurse-4.1.0.tgz",
+              "integrity": "sha1-RxO2U2rffyrE8yfVWed1a/9kgiA=",
+              "dev": true,
+              "requires": {
+                "estraverse": "4.1.1",
+                "object-assign": "4.1.0"
+              },
+              "dependencies": {
+                "estraverse": {
+                  "version": "4.1.1",
+                  "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/estraverse/-/estraverse-4.1.1.tgz",
+                  "integrity": "sha1-9srKcokzqFDvkGYdDheYK6RxEaI=",
+                  "dev": true
+                }
+              }
+            }
+          }
+        },
+        "espree": {
+          "version": "2.2.5",
+          "resolved": "https://registry.npmjs.org/espree/-/espree-2.2.5.tgz",
+          "integrity": "sha1-32kbkxCIlAKuspzAZnCMVmkLhUs=",
+          "dev": true
+        },
+        "estraverse": {
+          "version": "4.2.0",
+          "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/estraverse/-/estraverse-4.2.0.tgz",
+          "integrity": "sha1-De4/7TH81GlhjOc0IJn8GvoL2xM=",
+          "dev": true
+        },
+        "estraverse-fb": {
+          "version": "1.3.1",
+          "resolved": "https://registry.npmjs.org/estraverse-fb/-/estraverse-fb-1.3.1.tgz",
+          "integrity": "sha1-Fg51qA5gWwjOiUvM4v4+Qpq/kr8=",
+          "dev": true
+        },
+        "esutils": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
+          "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=",
+          "dev": true
+        },
+        "file-entry-cache": {
+          "version": "1.3.1",
+          "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/file-entry-cache/-/file-entry-cache-1.3.1.tgz",
+          "integrity": "sha1-RMYepgeuS+nBQC9B9EJwy/4zT/g=",
+          "dev": true,
+          "requires": {
+            "flat-cache": "1.2.1",
+            "object-assign": "4.1.0"
+          },
+          "dependencies": {
+            "flat-cache": {
+              "version": "1.2.1",
+              "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/flat-cache/-/flat-cache-1.2.1.tgz",
+              "integrity": "sha1-bIN9YiWn3lZZMjdAs21TYfcWkf8=",
+              "dev": true,
+              "requires": {
+                "circular-json": "0.3.1",
+                "del": "2.2.2",
+                "graceful-fs": "4.1.9",
+                "write": "0.2.1"
+              },
+              "dependencies": {
+                "circular-json": {
+                  "version": "0.3.1",
+                  "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/circular-json/-/circular-json-0.3.1.tgz",
+                  "integrity": "sha1-vos2rvzN6LPKeqLWr8B6NyQsDS0=",
+                  "dev": true
+                },
+                "del": {
+                  "version": "2.2.2",
+                  "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/del/-/del-2.2.2.tgz",
+                  "integrity": "sha1-wSyYHQZ4RshLyvhiz/kw2Qf/0ag=",
+                  "dev": true,
+                  "requires": {
+                    "globby": "5.0.0",
+                    "is-path-cwd": "1.0.0",
+                    "is-path-in-cwd": "1.0.0",
+                    "object-assign": "4.1.0",
+                    "pify": "2.3.0",
+                    "pinkie-promise": "2.0.1",
+                    "rimraf": "2.5.4"
+                  },
+                  "dependencies": {
+                    "globby": {
+                      "version": "5.0.0",
+                      "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/globby/-/globby-5.0.0.tgz",
+                      "integrity": "sha1-69hGZ8oNuzMLmbz8aOrCvFQ3Dg0=",
+                      "dev": true,
+                      "requires": {
+                        "array-union": "1.0.2",
+                        "arrify": "1.0.1",
+                        "glob": "7.1.0",
+                        "object-assign": "4.1.0",
+                        "pify": "2.3.0",
+                        "pinkie-promise": "2.0.1"
+                      },
+                      "dependencies": {
+                        "array-union": {
+                          "version": "1.0.2",
+                          "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/array-union/-/array-union-1.0.2.tgz",
+                          "integrity": "sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=",
+                          "dev": true,
+                          "requires": {
+                            "array-uniq": "1.0.3"
+                          },
+                          "dependencies": {
+                            "array-uniq": {
+                              "version": "1.0.3",
+                              "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/array-uniq/-/array-uniq-1.0.3.tgz",
+                              "integrity": "sha1-r2rId6Jcx/dOBYiUdThY39sk/bY=",
+                              "dev": true
+                            }
+                          }
+                        },
+                        "arrify": {
+                          "version": "1.0.1",
+                          "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/arrify/-/arrify-1.0.1.tgz",
+                          "integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=",
+                          "dev": true
+                        },
+                        "glob": {
+                          "version": "7.1.0",
+                          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.0.tgz",
+                          "integrity": "sha1-Nq3YVtdG0NmeTMJ5e7oa4sZycv0=",
+                          "dev": true,
+                          "requires": {
+                            "fs.realpath": "1.0.0",
+                            "inflight": "1.0.5",
+                            "inherits": "2.0.3",
+                            "minimatch": "3.0.3",
+                            "once": "1.4.0",
+                            "path-is-absolute": "1.0.1"
+                          },
+                          "dependencies": {
+                            "fs.realpath": {
+                              "version": "1.0.0",
+                              "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/fs.realpath/-/fs.realpath-1.0.0.tgz",
+                              "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+                              "dev": true
+                            },
+                            "inflight": {
+                              "version": "1.0.5",
+                              "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/inflight/-/inflight-1.0.5.tgz",
+                              "integrity": "sha1-2zIEzVqd4ubNiQuFxuL2a89PYgo=",
+                              "dev": true,
+                              "requires": {
+                                "once": "1.4.0",
+                                "wrappy": "1.0.2"
+                              },
+                              "dependencies": {
+                                "wrappy": {
+                                  "version": "1.0.2",
+                                  "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/wrappy/-/wrappy-1.0.2.tgz",
+                                  "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+                                  "dev": true
+                                }
+                              }
+                            },
+                            "inherits": {
+                              "version": "2.0.3",
+                              "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/inherits/-/inherits-2.0.3.tgz",
+                              "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+                              "dev": true
+                            },
+                            "once": {
+                              "version": "1.4.0",
+                              "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/once/-/once-1.4.0.tgz",
+                              "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+                              "dev": true,
+                              "requires": {
+                                "wrappy": "1.0.2"
+                              },
+                              "dependencies": {
+                                "wrappy": {
+                                  "version": "1.0.2",
+                                  "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/wrappy/-/wrappy-1.0.2.tgz",
+                                  "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+                                  "dev": true
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "is-path-cwd": {
+                      "version": "1.0.0",
+                      "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/is-path-cwd/-/is-path-cwd-1.0.0.tgz",
+                      "integrity": "sha1-0iXsIxMuie3Tj9p2dHLmLmXxEG0=",
+                      "dev": true
+                    },
+                    "is-path-in-cwd": {
+                      "version": "1.0.0",
+                      "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/is-path-in-cwd/-/is-path-in-cwd-1.0.0.tgz",
+                      "integrity": "sha1-ZHdYK4IU1gI0YJRWcAO+ip6sBNw=",
+                      "dev": true,
+                      "requires": {
+                        "is-path-inside": "1.0.0"
+                      },
+                      "dependencies": {
+                        "is-path-inside": {
+                          "version": "1.0.0",
+                          "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/is-path-inside/-/is-path-inside-1.0.0.tgz",
+                          "integrity": "sha1-/AbloWg/vaE95mev9xe7wQpI838=",
+                          "dev": true,
+                          "requires": {
+                            "path-is-inside": "1.0.2"
+                          }
+                        }
+                      }
+                    },
+                    "pify": {
+                      "version": "2.3.0",
+                      "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/pify/-/pify-2.3.0.tgz",
+                      "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
+                      "dev": true
+                    },
+                    "pinkie-promise": {
+                      "version": "2.0.1",
+                      "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
+                      "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
+                      "dev": true,
+                      "requires": {
+                        "pinkie": "2.0.4"
+                      },
+                      "dependencies": {
+                        "pinkie": {
+                          "version": "2.0.4",
+                          "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/pinkie/-/pinkie-2.0.4.tgz",
+                          "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA=",
+                          "dev": true
+                        }
+                      }
+                    },
+                    "rimraf": {
+                      "version": "2.5.4",
+                      "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/rimraf/-/rimraf-2.5.4.tgz",
+                      "integrity": "sha1-loAAk8vxoMhr2VtGJUZ1NcKd+gQ=",
+                      "dev": true,
+                      "requires": {
+                        "glob": "7.1.0"
+                      },
+                      "dependencies": {
+                        "glob": {
+                          "version": "7.1.0",
+                          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.0.tgz",
+                          "integrity": "sha1-Nq3YVtdG0NmeTMJ5e7oa4sZycv0=",
+                          "dev": true,
+                          "requires": {
+                            "fs.realpath": "1.0.0",
+                            "inflight": "1.0.5",
+                            "inherits": "2.0.3",
+                            "minimatch": "3.0.3",
+                            "once": "1.4.0",
+                            "path-is-absolute": "1.0.1"
+                          },
+                          "dependencies": {
+                            "fs.realpath": {
+                              "version": "1.0.0",
+                              "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/fs.realpath/-/fs.realpath-1.0.0.tgz",
+                              "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+                              "dev": true
+                            },
+                            "inflight": {
+                              "version": "1.0.5",
+                              "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/inflight/-/inflight-1.0.5.tgz",
+                              "integrity": "sha1-2zIEzVqd4ubNiQuFxuL2a89PYgo=",
+                              "dev": true,
+                              "requires": {
+                                "once": "1.4.0",
+                                "wrappy": "1.0.2"
+                              },
+                              "dependencies": {
+                                "wrappy": {
+                                  "version": "1.0.2",
+                                  "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/wrappy/-/wrappy-1.0.2.tgz",
+                                  "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+                                  "dev": true
+                                }
+                              }
+                            },
+                            "inherits": {
+                              "version": "2.0.3",
+                              "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/inherits/-/inherits-2.0.3.tgz",
+                              "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+                              "dev": true
+                            },
+                            "once": {
+                              "version": "1.4.0",
+                              "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/once/-/once-1.4.0.tgz",
+                              "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+                              "dev": true,
+                              "requires": {
+                                "wrappy": "1.0.2"
+                              },
+                              "dependencies": {
+                                "wrappy": {
+                                  "version": "1.0.2",
+                                  "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/wrappy/-/wrappy-1.0.2.tgz",
+                                  "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+                                  "dev": true
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                },
+                "graceful-fs": {
+                  "version": "4.1.9",
+                  "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.9.tgz",
+                  "integrity": "sha1-uqy6N9GdEfnRRtNXi8mZWMN4fik=",
+                  "dev": true
+                },
+                "write": {
+                  "version": "0.2.1",
+                  "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/write/-/write-0.2.1.tgz",
+                  "integrity": "sha1-X8A4KOJkzqP+kUVUdvejxWbLB1c=",
+                  "dev": true,
+                  "requires": {
+                    "mkdirp": "0.5.1"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "glob": {
+          "version": "5.0.15",
+          "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/glob/-/glob-5.0.15.tgz",
+          "integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
+          "dev": true,
+          "requires": {
+            "inflight": "1.0.5",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.3",
+            "once": "1.4.0",
+            "path-is-absolute": "1.0.1"
+          },
+          "dependencies": {
+            "inflight": {
+              "version": "1.0.5",
+              "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/inflight/-/inflight-1.0.5.tgz",
+              "integrity": "sha1-2zIEzVqd4ubNiQuFxuL2a89PYgo=",
+              "dev": true,
+              "requires": {
+                "once": "1.4.0",
+                "wrappy": "1.0.2"
+              },
+              "dependencies": {
+                "wrappy": {
+                  "version": "1.0.2",
+                  "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/wrappy/-/wrappy-1.0.2.tgz",
+                  "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+                  "dev": true
+                }
+              }
+            },
+            "inherits": {
+              "version": "2.0.3",
+              "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/inherits/-/inherits-2.0.3.tgz",
+              "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+              "dev": true
+            },
+            "once": {
+              "version": "1.4.0",
+              "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/once/-/once-1.4.0.tgz",
+              "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+              "dev": true,
+              "requires": {
+                "wrappy": "1.0.2"
+              },
+              "dependencies": {
+                "wrappy": {
+                  "version": "1.0.2",
+                  "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/wrappy/-/wrappy-1.0.2.tgz",
+                  "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+                  "dev": true
+                }
+              }
+            }
+          }
+        },
+        "globals": {
+          "version": "8.18.0",
+          "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/globals/-/globals-8.18.0.tgz",
+          "integrity": "sha1-k9SmK9ysOM+vr8R9awNHaMsP/LQ=",
+          "dev": true
+        },
+        "inquirer": {
+          "version": "0.11.4",
+          "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-0.11.4.tgz",
+          "integrity": "sha1-geM3ToNhvq/y2XAWIG01nQsy+k0=",
+          "dev": true,
+          "requires": {
+            "ansi-escapes": "1.4.0",
+            "ansi-regex": "2.0.0",
+            "chalk": "1.1.3",
+            "cli-cursor": "1.0.2",
+            "cli-width": "1.1.1",
+            "figures": "1.7.0",
+            "lodash": "3.10.1",
+            "readline2": "1.0.1",
+            "run-async": "0.1.0",
+            "rx-lite": "3.1.2",
+            "string-width": "1.0.2",
+            "strip-ansi": "3.0.1",
+            "through": "2.3.8"
+          },
+          "dependencies": {
+            "ansi-escapes": {
+              "version": "1.4.0",
+              "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/ansi-escapes/-/ansi-escapes-1.4.0.tgz",
+              "integrity": "sha1-06ioOzGapneTZisT52HHkRQiMG4=",
+              "dev": true
+            },
+            "ansi-regex": {
+              "version": "2.0.0",
+              "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/ansi-regex/-/ansi-regex-2.0.0.tgz",
+              "integrity": "sha1-xQYbbg74qBd15Q9dZhUb9r83EQc=",
+              "dev": true
+            },
+            "cli-cursor": {
+              "version": "1.0.2",
+              "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/cli-cursor/-/cli-cursor-1.0.2.tgz",
+              "integrity": "sha1-ZNo/fValRBLll5S9Ytw1KV6PKYc=",
+              "dev": true,
+              "requires": {
+                "restore-cursor": "1.0.1"
+              },
+              "dependencies": {
+                "restore-cursor": {
+                  "version": "1.0.1",
+                  "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/restore-cursor/-/restore-cursor-1.0.1.tgz",
+                  "integrity": "sha1-NGYfRohjJ/7SmRR5FSJS35LapUE=",
+                  "dev": true,
+                  "requires": {
+                    "exit-hook": "1.1.1",
+                    "onetime": "1.1.0"
+                  },
+                  "dependencies": {
+                    "exit-hook": {
+                      "version": "1.1.1",
+                      "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/exit-hook/-/exit-hook-1.1.1.tgz",
+                      "integrity": "sha1-8FyiM7SMBdVP/wd2XfhQfpXAL/g=",
+                      "dev": true
+                    },
+                    "onetime": {
+                      "version": "1.1.0",
+                      "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/onetime/-/onetime-1.1.0.tgz",
+                      "integrity": "sha1-ofeDj4MUxRbwXs78vEzP4EtO14k=",
+                      "dev": true
+                    }
+                  }
+                }
+              }
+            },
+            "cli-width": {
+              "version": "1.1.1",
+              "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-1.1.1.tgz",
+              "integrity": "sha1-pNKT72frt7iNSk1CwMzwDE0eNm0=",
+              "dev": true
+            },
+            "figures": {
+              "version": "1.7.0",
+              "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/figures/-/figures-1.7.0.tgz",
+              "integrity": "sha1-y+Hjr/zxzUS4DK3+0o3Hk6lwHS4=",
+              "dev": true,
+              "requires": {
+                "escape-string-regexp": "1.0.5",
+                "object-assign": "4.1.0"
+              }
+            },
+            "lodash": {
+              "version": "3.10.1",
+              "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/lodash/-/lodash-3.10.1.tgz",
+              "integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y=",
+              "dev": true
+            },
+            "readline2": {
+              "version": "1.0.1",
+              "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/readline2/-/readline2-1.0.1.tgz",
+              "integrity": "sha1-QQWWCP/BVHV7cV2ZidGZ/783LjU=",
+              "dev": true,
+              "requires": {
+                "code-point-at": "1.0.1",
+                "is-fullwidth-code-point": "1.0.0",
+                "mute-stream": "0.0.5"
+              },
+              "dependencies": {
+                "code-point-at": {
+                  "version": "1.0.1",
+                  "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.0.1.tgz",
+                  "integrity": "sha1-EQTNNPm1tF0+uojxurwZJOHONfs=",
+                  "dev": true,
+                  "requires": {
+                    "number-is-nan": "1.0.1"
+                  },
+                  "dependencies": {
+                    "number-is-nan": {
+                      "version": "1.0.1",
+                      "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
+                      "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
+                      "dev": true
+                    }
+                  }
+                },
+                "is-fullwidth-code-point": {
+                  "version": "1.0.0",
+                  "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+                  "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+                  "dev": true,
+                  "requires": {
+                    "number-is-nan": "1.0.1"
+                  },
+                  "dependencies": {
+                    "number-is-nan": {
+                      "version": "1.0.1",
+                      "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
+                      "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
+                      "dev": true
+                    }
+                  }
+                },
+                "mute-stream": {
+                  "version": "0.0.5",
+                  "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.5.tgz",
+                  "integrity": "sha1-j7+rsKmKJT0xhDMfno3rc3L6xsA=",
+                  "dev": true
+                }
+              }
+            },
+            "run-async": {
+              "version": "0.1.0",
+              "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/run-async/-/run-async-0.1.0.tgz",
+              "integrity": "sha1-yK1KXhEGYeQCp9IbUw4AnyX444k=",
+              "dev": true,
+              "requires": {
+                "once": "1.4.0"
+              },
+              "dependencies": {
+                "once": {
+                  "version": "1.4.0",
+                  "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/once/-/once-1.4.0.tgz",
+                  "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+                  "dev": true,
+                  "requires": {
+                    "wrappy": "1.0.2"
+                  },
+                  "dependencies": {
+                    "wrappy": {
+                      "version": "1.0.2",
+                      "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/wrappy/-/wrappy-1.0.2.tgz",
+                      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+                      "dev": true
+                    }
+                  }
+                }
+              }
+            },
+            "rx-lite": {
+              "version": "3.1.2",
+              "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/rx-lite/-/rx-lite-3.1.2.tgz",
+              "integrity": "sha1-Gc5QLKVyZl87ZHsQk5+X/RYV8QI=",
+              "dev": true
+            },
+            "string-width": {
+              "version": "1.0.2",
+              "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/string-width/-/string-width-1.0.2.tgz",
+              "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+              "dev": true,
+              "requires": {
+                "code-point-at": "1.0.1",
+                "is-fullwidth-code-point": "1.0.0",
+                "strip-ansi": "3.0.1"
+              },
+              "dependencies": {
+                "code-point-at": {
+                  "version": "1.0.1",
+                  "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.0.1.tgz",
+                  "integrity": "sha1-EQTNNPm1tF0+uojxurwZJOHONfs=",
+                  "dev": true,
+                  "requires": {
+                    "number-is-nan": "1.0.1"
+                  },
+                  "dependencies": {
+                    "number-is-nan": {
+                      "version": "1.0.1",
+                      "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
+                      "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
+                      "dev": true
+                    }
+                  }
+                },
+                "is-fullwidth-code-point": {
+                  "version": "1.0.0",
+                  "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+                  "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+                  "dev": true,
+                  "requires": {
+                    "number-is-nan": "1.0.1"
+                  },
+                  "dependencies": {
+                    "number-is-nan": {
+                      "version": "1.0.1",
+                      "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
+                      "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
+                      "dev": true
+                    }
+                  }
+                }
+              }
+            },
+            "strip-ansi": {
+              "version": "3.0.1",
+              "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/strip-ansi/-/strip-ansi-3.0.1.tgz",
+              "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+              "dev": true,
+              "requires": {
+                "ansi-regex": "2.0.0"
+              }
+            },
+            "through": {
+              "version": "2.3.8",
+              "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/through/-/through-2.3.8.tgz",
+              "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
+              "dev": true
+            }
+          }
+        },
+        "is-my-json-valid": {
+          "version": "2.15.0",
+          "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.15.0.tgz",
+          "integrity": "sha1-k27do8o8IR/ZjzstPgjaQ/eykVs=",
+          "dev": true,
+          "requires": {
+            "generate-function": "2.0.0",
+            "generate-object-property": "1.2.0",
+            "jsonpointer": "4.0.0",
+            "xtend": "4.0.1"
+          },
+          "dependencies": {
+            "generate-function": {
+              "version": "2.0.0",
+              "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz",
+              "integrity": "sha1-aFj+fAlpt9TpCTM3ZHrHn2DfvnQ=",
+              "dev": true
+            },
+            "generate-object-property": {
+              "version": "1.2.0",
+              "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
+              "integrity": "sha1-nA4cQDCM6AT0eDYYuTf6iPmdUNA=",
+              "dev": true,
+              "requires": {
+                "is-property": "1.0.2"
+              },
+              "dependencies": {
+                "is-property": {
+                  "version": "1.0.2",
+                  "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
+                  "integrity": "sha1-V/4cTkhHTt1lsJkR8msc1Ald2oQ=",
+                  "dev": true
+                }
+              }
+            },
+            "jsonpointer": {
+              "version": "4.0.0",
+              "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-4.0.0.tgz",
+              "integrity": "sha1-ZmHhYdL8RF8Z+YQwIxNDci4fy9U=",
+              "dev": true
+            },
+            "xtend": {
+              "version": "4.0.1",
+              "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/xtend/-/xtend-4.0.1.tgz",
+              "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68=",
+              "dev": true
+            }
+          }
+        },
+        "is-resolvable": {
+          "version": "1.0.0",
+          "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/is-resolvable/-/is-resolvable-1.0.0.tgz",
+          "integrity": "sha1-jfV8YeouPFAUCNEA+wE8+NbgzGI=",
+          "dev": true,
+          "requires": {
+            "tryit": "1.0.2"
+          },
+          "dependencies": {
+            "tryit": {
+              "version": "1.0.2",
+              "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/tryit/-/tryit-1.0.2.tgz",
+              "integrity": "sha1-wZawBz5rHFldk8nIMIVbeswypFM=",
+              "dev": true
+            }
+          }
+        },
+        "js-yaml": {
+          "version": "3.4.5",
+          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.4.5.tgz",
+          "integrity": "sha1-w0A3l98SuRhmV08t4jZG/oyvtE0=",
+          "dev": true,
+          "requires": {
+            "argparse": "1.0.9",
+            "esprima": "2.7.3"
+          },
+          "dependencies": {
+            "argparse": {
+              "version": "1.0.9",
+              "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.9.tgz",
+              "integrity": "sha1-c9g7wmP4bpf4zE9rrhsOkKfSLIY=",
+              "dev": true,
+              "requires": {
+                "sprintf-js": "1.0.3"
+              },
+              "dependencies": {
+                "sprintf-js": {
+                  "version": "1.0.3",
+                  "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/sprintf-js/-/sprintf-js-1.0.3.tgz",
+                  "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
+                  "dev": true
+                }
+              }
+            },
+            "esprima": {
+              "version": "2.7.3",
+              "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/esprima/-/esprima-2.7.3.tgz",
+              "integrity": "sha1-luO3DVd59q1JzQMmc9HDEnZ7pYE=",
+              "dev": true
+            }
+          }
+        },
+        "json-stable-stringify": {
+          "version": "1.0.1",
+          "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
+          "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
+          "dev": true,
+          "requires": {
+            "jsonify": "0.0.0"
+          },
+          "dependencies": {
+            "jsonify": {
+              "version": "0.0.0",
+              "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
+              "integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM=",
+              "dev": true
+            }
+          }
+        },
+        "lodash.clonedeep": {
+          "version": "3.0.2",
+          "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/lodash.clonedeep/-/lodash.clonedeep-3.0.2.tgz",
+          "integrity": "sha1-oKHkDYKl6on/WxR7hETtY9koJ9s=",
+          "dev": true,
+          "requires": {
+            "lodash._baseclone": "3.3.0",
+            "lodash._bindcallback": "3.0.1"
+          },
+          "dependencies": {
+            "lodash._baseclone": {
+              "version": "3.3.0",
+              "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/lodash._baseclone/-/lodash._baseclone-3.3.0.tgz",
+              "integrity": "sha1-MDUZv2OT/n5C802LYw73eU41Qrc=",
+              "dev": true,
+              "requires": {
+                "lodash._arraycopy": "3.0.0",
+                "lodash._arrayeach": "3.0.0",
+                "lodash._baseassign": "3.2.0",
+                "lodash._basefor": "3.0.3",
+                "lodash.isarray": "3.0.4",
+                "lodash.keys": "3.1.2"
+              },
+              "dependencies": {
+                "lodash._arraycopy": {
+                  "version": "3.0.0",
+                  "resolved": "https://registry.npmjs.org/lodash._arraycopy/-/lodash._arraycopy-3.0.0.tgz",
+                  "integrity": "sha1-due3wfH7klRzdIeKVi7Qaj5Q9uE=",
+                  "dev": true
+                },
+                "lodash._arrayeach": {
+                  "version": "3.0.0",
+                  "resolved": "https://registry.npmjs.org/lodash._arrayeach/-/lodash._arrayeach-3.0.0.tgz",
+                  "integrity": "sha1-urFWsqkNPxu9XGU0AzSeXlkz754=",
+                  "dev": true
+                },
+                "lodash._baseassign": {
+                  "version": "3.2.0",
+                  "resolved": "https://registry.npmjs.org/lodash._baseassign/-/lodash._baseassign-3.2.0.tgz",
+                  "integrity": "sha1-jDigmVAPIVrQnlnxci/QxSv+Ck4=",
+                  "dev": true,
+                  "requires": {
+                    "lodash._basecopy": "3.0.1",
+                    "lodash.keys": "3.1.2"
+                  },
+                  "dependencies": {
+                    "lodash._basecopy": {
+                      "version": "3.0.1",
+                      "resolved": "https://registry.npmjs.org/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz",
+                      "integrity": "sha1-jaDmqHbPNEwK2KVIghEd08XHyjY=",
+                      "dev": true
+                    }
+                  }
+                },
+                "lodash._basefor": {
+                  "version": "3.0.3",
+                  "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/lodash._basefor/-/lodash._basefor-3.0.3.tgz",
+                  "integrity": "sha1-dVC06SGO8J+tJDQ7YSAhx5tMIMI=",
+                  "dev": true
+                },
+                "lodash.isarray": {
+                  "version": "3.0.4",
+                  "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/lodash.isarray/-/lodash.isarray-3.0.4.tgz",
+                  "integrity": "sha1-eeTriMNqgSKvhvhEqpvNhRtfu1U=",
+                  "dev": true
+                },
+                "lodash.keys": {
+                  "version": "3.1.2",
+                  "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/lodash.keys/-/lodash.keys-3.1.2.tgz",
+                  "integrity": "sha1-TbwEcrFWvlCgsoaFXRvQsMZWCYo=",
+                  "dev": true,
+                  "requires": {
+                    "lodash._getnative": "3.9.1",
+                    "lodash.isarguments": "3.1.0",
+                    "lodash.isarray": "3.0.4"
+                  },
+                  "dependencies": {
+                    "lodash._getnative": {
+                      "version": "3.9.1",
+                      "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/lodash._getnative/-/lodash._getnative-3.9.1.tgz",
+                      "integrity": "sha1-VwvH3t5G1hzc3mh9ZdPuy6o6r/U=",
+                      "dev": true
+                    },
+                    "lodash.isarguments": {
+                      "version": "3.1.0",
+                      "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
+                      "integrity": "sha1-L1c9hcaiQon/AGY7SRwdM4/zRYo=",
+                      "dev": true
+                    }
+                  }
+                }
+              }
+            },
+            "lodash._bindcallback": {
+              "version": "3.0.1",
+              "resolved": "https://registry.npmjs.org/lodash._bindcallback/-/lodash._bindcallback-3.0.1.tgz",
+              "integrity": "sha1-5THCdkTPi1epnhftlbNcdIeJOS4=",
+              "dev": true
+            }
+          }
+        },
+        "lodash.merge": {
+          "version": "3.3.2",
+          "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/lodash.merge/-/lodash.merge-3.3.2.tgz",
+          "integrity": "sha1-DZDZPtY3sYeEN7s+IWASYNev6ZQ=",
+          "dev": true,
+          "requires": {
+            "lodash._arraycopy": "3.0.0",
+            "lodash._arrayeach": "3.0.0",
+            "lodash._createassigner": "3.1.1",
+            "lodash._getnative": "3.9.1",
+            "lodash.isarguments": "3.1.0",
+            "lodash.isarray": "3.0.4",
+            "lodash.isplainobject": "3.2.0",
+            "lodash.istypedarray": "3.0.6",
+            "lodash.keys": "3.1.2",
+            "lodash.keysin": "3.0.8",
+            "lodash.toplainobject": "3.0.0"
+          },
+          "dependencies": {
+            "lodash._arraycopy": {
+              "version": "3.0.0",
+              "resolved": "https://registry.npmjs.org/lodash._arraycopy/-/lodash._arraycopy-3.0.0.tgz",
+              "integrity": "sha1-due3wfH7klRzdIeKVi7Qaj5Q9uE=",
+              "dev": true
+            },
+            "lodash._arrayeach": {
+              "version": "3.0.0",
+              "resolved": "https://registry.npmjs.org/lodash._arrayeach/-/lodash._arrayeach-3.0.0.tgz",
+              "integrity": "sha1-urFWsqkNPxu9XGU0AzSeXlkz754=",
+              "dev": true
+            },
+            "lodash._createassigner": {
+              "version": "3.1.1",
+              "resolved": "https://registry.npmjs.org/lodash._createassigner/-/lodash._createassigner-3.1.1.tgz",
+              "integrity": "sha1-g4pbri/aymOsIt7o4Z+k5taXCxE=",
+              "dev": true,
+              "requires": {
+                "lodash._bindcallback": "3.0.1",
+                "lodash._isiterateecall": "3.0.9",
+                "lodash.restparam": "3.6.1"
+              },
+              "dependencies": {
+                "lodash._bindcallback": {
+                  "version": "3.0.1",
+                  "resolved": "https://registry.npmjs.org/lodash._bindcallback/-/lodash._bindcallback-3.0.1.tgz",
+                  "integrity": "sha1-5THCdkTPi1epnhftlbNcdIeJOS4=",
+                  "dev": true
+                },
+                "lodash._isiterateecall": {
+                  "version": "3.0.9",
+                  "resolved": "https://registry.npmjs.org/lodash._isiterateecall/-/lodash._isiterateecall-3.0.9.tgz",
+                  "integrity": "sha1-UgOte6Ql+uhCRg5pbbnPPmqsBXw=",
+                  "dev": true
+                },
+                "lodash.restparam": {
+                  "version": "3.6.1",
+                  "resolved": "https://registry.npmjs.org/lodash.restparam/-/lodash.restparam-3.6.1.tgz",
+                  "integrity": "sha1-k2pOMJ7zMKdkXtQUWYbIWuWyCAU=",
+                  "dev": true
+                }
+              }
+            },
+            "lodash._getnative": {
+              "version": "3.9.1",
+              "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/lodash._getnative/-/lodash._getnative-3.9.1.tgz",
+              "integrity": "sha1-VwvH3t5G1hzc3mh9ZdPuy6o6r/U=",
+              "dev": true
+            },
+            "lodash.isarguments": {
+              "version": "3.1.0",
+              "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
+              "integrity": "sha1-L1c9hcaiQon/AGY7SRwdM4/zRYo=",
+              "dev": true
+            },
+            "lodash.isarray": {
+              "version": "3.0.4",
+              "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/lodash.isarray/-/lodash.isarray-3.0.4.tgz",
+              "integrity": "sha1-eeTriMNqgSKvhvhEqpvNhRtfu1U=",
+              "dev": true
+            },
+            "lodash.isplainobject": {
+              "version": "3.2.0",
+              "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/lodash.isplainobject/-/lodash.isplainobject-3.2.0.tgz",
+              "integrity": "sha1-moI4rhayAEMpYM1zRlEtASP79MU=",
+              "dev": true,
+              "requires": {
+                "lodash._basefor": "3.0.3",
+                "lodash.isarguments": "3.1.0",
+                "lodash.keysin": "3.0.8"
+              },
+              "dependencies": {
+                "lodash._basefor": {
+                  "version": "3.0.3",
+                  "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/lodash._basefor/-/lodash._basefor-3.0.3.tgz",
+                  "integrity": "sha1-dVC06SGO8J+tJDQ7YSAhx5tMIMI=",
+                  "dev": true
+                }
+              }
+            },
+            "lodash.istypedarray": {
+              "version": "3.0.6",
+              "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/lodash.istypedarray/-/lodash.istypedarray-3.0.6.tgz",
+              "integrity": "sha1-yaR3SYYHUB2OhJTSg7h8OSgc72I=",
+              "dev": true
+            },
+            "lodash.keys": {
+              "version": "3.1.2",
+              "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/lodash.keys/-/lodash.keys-3.1.2.tgz",
+              "integrity": "sha1-TbwEcrFWvlCgsoaFXRvQsMZWCYo=",
+              "dev": true,
+              "requires": {
+                "lodash._getnative": "3.9.1",
+                "lodash.isarguments": "3.1.0",
+                "lodash.isarray": "3.0.4"
+              }
+            },
+            "lodash.keysin": {
+              "version": "3.0.8",
+              "resolved": "https://registry.npmjs.org/lodash.keysin/-/lodash.keysin-3.0.8.tgz",
+              "integrity": "sha1-IsRJPrvtsUJ5YqVLRFssinZ/tH8=",
+              "dev": true,
+              "requires": {
+                "lodash.isarguments": "3.1.0",
+                "lodash.isarray": "3.0.4"
+              }
+            },
+            "lodash.toplainobject": {
+              "version": "3.0.0",
+              "resolved": "https://registry.npmjs.org/lodash.toplainobject/-/lodash.toplainobject-3.0.0.tgz",
+              "integrity": "sha1-KHkK2ULSk9eKpmOgfs9/UsoEGY0=",
+              "dev": true,
+              "requires": {
+                "lodash._basecopy": "3.0.1",
+                "lodash.keysin": "3.0.8"
+              },
+              "dependencies": {
+                "lodash._basecopy": {
+                  "version": "3.0.1",
+                  "resolved": "https://registry.npmjs.org/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz",
+                  "integrity": "sha1-jaDmqHbPNEwK2KVIghEd08XHyjY=",
+                  "dev": true
+                }
+              }
+            }
+          }
+        },
+        "lodash.omit": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/lodash.omit/-/lodash.omit-3.1.0.tgz",
+          "integrity": "sha1-iX/jguZBPZrJfGH3jtHgV6AK+fM=",
+          "dev": true,
+          "requires": {
+            "lodash._arraymap": "3.0.0",
+            "lodash._basedifference": "3.0.3",
+            "lodash._baseflatten": "3.1.4",
+            "lodash._bindcallback": "3.0.1",
+            "lodash._pickbyarray": "3.0.2",
+            "lodash._pickbycallback": "3.0.0",
+            "lodash.keysin": "3.0.8",
+            "lodash.restparam": "3.6.1"
+          },
+          "dependencies": {
+            "lodash._arraymap": {
+              "version": "3.0.0",
+              "resolved": "https://registry.npmjs.org/lodash._arraymap/-/lodash._arraymap-3.0.0.tgz",
+              "integrity": "sha1-Go/Q9MDfS2HeoHbXF83Jfwo8PmY=",
+              "dev": true
+            },
+            "lodash._basedifference": {
+              "version": "3.0.3",
+              "resolved": "https://registry.npmjs.org/lodash._basedifference/-/lodash._basedifference-3.0.3.tgz",
+              "integrity": "sha1-8sIEKWwqeOArOJCBtu3KyTPPYpw=",
+              "dev": true,
+              "requires": {
+                "lodash._baseindexof": "3.1.0",
+                "lodash._cacheindexof": "3.0.2",
+                "lodash._createcache": "3.1.2"
+              },
+              "dependencies": {
+                "lodash._baseindexof": {
+                  "version": "3.1.0",
+                  "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/lodash._baseindexof/-/lodash._baseindexof-3.1.0.tgz",
+                  "integrity": "sha1-/lK1OhxnYeQmGNZU5KJXie1hgiw=",
+                  "dev": true
+                },
+                "lodash._cacheindexof": {
+                  "version": "3.0.2",
+                  "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/lodash._cacheindexof/-/lodash._cacheindexof-3.0.2.tgz",
+                  "integrity": "sha1-PcaayCSY0u5ePOVgkbr9Ktx73pI=",
+                  "dev": true
+                },
+                "lodash._createcache": {
+                  "version": "3.1.2",
+                  "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/lodash._createcache/-/lodash._createcache-3.1.2.tgz",
+                  "integrity": "sha1-VtagZAF2JeeevKa4AY4XRAvc8JM=",
+                  "dev": true,
+                  "requires": {
+                    "lodash._getnative": "3.9.1"
+                  },
+                  "dependencies": {
+                    "lodash._getnative": {
+                      "version": "3.9.1",
+                      "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/lodash._getnative/-/lodash._getnative-3.9.1.tgz",
+                      "integrity": "sha1-VwvH3t5G1hzc3mh9ZdPuy6o6r/U=",
+                      "dev": true
+                    }
+                  }
+                }
+              }
+            },
+            "lodash._baseflatten": {
+              "version": "3.1.4",
+              "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/lodash._baseflatten/-/lodash._baseflatten-3.1.4.tgz",
+              "integrity": "sha1-B3D/gBMa9uNPO1EXlqe6UhTmX/c=",
+              "dev": true,
+              "requires": {
+                "lodash.isarguments": "3.1.0",
+                "lodash.isarray": "3.0.4"
+              },
+              "dependencies": {
+                "lodash.isarguments": {
+                  "version": "3.1.0",
+                  "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
+                  "integrity": "sha1-L1c9hcaiQon/AGY7SRwdM4/zRYo=",
+                  "dev": true
+                },
+                "lodash.isarray": {
+                  "version": "3.0.4",
+                  "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/lodash.isarray/-/lodash.isarray-3.0.4.tgz",
+                  "integrity": "sha1-eeTriMNqgSKvhvhEqpvNhRtfu1U=",
+                  "dev": true
+                }
+              }
+            },
+            "lodash._bindcallback": {
+              "version": "3.0.1",
+              "resolved": "https://registry.npmjs.org/lodash._bindcallback/-/lodash._bindcallback-3.0.1.tgz",
+              "integrity": "sha1-5THCdkTPi1epnhftlbNcdIeJOS4=",
+              "dev": true
+            },
+            "lodash._pickbyarray": {
+              "version": "3.0.2",
+              "resolved": "https://registry.npmjs.org/lodash._pickbyarray/-/lodash._pickbyarray-3.0.2.tgz",
+              "integrity": "sha1-H4mNlgfrVgsOFnOEt3x8bRCKpMU=",
+              "dev": true
+            },
+            "lodash._pickbycallback": {
+              "version": "3.0.0",
+              "resolved": "https://registry.npmjs.org/lodash._pickbycallback/-/lodash._pickbycallback-3.0.0.tgz",
+              "integrity": "sha1-/2G5oBens699MObFPeKK+hm4dQo=",
+              "dev": true,
+              "requires": {
+                "lodash._basefor": "3.0.3",
+                "lodash.keysin": "3.0.8"
+              },
+              "dependencies": {
+                "lodash._basefor": {
+                  "version": "3.0.3",
+                  "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/lodash._basefor/-/lodash._basefor-3.0.3.tgz",
+                  "integrity": "sha1-dVC06SGO8J+tJDQ7YSAhx5tMIMI=",
+                  "dev": true
+                }
+              }
+            },
+            "lodash.keysin": {
+              "version": "3.0.8",
+              "resolved": "https://registry.npmjs.org/lodash.keysin/-/lodash.keysin-3.0.8.tgz",
+              "integrity": "sha1-IsRJPrvtsUJ5YqVLRFssinZ/tH8=",
+              "dev": true,
+              "requires": {
+                "lodash.isarguments": "3.1.0",
+                "lodash.isarray": "3.0.4"
+              },
+              "dependencies": {
+                "lodash.isarguments": {
+                  "version": "3.1.0",
+                  "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
+                  "integrity": "sha1-L1c9hcaiQon/AGY7SRwdM4/zRYo=",
+                  "dev": true
+                },
+                "lodash.isarray": {
+                  "version": "3.0.4",
+                  "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/lodash.isarray/-/lodash.isarray-3.0.4.tgz",
+                  "integrity": "sha1-eeTriMNqgSKvhvhEqpvNhRtfu1U=",
+                  "dev": true
+                }
+              }
+            },
+            "lodash.restparam": {
+              "version": "3.6.1",
+              "resolved": "https://registry.npmjs.org/lodash.restparam/-/lodash.restparam-3.6.1.tgz",
+              "integrity": "sha1-k2pOMJ7zMKdkXtQUWYbIWuWyCAU=",
+              "dev": true
+            }
+          }
+        },
+        "minimatch": {
+          "version": "3.0.3",
+          "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/minimatch/-/minimatch-3.0.3.tgz",
+          "integrity": "sha1-Kk5AkLlrLbBqnX3wEFWmKnfJt3Q=",
+          "dev": true,
+          "requires": {
+            "brace-expansion": "1.1.6"
+          },
+          "dependencies": {
+            "brace-expansion": {
+              "version": "1.1.6",
+              "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/brace-expansion/-/brace-expansion-1.1.6.tgz",
+              "integrity": "sha1-cZfX6qm4fmSDkOph/GbIRCdCDfk=",
+              "dev": true,
+              "requires": {
+                "balanced-match": "0.4.2",
+                "concat-map": "0.0.1"
+              },
+              "dependencies": {
+                "balanced-match": {
+                  "version": "0.4.2",
+                  "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/balanced-match/-/balanced-match-0.4.2.tgz",
+                  "integrity": "sha1-yz8+PHMtwPAe5wtAPzAuYddwmDg=",
+                  "dev": true
+                },
+                "concat-map": {
+                  "version": "0.0.1",
+                  "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+                  "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+                  "dev": true
+                }
+              }
+            }
+          }
+        },
+        "mkdirp": {
+          "version": "0.5.1",
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+          "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+          "dev": true,
+          "requires": {
+            "minimist": "0.0.8"
+          },
+          "dependencies": {
+            "minimist": {
+              "version": "0.0.8",
+              "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+              "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+              "dev": true
+            }
+          }
+        },
+        "object-assign": {
+          "version": "4.1.0",
+          "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/object-assign/-/object-assign-4.1.0.tgz",
+          "integrity": "sha1-ejs9DpgGPUP0wD8uiubNUahog6A=",
+          "dev": true
+        },
+        "optionator": {
+          "version": "0.6.0",
+          "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.6.0.tgz",
+          "integrity": "sha1-tj7Lvw4xX61LyYJ7Rdx7pFKE/LY=",
+          "dev": true,
+          "requires": {
+            "deep-is": "0.1.3",
+            "fast-levenshtein": "1.0.7",
+            "levn": "0.2.5",
+            "prelude-ls": "1.1.2",
+            "type-check": "0.3.2",
+            "wordwrap": "0.0.3"
+          },
+          "dependencies": {
+            "deep-is": {
+              "version": "0.1.3",
+              "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
+              "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=",
+              "dev": true
+            },
+            "fast-levenshtein": {
+              "version": "1.0.7",
+              "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/fast-levenshtein/-/fast-levenshtein-1.0.7.tgz",
+              "integrity": "sha1-AXjc3uAjuSkFGTrwlZ6KdjnP3Lk=",
+              "dev": true
+            },
+            "levn": {
+              "version": "0.2.5",
+              "resolved": "https://registry.npmjs.org/levn/-/levn-0.2.5.tgz",
+              "integrity": "sha1-uo0znQykphDjo/FFucr0iAcVUFQ=",
+              "dev": true,
+              "requires": {
+                "prelude-ls": "1.1.2",
+                "type-check": "0.3.2"
+              }
+            },
+            "prelude-ls": {
+              "version": "1.1.2",
+              "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
+              "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
+              "dev": true
+            },
+            "type-check": {
+              "version": "0.3.2",
+              "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/type-check/-/type-check-0.3.2.tgz",
+              "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
+              "dev": true,
+              "requires": {
+                "prelude-ls": "1.1.2"
+              }
+            },
+            "wordwrap": {
+              "version": "0.0.3",
+              "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
+              "integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc=",
+              "dev": true
+            }
+          }
+        },
+        "path-is-absolute": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+          "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+          "dev": true
+        },
+        "path-is-inside": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/path-is-inside/-/path-is-inside-1.0.2.tgz",
+          "integrity": "sha1-NlQX3t5EQw0cEa9hAn+s8HS9/FM=",
+          "dev": true
+        },
+        "shelljs": {
+          "version": "0.5.3",
+          "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.5.3.tgz",
+          "integrity": "sha1-xUmCuZbHbvDB5rWfvcWCX1txMRM=",
+          "dev": true
+        },
+        "strip-json-comments": {
+          "version": "1.0.4",
+          "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/strip-json-comments/-/strip-json-comments-1.0.4.tgz",
+          "integrity": "sha1-HhX7ysl9Pumb8tc7TGVrCCu6+5E=",
+          "dev": true
+        },
+        "text-table": {
+          "version": "0.2.0",
+          "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
+          "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
+          "dev": true
+        },
+        "user-home": {
+          "version": "2.0.0",
+          "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/user-home/-/user-home-2.0.0.tgz",
+          "integrity": "sha1-nHC/2Babwdy/SGBODwS4tJzenp8=",
+          "dev": true,
+          "requires": {
+            "os-homedir": "1.0.2"
+          },
+          "dependencies": {
+            "os-homedir": {
+              "version": "1.0.2",
+              "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
+              "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
+              "dev": true
+            }
+          }
+        },
+        "xml-escape": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/xml-escape/-/xml-escape-1.0.0.tgz",
+          "integrity": "sha1-AJY9aXsq3wwYXE4E5zF0upsojrI=",
+          "dev": true
+        }
+      }
+    },
+    "eyeglass-dev-eslint": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/eyeglass-dev-eslint/-/eyeglass-dev-eslint-2.0.0.tgz",
+      "integrity": "sha1-wLu3F+GDosVXRz9xHPQzFQzr2ZE=",
+      "dev": true,
+      "requires": {
+        "eslint": "1.10.3"
+      }
+    },
+    "eyeglass-dev-site-builder": {
+      "version": "0.0.5",
+      "resolved": "https://registry.npmjs.org/eyeglass-dev-site-builder/-/eyeglass-dev-site-builder-0.0.5.tgz",
+      "integrity": "sha1-Z/jGighx6sr54620QEq8M6daZBU=",
+      "dev": true,
+      "requires": {
+        "camelcase": "1.2.1",
+        "cheerio": "0.19.0",
+        "eyeglass": "0.7.1",
+        "glob": "5.0.15",
+        "handlebars": "4.0.5",
+        "handlebars-helper-equal": "1.0.0",
+        "highlight.js": "8.9.1",
+        "jsonfile": "2.4.0",
+        "lodash.merge": "3.3.2",
+        "metalsmith": "1.7.0",
+        "metalsmith-autoprefixer": "1.1.0",
+        "metalsmith-babel": "3.0.0",
+        "metalsmith-build-date": "0.1.0",
+        "metalsmith-collections": "0.7.0",
+        "metalsmith-copy": "0.2.1",
+        "metalsmith-drafts": "0.0.1",
+        "metalsmith-html-minifier": "1.1.0",
+        "metalsmith-in-place": "1.4.4",
+        "metalsmith-layouts": "1.6.5",
+        "metalsmith-markdown": "0.2.1",
+        "metalsmith-paginate": "0.3.0",
+        "metalsmith-permalinks": "0.4.1",
+        "metalsmith-redirect": "1.3.1",
+        "metalsmith-sass": "1.3.0",
+        "metalsmith-serve": "0.0.4",
+        "metalsmith-tags": "0.13.0",
+        "metalsmith-templates": "0.7.0",
+        "metalsmith-uglify": "1.5.1",
+        "metalsmith-watch": "1.0.3",
+        "minimatch": "3.0.3",
+        "moment": "2.15.1",
+        "node-sass": "3.10.1",
+        "node-uuid": "1.4.7",
+        "request": "2.75.0"
+      },
+      "dependencies": {
+        "camelcase": {
+          "version": "1.2.1",
+          "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/camelcase/-/camelcase-1.2.1.tgz",
+          "integrity": "sha1-m7UwTS4LVmmLLHWLCKPqqdqlijk=",
+          "dev": true
+        },
+        "cheerio": {
+          "version": "0.19.0",
+          "resolved": "https://registry.npmjs.org/cheerio/-/cheerio-0.19.0.tgz",
+          "integrity": "sha1-dy5wFfLuKZZQltcepBdbdas1SSU=",
+          "dev": true,
+          "requires": {
+            "css-select": "1.0.0",
+            "dom-serializer": "0.1.0",
+            "entities": "1.1.1",
+            "htmlparser2": "3.8.3",
+            "lodash": "3.10.1"
+          },
+          "dependencies": {
+            "css-select": {
+              "version": "1.0.0",
+              "resolved": "https://registry.npmjs.org/css-select/-/css-select-1.0.0.tgz",
+              "integrity": "sha1-sRIcpRhI3SZOIkTQWM7iVN7rRLA=",
+              "dev": true,
+              "requires": {
+                "boolbase": "1.0.0",
+                "css-what": "1.0.0",
+                "domutils": "1.4.3",
+                "nth-check": "1.0.1"
+              },
+              "dependencies": {
+                "boolbase": {
+                  "version": "1.0.0",
+                  "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
+                  "integrity": "sha1-aN/1++YMUes3cl6p4+0xDcwed24=",
+                  "dev": true
+                },
+                "css-what": {
+                  "version": "1.0.0",
+                  "resolved": "https://registry.npmjs.org/css-what/-/css-what-1.0.0.tgz",
+                  "integrity": "sha1-18wt9FGAZm+Z0rFEYmOUaeAPc2w=",
+                  "dev": true
+                },
+                "domutils": {
+                  "version": "1.4.3",
+                  "resolved": "https://registry.npmjs.org/domutils/-/domutils-1.4.3.tgz",
+                  "integrity": "sha1-CGVRN5bGswYDGFDhdVFrr4C3Km8=",
+                  "dev": true,
+                  "requires": {
+                    "domelementtype": "1.3.0"
+                  },
+                  "dependencies": {
+                    "domelementtype": {
+                      "version": "1.3.0",
+                      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.0.tgz",
+                      "integrity": "sha1-sXrtguirWeUt2cGbF1bg/BhyBMI=",
+                      "dev": true
+                    }
+                  }
+                },
+                "nth-check": {
+                  "version": "1.0.1",
+                  "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-1.0.1.tgz",
+                  "integrity": "sha1-mSms32KPwsQQmN6rgqxYDPFJquQ=",
+                  "dev": true,
+                  "requires": {
+                    "boolbase": "1.0.0"
+                  }
+                }
+              }
+            },
+            "dom-serializer": {
+              "version": "0.1.0",
+              "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.1.0.tgz",
+              "integrity": "sha1-BzxpdUbOB4DOI75KKOKT5AvDDII=",
+              "dev": true,
+              "requires": {
+                "domelementtype": "1.1.3",
+                "entities": "1.1.1"
+              },
+              "dependencies": {
+                "domelementtype": {
+                  "version": "1.1.3",
+                  "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.1.3.tgz",
+                  "integrity": "sha1-vSh3PiZCiBrsUVRJJCmcXNgiGFs=",
+                  "dev": true
+                }
+              }
+            },
+            "entities": {
+              "version": "1.1.1",
+              "resolved": "https://registry.npmjs.org/entities/-/entities-1.1.1.tgz",
+              "integrity": "sha1-blwtClYhtdra7O+AuQ7ftc13cvA=",
+              "dev": true
+            },
+            "htmlparser2": {
+              "version": "3.8.3",
+              "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/htmlparser2/-/htmlparser2-3.8.3.tgz",
+              "integrity": "sha1-mWwosZFRaovoZQGn15dX5ccMEGg=",
+              "dev": true,
+              "requires": {
+                "domelementtype": "1.3.0",
+                "domhandler": "2.3.0",
+                "domutils": "1.5.1",
+                "entities": "1.0.0",
+                "readable-stream": "1.1.14"
+              },
+              "dependencies": {
+                "domelementtype": {
+                  "version": "1.3.0",
+                  "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.0.tgz",
+                  "integrity": "sha1-sXrtguirWeUt2cGbF1bg/BhyBMI=",
+                  "dev": true
+                },
+                "domhandler": {
+                  "version": "2.3.0",
+                  "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-2.3.0.tgz",
+                  "integrity": "sha1-LeWaCCLVAn+r/28DLCsloqir5zg=",
+                  "dev": true,
+                  "requires": {
+                    "domelementtype": "1.3.0"
+                  }
+                },
+                "domutils": {
+                  "version": "1.5.1",
+                  "resolved": "https://registry.npmjs.org/domutils/-/domutils-1.5.1.tgz",
+                  "integrity": "sha1-3NhIiib1Y9YQeeSMn3t+Mjc2gs8=",
+                  "dev": true,
+                  "requires": {
+                    "dom-serializer": "0.1.0",
+                    "domelementtype": "1.3.0"
+                  }
+                },
+                "entities": {
+                  "version": "1.0.0",
+                  "resolved": "https://registry.npmjs.org/entities/-/entities-1.0.0.tgz",
+                  "integrity": "sha1-sph6o4ITR/zeZCsk/fyeT7cSvyY=",
+                  "dev": true
+                },
+                "readable-stream": {
+                  "version": "1.1.14",
+                  "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/readable-stream/-/readable-stream-1.1.14.tgz",
+                  "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
+                  "dev": true,
+                  "requires": {
+                    "core-util-is": "1.0.2",
+                    "inherits": "2.0.3",
+                    "isarray": "0.0.1",
+                    "string_decoder": "0.10.31"
+                  },
+                  "dependencies": {
+                    "core-util-is": {
+                      "version": "1.0.2",
+                      "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/core-util-is/-/core-util-is-1.0.2.tgz",
+                      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
+                      "dev": true
+                    },
+                    "inherits": {
+                      "version": "2.0.3",
+                      "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/inherits/-/inherits-2.0.3.tgz",
+                      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+                      "dev": true
+                    },
+                    "isarray": {
+                      "version": "0.0.1",
+                      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+                      "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
+                      "dev": true
+                    },
+                    "string_decoder": {
+                      "version": "0.10.31",
+                      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+                      "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
+                      "dev": true
+                    }
+                  }
+                }
+              }
+            },
+            "lodash": {
+              "version": "3.10.1",
+              "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/lodash/-/lodash-3.10.1.tgz",
+              "integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y=",
+              "dev": true
+            }
+          }
+        },
+        "eyeglass": {
+          "version": "0.7.1",
+          "resolved": "https://registry.npmjs.org/eyeglass/-/eyeglass-0.7.1.tgz",
+          "integrity": "sha1-8Bg2wIxQYsHrBGO54o18bk4QSds=",
+          "dev": true,
+          "requires": {
+            "archy": "1.0.0",
+            "deasync": "0.1.8",
+            "debug": "2.2.0",
+            "fs-extra": "0.24.0",
+            "glob": "5.0.15",
+            "lodash.includes": "3.1.3",
+            "lodash.merge": "3.3.2",
+            "lodash.uniq": "3.2.2",
+            "node-sass": "3.10.1",
+            "node-sass-utils": "1.1.2",
+            "semver": "5.3.0",
+            "tmp": "0.0.28"
+          },
+          "dependencies": {
+            "fs-extra": {
+              "version": "0.24.0",
+              "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/fs-extra/-/fs-extra-0.24.0.tgz",
+              "integrity": "sha1-1OQ0KpZnXLeEZjOmCZJJMytTmVI=",
+              "dev": true,
+              "requires": {
+                "graceful-fs": "4.1.9",
+                "jsonfile": "2.4.0",
+                "path-is-absolute": "1.0.1",
+                "rimraf": "2.5.4"
+              },
+              "dependencies": {
+                "graceful-fs": {
+                  "version": "4.1.9",
+                  "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.9.tgz",
+                  "integrity": "sha1-uqy6N9GdEfnRRtNXi8mZWMN4fik=",
+                  "dev": true
+                },
+                "path-is-absolute": {
+                  "version": "1.0.1",
+                  "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+                  "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+                  "dev": true
+                },
+                "rimraf": {
+                  "version": "2.5.4",
+                  "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/rimraf/-/rimraf-2.5.4.tgz",
+                  "integrity": "sha1-loAAk8vxoMhr2VtGJUZ1NcKd+gQ=",
+                  "dev": true,
+                  "requires": {
+                    "glob": "7.1.0"
+                  },
+                  "dependencies": {
+                    "glob": {
+                      "version": "7.1.0",
+                      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.0.tgz",
+                      "integrity": "sha1-Nq3YVtdG0NmeTMJ5e7oa4sZycv0=",
+                      "dev": true,
+                      "requires": {
+                        "fs.realpath": "1.0.0",
+                        "inflight": "1.0.5",
+                        "inherits": "2.0.3",
+                        "minimatch": "3.0.3",
+                        "once": "1.4.0",
+                        "path-is-absolute": "1.0.1"
+                      },
+                      "dependencies": {
+                        "fs.realpath": {
+                          "version": "1.0.0",
+                          "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/fs.realpath/-/fs.realpath-1.0.0.tgz",
+                          "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+                          "dev": true
+                        },
+                        "inflight": {
+                          "version": "1.0.5",
+                          "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/inflight/-/inflight-1.0.5.tgz",
+                          "integrity": "sha1-2zIEzVqd4ubNiQuFxuL2a89PYgo=",
+                          "dev": true,
+                          "requires": {
+                            "once": "1.4.0",
+                            "wrappy": "1.0.2"
+                          },
+                          "dependencies": {
+                            "wrappy": {
+                              "version": "1.0.2",
+                              "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/wrappy/-/wrappy-1.0.2.tgz",
+                              "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+                              "dev": true
+                            }
+                          }
+                        },
+                        "inherits": {
+                          "version": "2.0.3",
+                          "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/inherits/-/inherits-2.0.3.tgz",
+                          "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+                          "dev": true
+                        },
+                        "once": {
+                          "version": "1.4.0",
+                          "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/once/-/once-1.4.0.tgz",
+                          "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+                          "dev": true,
+                          "requires": {
+                            "wrappy": "1.0.2"
+                          },
+                          "dependencies": {
+                            "wrappy": {
+                              "version": "1.0.2",
+                              "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/wrappy/-/wrappy-1.0.2.tgz",
+                              "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+                              "dev": true
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "lodash.includes": {
+              "version": "3.1.3",
+              "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/lodash.includes/-/lodash.includes-3.1.3.tgz",
+              "integrity": "sha1-wyLQScJ4krKaAbmVk25ZU4HrvBc=",
+              "dev": true,
+              "requires": {
+                "lodash._baseindexof": "3.1.0",
+                "lodash._basevalues": "3.0.0",
+                "lodash._isiterateecall": "3.0.9",
+                "lodash.isarray": "3.0.4",
+                "lodash.isstring": "3.0.1",
+                "lodash.keys": "3.1.2"
+              },
+              "dependencies": {
+                "lodash._baseindexof": {
+                  "version": "3.1.0",
+                  "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/lodash._baseindexof/-/lodash._baseindexof-3.1.0.tgz",
+                  "integrity": "sha1-/lK1OhxnYeQmGNZU5KJXie1hgiw=",
+                  "dev": true
+                },
+                "lodash._basevalues": {
+                  "version": "3.0.0",
+                  "resolved": "https://registry.npmjs.org/lodash._basevalues/-/lodash._basevalues-3.0.0.tgz",
+                  "integrity": "sha1-W3dXYoAr3j0yl1A+JjAIIP32Ybc=",
+                  "dev": true
+                },
+                "lodash._isiterateecall": {
+                  "version": "3.0.9",
+                  "resolved": "https://registry.npmjs.org/lodash._isiterateecall/-/lodash._isiterateecall-3.0.9.tgz",
+                  "integrity": "sha1-UgOte6Ql+uhCRg5pbbnPPmqsBXw=",
+                  "dev": true
+                },
+                "lodash.isarray": {
+                  "version": "3.0.4",
+                  "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/lodash.isarray/-/lodash.isarray-3.0.4.tgz",
+                  "integrity": "sha1-eeTriMNqgSKvhvhEqpvNhRtfu1U=",
+                  "dev": true
+                },
+                "lodash.isstring": {
+                  "version": "3.0.1",
+                  "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/lodash.isstring/-/lodash.isstring-3.0.1.tgz",
+                  "integrity": "sha1-QWOJROoELvZ61nwpOqVB0/PW5Tw=",
+                  "dev": true
+                },
+                "lodash.keys": {
+                  "version": "3.1.2",
+                  "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/lodash.keys/-/lodash.keys-3.1.2.tgz",
+                  "integrity": "sha1-TbwEcrFWvlCgsoaFXRvQsMZWCYo=",
+                  "dev": true,
+                  "requires": {
+                    "lodash._getnative": "3.9.1",
+                    "lodash.isarguments": "3.1.0",
+                    "lodash.isarray": "3.0.4"
+                  },
+                  "dependencies": {
+                    "lodash._getnative": {
+                      "version": "3.9.1",
+                      "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/lodash._getnative/-/lodash._getnative-3.9.1.tgz",
+                      "integrity": "sha1-VwvH3t5G1hzc3mh9ZdPuy6o6r/U=",
+                      "dev": true
+                    },
+                    "lodash.isarguments": {
+                      "version": "3.1.0",
+                      "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
+                      "integrity": "sha1-L1c9hcaiQon/AGY7SRwdM4/zRYo=",
+                      "dev": true
+                    }
+                  }
+                }
+              }
+            },
+            "lodash.uniq": {
+              "version": "3.2.2",
+              "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/lodash.uniq/-/lodash.uniq-3.2.2.tgz",
+              "integrity": "sha1-FGw28l510ZUBukAuiLoUk39jzYs=",
+              "dev": true,
+              "requires": {
+                "lodash._basecallback": "3.3.1",
+                "lodash._baseuniq": "3.0.3",
+                "lodash._getnative": "3.9.1",
+                "lodash._isiterateecall": "3.0.9",
+                "lodash.isarray": "3.0.4"
+              },
+              "dependencies": {
+                "lodash._basecallback": {
+                  "version": "3.3.1",
+                  "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/lodash._basecallback/-/lodash._basecallback-3.3.1.tgz",
+                  "integrity": "sha1-t7K7Q9whYEJKIczybFfkQ3cqjic=",
+                  "dev": true,
+                  "requires": {
+                    "lodash._baseisequal": "3.0.7",
+                    "lodash._bindcallback": "3.0.1",
+                    "lodash.isarray": "3.0.4",
+                    "lodash.pairs": "3.0.1"
+                  },
+                  "dependencies": {
+                    "lodash._baseisequal": {
+                      "version": "3.0.7",
+                      "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/lodash._baseisequal/-/lodash._baseisequal-3.0.7.tgz",
+                      "integrity": "sha1-2AJfdjOdKTQnZ9zIh85cuVpbUfE=",
+                      "dev": true,
+                      "requires": {
+                        "lodash.isarray": "3.0.4",
+                        "lodash.istypedarray": "3.0.6",
+                        "lodash.keys": "3.1.2"
+                      },
+                      "dependencies": {
+                        "lodash.istypedarray": {
+                          "version": "3.0.6",
+                          "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/lodash.istypedarray/-/lodash.istypedarray-3.0.6.tgz",
+                          "integrity": "sha1-yaR3SYYHUB2OhJTSg7h8OSgc72I=",
+                          "dev": true
+                        },
+                        "lodash.keys": {
+                          "version": "3.1.2",
+                          "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/lodash.keys/-/lodash.keys-3.1.2.tgz",
+                          "integrity": "sha1-TbwEcrFWvlCgsoaFXRvQsMZWCYo=",
+                          "dev": true,
+                          "requires": {
+                            "lodash._getnative": "3.9.1",
+                            "lodash.isarguments": "3.1.0",
+                            "lodash.isarray": "3.0.4"
+                          },
+                          "dependencies": {
+                            "lodash.isarguments": {
+                              "version": "3.1.0",
+                              "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
+                              "integrity": "sha1-L1c9hcaiQon/AGY7SRwdM4/zRYo=",
+                              "dev": true
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "lodash._bindcallback": {
+                      "version": "3.0.1",
+                      "resolved": "https://registry.npmjs.org/lodash._bindcallback/-/lodash._bindcallback-3.0.1.tgz",
+                      "integrity": "sha1-5THCdkTPi1epnhftlbNcdIeJOS4=",
+                      "dev": true
+                    },
+                    "lodash.pairs": {
+                      "version": "3.0.1",
+                      "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/lodash.pairs/-/lodash.pairs-3.0.1.tgz",
+                      "integrity": "sha1-u+CNV4bu6qCaFckevw3LfSvjJqk=",
+                      "dev": true,
+                      "requires": {
+                        "lodash.keys": "3.1.2"
+                      },
+                      "dependencies": {
+                        "lodash.keys": {
+                          "version": "3.1.2",
+                          "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/lodash.keys/-/lodash.keys-3.1.2.tgz",
+                          "integrity": "sha1-TbwEcrFWvlCgsoaFXRvQsMZWCYo=",
+                          "dev": true,
+                          "requires": {
+                            "lodash._getnative": "3.9.1",
+                            "lodash.isarguments": "3.1.0",
+                            "lodash.isarray": "3.0.4"
+                          },
+                          "dependencies": {
+                            "lodash.isarguments": {
+                              "version": "3.1.0",
+                              "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
+                              "integrity": "sha1-L1c9hcaiQon/AGY7SRwdM4/zRYo=",
+                              "dev": true
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                },
+                "lodash._baseuniq": {
+                  "version": "3.0.3",
+                  "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/lodash._baseuniq/-/lodash._baseuniq-3.0.3.tgz",
+                  "integrity": "sha1-ISP6DbLWnCjVvrHB821hUip0AjQ=",
+                  "dev": true,
+                  "requires": {
+                    "lodash._baseindexof": "3.1.0",
+                    "lodash._cacheindexof": "3.0.2",
+                    "lodash._createcache": "3.1.2"
+                  },
+                  "dependencies": {
+                    "lodash._baseindexof": {
+                      "version": "3.1.0",
+                      "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/lodash._baseindexof/-/lodash._baseindexof-3.1.0.tgz",
+                      "integrity": "sha1-/lK1OhxnYeQmGNZU5KJXie1hgiw=",
+                      "dev": true
+                    },
+                    "lodash._cacheindexof": {
+                      "version": "3.0.2",
+                      "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/lodash._cacheindexof/-/lodash._cacheindexof-3.0.2.tgz",
+                      "integrity": "sha1-PcaayCSY0u5ePOVgkbr9Ktx73pI=",
+                      "dev": true
+                    },
+                    "lodash._createcache": {
+                      "version": "3.1.2",
+                      "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/lodash._createcache/-/lodash._createcache-3.1.2.tgz",
+                      "integrity": "sha1-VtagZAF2JeeevKa4AY4XRAvc8JM=",
+                      "dev": true,
+                      "requires": {
+                        "lodash._getnative": "3.9.1"
+                      }
+                    }
+                  }
+                },
+                "lodash._getnative": {
+                  "version": "3.9.1",
+                  "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/lodash._getnative/-/lodash._getnative-3.9.1.tgz",
+                  "integrity": "sha1-VwvH3t5G1hzc3mh9ZdPuy6o6r/U=",
+                  "dev": true
+                },
+                "lodash._isiterateecall": {
+                  "version": "3.0.9",
+                  "resolved": "https://registry.npmjs.org/lodash._isiterateecall/-/lodash._isiterateecall-3.0.9.tgz",
+                  "integrity": "sha1-UgOte6Ql+uhCRg5pbbnPPmqsBXw=",
+                  "dev": true
+                },
+                "lodash.isarray": {
+                  "version": "3.0.4",
+                  "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/lodash.isarray/-/lodash.isarray-3.0.4.tgz",
+                  "integrity": "sha1-eeTriMNqgSKvhvhEqpvNhRtfu1U=",
+                  "dev": true
+                }
+              }
+            },
+            "tmp": {
+              "version": "0.0.28",
+              "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.28.tgz",
+              "integrity": "sha1-Fyc1t/YU6nrzlmT6hM8N5OUV0SA=",
+              "dev": true,
+              "requires": {
+                "os-tmpdir": "1.0.2"
+              },
+              "dependencies": {
+                "os-tmpdir": {
+                  "version": "1.0.2",
+                  "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+                  "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
+                  "dev": true
+                }
+              }
+            }
+          }
+        },
+        "glob": {
+          "version": "5.0.15",
+          "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/glob/-/glob-5.0.15.tgz",
+          "integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
+          "dev": true,
+          "requires": {
+            "inflight": "1.0.5",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.3",
+            "once": "1.4.0",
+            "path-is-absolute": "1.0.1"
+          },
+          "dependencies": {
+            "inflight": {
+              "version": "1.0.5",
+              "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/inflight/-/inflight-1.0.5.tgz",
+              "integrity": "sha1-2zIEzVqd4ubNiQuFxuL2a89PYgo=",
+              "dev": true,
+              "requires": {
+                "once": "1.4.0",
+                "wrappy": "1.0.2"
+              },
+              "dependencies": {
+                "wrappy": {
+                  "version": "1.0.2",
+                  "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/wrappy/-/wrappy-1.0.2.tgz",
+                  "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+                  "dev": true
+                }
+              }
+            },
+            "inherits": {
+              "version": "2.0.3",
+              "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/inherits/-/inherits-2.0.3.tgz",
+              "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+              "dev": true
+            },
+            "once": {
+              "version": "1.4.0",
+              "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/once/-/once-1.4.0.tgz",
+              "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+              "dev": true,
+              "requires": {
+                "wrappy": "1.0.2"
+              },
+              "dependencies": {
+                "wrappy": {
+                  "version": "1.0.2",
+                  "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/wrappy/-/wrappy-1.0.2.tgz",
+                  "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+                  "dev": true
+                }
+              }
+            },
+            "path-is-absolute": {
+              "version": "1.0.1",
+              "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+              "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+              "dev": true
+            }
+          }
+        },
+        "handlebars-helper-equal": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/handlebars-helper-equal/-/handlebars-helper-equal-1.0.0.tgz",
+          "integrity": "sha1-QMAHjnJm2ksGktiTS/4+kQsKelg=",
+          "dev": true
+        },
+        "highlight.js": {
+          "version": "8.9.1",
+          "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-8.9.1.tgz",
+          "integrity": "sha1-uKnFSTISqTkvAiK2SclhFJfr+4g=",
+          "dev": true
+        },
+        "jsonfile": {
+          "version": "2.4.0",
+          "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-2.4.0.tgz",
+          "integrity": "sha1-NzaitCi4e72gzIO1P6PWM6NcKug=",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "4.1.9"
+          },
+          "dependencies": {
+            "graceful-fs": {
+              "version": "4.1.9",
+              "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.9.tgz",
+              "integrity": "sha1-uqy6N9GdEfnRRtNXi8mZWMN4fik=",
+              "dev": true,
+              "optional": true
+            }
+          }
+        },
+        "lodash.merge": {
+          "version": "3.3.2",
+          "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/lodash.merge/-/lodash.merge-3.3.2.tgz",
+          "integrity": "sha1-DZDZPtY3sYeEN7s+IWASYNev6ZQ=",
+          "dev": true,
+          "requires": {
+            "lodash._arraycopy": "3.0.0",
+            "lodash._arrayeach": "3.0.0",
+            "lodash._createassigner": "3.1.1",
+            "lodash._getnative": "3.9.1",
+            "lodash.isarguments": "3.1.0",
+            "lodash.isarray": "3.0.4",
+            "lodash.isplainobject": "3.2.0",
+            "lodash.istypedarray": "3.0.6",
+            "lodash.keys": "3.1.2",
+            "lodash.keysin": "3.0.8",
+            "lodash.toplainobject": "3.0.0"
+          },
+          "dependencies": {
+            "lodash._arraycopy": {
+              "version": "3.0.0",
+              "resolved": "https://registry.npmjs.org/lodash._arraycopy/-/lodash._arraycopy-3.0.0.tgz",
+              "integrity": "sha1-due3wfH7klRzdIeKVi7Qaj5Q9uE=",
+              "dev": true
+            },
+            "lodash._arrayeach": {
+              "version": "3.0.0",
+              "resolved": "https://registry.npmjs.org/lodash._arrayeach/-/lodash._arrayeach-3.0.0.tgz",
+              "integrity": "sha1-urFWsqkNPxu9XGU0AzSeXlkz754=",
+              "dev": true
+            },
+            "lodash._createassigner": {
+              "version": "3.1.1",
+              "resolved": "https://registry.npmjs.org/lodash._createassigner/-/lodash._createassigner-3.1.1.tgz",
+              "integrity": "sha1-g4pbri/aymOsIt7o4Z+k5taXCxE=",
+              "dev": true,
+              "requires": {
+                "lodash._bindcallback": "3.0.1",
+                "lodash._isiterateecall": "3.0.9",
+                "lodash.restparam": "3.6.1"
+              },
+              "dependencies": {
+                "lodash._bindcallback": {
+                  "version": "3.0.1",
+                  "resolved": "https://registry.npmjs.org/lodash._bindcallback/-/lodash._bindcallback-3.0.1.tgz",
+                  "integrity": "sha1-5THCdkTPi1epnhftlbNcdIeJOS4=",
+                  "dev": true
+                },
+                "lodash._isiterateecall": {
+                  "version": "3.0.9",
+                  "resolved": "https://registry.npmjs.org/lodash._isiterateecall/-/lodash._isiterateecall-3.0.9.tgz",
+                  "integrity": "sha1-UgOte6Ql+uhCRg5pbbnPPmqsBXw=",
+                  "dev": true
+                },
+                "lodash.restparam": {
+                  "version": "3.6.1",
+                  "resolved": "https://registry.npmjs.org/lodash.restparam/-/lodash.restparam-3.6.1.tgz",
+                  "integrity": "sha1-k2pOMJ7zMKdkXtQUWYbIWuWyCAU=",
+                  "dev": true
+                }
+              }
+            },
+            "lodash._getnative": {
+              "version": "3.9.1",
+              "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/lodash._getnative/-/lodash._getnative-3.9.1.tgz",
+              "integrity": "sha1-VwvH3t5G1hzc3mh9ZdPuy6o6r/U=",
+              "dev": true
+            },
+            "lodash.isarguments": {
+              "version": "3.1.0",
+              "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
+              "integrity": "sha1-L1c9hcaiQon/AGY7SRwdM4/zRYo=",
+              "dev": true
+            },
+            "lodash.isarray": {
+              "version": "3.0.4",
+              "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/lodash.isarray/-/lodash.isarray-3.0.4.tgz",
+              "integrity": "sha1-eeTriMNqgSKvhvhEqpvNhRtfu1U=",
+              "dev": true
+            },
+            "lodash.isplainobject": {
+              "version": "3.2.0",
+              "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/lodash.isplainobject/-/lodash.isplainobject-3.2.0.tgz",
+              "integrity": "sha1-moI4rhayAEMpYM1zRlEtASP79MU=",
+              "dev": true,
+              "requires": {
+                "lodash._basefor": "3.0.3",
+                "lodash.isarguments": "3.1.0",
+                "lodash.keysin": "3.0.8"
+              },
+              "dependencies": {
+                "lodash._basefor": {
+                  "version": "3.0.3",
+                  "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/lodash._basefor/-/lodash._basefor-3.0.3.tgz",
+                  "integrity": "sha1-dVC06SGO8J+tJDQ7YSAhx5tMIMI=",
+                  "dev": true
+                }
+              }
+            },
+            "lodash.istypedarray": {
+              "version": "3.0.6",
+              "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/lodash.istypedarray/-/lodash.istypedarray-3.0.6.tgz",
+              "integrity": "sha1-yaR3SYYHUB2OhJTSg7h8OSgc72I=",
+              "dev": true
+            },
+            "lodash.keys": {
+              "version": "3.1.2",
+              "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/lodash.keys/-/lodash.keys-3.1.2.tgz",
+              "integrity": "sha1-TbwEcrFWvlCgsoaFXRvQsMZWCYo=",
+              "dev": true,
+              "requires": {
+                "lodash._getnative": "3.9.1",
+                "lodash.isarguments": "3.1.0",
+                "lodash.isarray": "3.0.4"
+              }
+            },
+            "lodash.keysin": {
+              "version": "3.0.8",
+              "resolved": "https://registry.npmjs.org/lodash.keysin/-/lodash.keysin-3.0.8.tgz",
+              "integrity": "sha1-IsRJPrvtsUJ5YqVLRFssinZ/tH8=",
+              "dev": true,
+              "requires": {
+                "lodash.isarguments": "3.1.0",
+                "lodash.isarray": "3.0.4"
+              }
+            },
+            "lodash.toplainobject": {
+              "version": "3.0.0",
+              "resolved": "https://registry.npmjs.org/lodash.toplainobject/-/lodash.toplainobject-3.0.0.tgz",
+              "integrity": "sha1-KHkK2ULSk9eKpmOgfs9/UsoEGY0=",
+              "dev": true,
+              "requires": {
+                "lodash._basecopy": "3.0.1",
+                "lodash.keysin": "3.0.8"
+              },
+              "dependencies": {
+                "lodash._basecopy": {
+                  "version": "3.0.1",
+                  "resolved": "https://registry.npmjs.org/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz",
+                  "integrity": "sha1-jaDmqHbPNEwK2KVIghEd08XHyjY=",
+                  "dev": true
+                }
+              }
+            }
+          }
+        },
+        "metalsmith": {
+          "version": "1.7.0",
+          "resolved": "https://registry.npmjs.org/metalsmith/-/metalsmith-1.7.0.tgz",
+          "integrity": "sha1-y2hg1QENgDatonxEltFJq+KjUE0=",
+          "dev": true,
+          "requires": {
+            "absolute": "0.0.1",
+            "async": "0.9.2",
+            "chalk": "0.5.1",
+            "clone": "0.1.19",
+            "co-fs-extra": "0.0.2",
+            "commander": "2.9.0",
+            "fs-extra": "0.10.0",
+            "gnode": "0.1.2",
+            "gray-matter": "2.0.2",
+            "is": "2.2.1",
+            "is-utf8": "0.2.1",
+            "recursive-readdir": "1.3.0",
+            "rimraf": "2.5.4",
+            "stat-mode": "0.2.2",
+            "thunkify": "2.1.2",
+            "unyield": "0.0.1",
+            "ware": "1.3.0"
+          },
+          "dependencies": {
+            "absolute": {
+              "version": "0.0.1",
+              "resolved": "https://registry.npmjs.org/absolute/-/absolute-0.0.1.tgz",
+              "integrity": "sha1-wigi+H4ck59XmIdQTZwQnEFzgp0=",
+              "dev": true
+            },
+            "async": {
+              "version": "0.9.2",
+              "resolved": "https://registry.npmjs.org/async/-/async-0.9.2.tgz",
+              "integrity": "sha1-rqdNXmHB+JlhO/ZL2mbUx48v0X0=",
+              "dev": true
+            },
+            "chalk": {
+              "version": "0.5.1",
+              "resolved": "https://registry.npmjs.org/chalk/-/chalk-0.5.1.tgz",
+              "integrity": "sha1-Zjs6ZItotV0EaQ1JFnqoN4WPIXQ=",
+              "dev": true,
+              "requires": {
+                "ansi-styles": "1.1.0",
+                "escape-string-regexp": "1.0.5",
+                "has-ansi": "0.1.0",
+                "strip-ansi": "0.3.0",
+                "supports-color": "0.2.0"
+              },
+              "dependencies": {
+                "ansi-styles": {
+                  "version": "1.1.0",
+                  "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.1.0.tgz",
+                  "integrity": "sha1-6uy/Zs1waIJ2Cy9GkVgrj1XXp94=",
+                  "dev": true
+                },
+                "escape-string-regexp": {
+                  "version": "1.0.5",
+                  "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+                  "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+                  "dev": true
+                },
+                "has-ansi": {
+                  "version": "0.1.0",
+                  "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-0.1.0.tgz",
+                  "integrity": "sha1-hPJlqujA5qiKEtcCKJS3VoiUxi4=",
+                  "dev": true,
+                  "requires": {
+                    "ansi-regex": "0.2.1"
+                  },
+                  "dependencies": {
+                    "ansi-regex": {
+                      "version": "0.2.1",
+                      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz",
+                      "integrity": "sha1-DY6UaWej2BQ/k+JOKYUl/BsiNfk=",
+                      "dev": true
+                    }
+                  }
+                },
+                "strip-ansi": {
+                  "version": "0.3.0",
+                  "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.3.0.tgz",
+                  "integrity": "sha1-JfSOoiynkYfzF0pNuHWTR7sSYiA=",
+                  "dev": true,
+                  "requires": {
+                    "ansi-regex": "0.2.1"
+                  },
+                  "dependencies": {
+                    "ansi-regex": {
+                      "version": "0.2.1",
+                      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz",
+                      "integrity": "sha1-DY6UaWej2BQ/k+JOKYUl/BsiNfk=",
+                      "dev": true
+                    }
+                  }
+                },
+                "supports-color": {
+                  "version": "0.2.0",
+                  "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-0.2.0.tgz",
+                  "integrity": "sha1-2S3iaU6z9nMjlz1649i1W0wiGQo=",
+                  "dev": true
+                }
+              }
+            },
+            "clone": {
+              "version": "0.1.19",
+              "resolved": "https://registry.npmjs.org/clone/-/clone-0.1.19.tgz",
+              "integrity": "sha1-YT+2hjmyaklKxTJT4Vsaa9iK2oU=",
+              "dev": true
+            },
+            "co-fs-extra": {
+              "version": "0.0.2",
+              "resolved": "https://registry.npmjs.org/co-fs-extra/-/co-fs-extra-0.0.2.tgz",
+              "integrity": "sha1-As+1zVwksl9ogNPmAqebvjpA+TQ=",
+              "dev": true,
+              "requires": {
+                "co-fs": "1.2.0",
+                "fs-extra": "0.12.0",
+                "thunkify": "2.1.2"
+              },
+              "dependencies": {
+                "co-fs": {
+                  "version": "1.2.0",
+                  "resolved": "https://registry.npmjs.org/co-fs/-/co-fs-1.2.0.tgz",
+                  "integrity": "sha1-pt8EXOWMBO7UVYb/Q4UDKBOrpk4=",
+                  "dev": true,
+                  "requires": {
+                    "co-from-stream": "0.0.0",
+                    "thunkify": "0.0.1"
+                  },
+                  "dependencies": {
+                    "co-from-stream": {
+                      "version": "0.0.0",
+                      "resolved": "https://registry.npmjs.org/co-from-stream/-/co-from-stream-0.0.0.tgz",
+                      "integrity": "sha1-GlzYztdyY5RglPo58kmaYyl7yvk=",
+                      "dev": true,
+                      "requires": {
+                        "co-read": "0.0.1"
+                      },
+                      "dependencies": {
+                        "co-read": {
+                          "version": "0.0.1",
+                          "resolved": "https://registry.npmjs.org/co-read/-/co-read-0.0.1.tgz",
+                          "integrity": "sha1-+Bs+uKhmdf7FHj2IOn9WToc8k4k=",
+                          "dev": true
+                        }
+                      }
+                    },
+                    "thunkify": {
+                      "version": "0.0.1",
+                      "resolved": "https://registry.npmjs.org/thunkify/-/thunkify-0.0.1.tgz",
+                      "integrity": "sha1-vV02sQabQHjl3LrI+rRTWb6mGD0=",
+                      "dev": true
+                    }
+                  }
+                },
+                "fs-extra": {
+                  "version": "0.12.0",
+                  "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-0.12.0.tgz",
+                  "integrity": "sha1-QHz24RMh5EDWb5SG+6HMnrTCGGg=",
+                  "dev": true,
+                  "requires": {
+                    "jsonfile": "2.4.0",
+                    "mkdirp": "0.5.1",
+                    "ncp": "0.6.0",
+                    "rimraf": "2.5.4"
+                  },
+                  "dependencies": {
+                    "mkdirp": {
+                      "version": "0.5.1",
+                      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+                      "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+                      "dev": true,
+                      "requires": {
+                        "minimist": "0.0.8"
+                      },
+                      "dependencies": {
+                        "minimist": {
+                          "version": "0.0.8",
+                          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+                          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+                          "dev": true
+                        }
+                      }
+                    },
+                    "ncp": {
+                      "version": "0.6.0",
+                      "resolved": "https://registry.npmjs.org/ncp/-/ncp-0.6.0.tgz",
+                      "integrity": "sha1-34zgIeJiviG1L+s9Plz6qxJJHw0=",
+                      "dev": true
+                    }
+                  }
+                }
+              }
+            },
+            "commander": {
+              "version": "2.9.0",
+              "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
+              "integrity": "sha1-nJkJQXbhIkDLItbFFGCYQA/g99Q=",
+              "dev": true,
+              "requires": {
+                "graceful-readlink": "1.0.1"
+              },
+              "dependencies": {
+                "graceful-readlink": {
+                  "version": "1.0.1",
+                  "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz",
+                  "integrity": "sha1-TK+tdrxi8C+gObL5Tpo906ORpyU=",
+                  "dev": true
+                }
+              }
+            },
+            "fs-extra": {
+              "version": "0.10.0",
+              "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-0.10.0.tgz",
+              "integrity": "sha1-mcDsL9XqqtnWRiReSwFLVnKZgq8=",
+              "dev": true,
+              "requires": {
+                "jsonfile": "1.2.0",
+                "mkdirp": "0.5.1",
+                "ncp": "0.5.1",
+                "rimraf": "2.5.4"
+              },
+              "dependencies": {
+                "jsonfile": {
+                  "version": "1.2.0",
+                  "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-1.2.0.tgz",
+                  "integrity": "sha1-XzXWzZ+Ubsl7Wxg1P6nljfG4b2o=",
+                  "dev": true
+                },
+                "mkdirp": {
+                  "version": "0.5.1",
+                  "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+                  "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+                  "dev": true,
+                  "requires": {
+                    "minimist": "0.0.8"
+                  },
+                  "dependencies": {
+                    "minimist": {
+                      "version": "0.0.8",
+                      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+                      "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+                      "dev": true
+                    }
+                  }
+                },
+                "ncp": {
+                  "version": "0.5.1",
+                  "resolved": "https://registry.npmjs.org/ncp/-/ncp-0.5.1.tgz",
+                  "integrity": "sha1-dDmFMW49tFkoG1hxaehFc1oFQ58=",
+                  "dev": true
+                }
+              }
+            },
+            "gnode": {
+              "version": "0.1.2",
+              "resolved": "https://registry.npmjs.org/gnode/-/gnode-0.1.2.tgz",
+              "integrity": "sha1-CpVaXMIi9pnhQwakVZUF2QCA/dk=",
+              "dev": true,
+              "requires": {
+                "regenerator": "0.8.46"
+              },
+              "dependencies": {
+                "regenerator": {
+                  "version": "0.8.46",
+                  "resolved": "https://registry.npmjs.org/regenerator/-/regenerator-0.8.46.tgz",
+                  "integrity": "sha1-FUwydoY2HtUsrWmyVF78U6PQdpY=",
+                  "dev": true,
+                  "requires": {
+                    "commoner": "0.10.4",
+                    "defs": "1.1.1",
+                    "esprima-fb": "15001.1001.0-dev-harmony-fb",
+                    "private": "0.1.6",
+                    "recast": "0.10.33",
+                    "regenerator-runtime": "0.9.5",
+                    "through": "2.3.8"
+                  },
+                  "dependencies": {
+                    "commoner": {
+                      "version": "0.10.4",
+                      "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/commoner/-/commoner-0.10.4.tgz",
+                      "integrity": "sha1-mPMzPdOtOZWWuy04Sng7tyE9aPg=",
+                      "dev": true,
+                      "requires": {
+                        "commander": "2.9.0",
+                        "detective": "4.3.1",
+                        "glob": "5.0.15",
+                        "graceful-fs": "4.1.9",
+                        "iconv-lite": "0.4.13",
+                        "mkdirp": "0.5.1",
+                        "private": "0.1.6",
+                        "q": "1.4.1",
+                        "recast": "0.10.33"
+                      },
+                      "dependencies": {
+                        "detective": {
+                          "version": "4.3.1",
+                          "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/detective/-/detective-4.3.1.tgz",
+                          "integrity": "sha1-n7Bt0e6PDqTbzGB82jnZzh1Pcm8=",
+                          "dev": true,
+                          "requires": {
+                            "acorn": "1.2.2",
+                            "defined": "1.0.0"
+                          },
+                          "dependencies": {
+                            "acorn": {
+                              "version": "1.2.2",
+                              "resolved": "https://registry.npmjs.org/acorn/-/acorn-1.2.2.tgz",
+                              "integrity": "sha1-yM4n3grMdtiW0rH6099YjZ6C8BQ=",
+                              "dev": true
+                            },
+                            "defined": {
+                              "version": "1.0.0",
+                              "resolved": "https://registry.npmjs.org/defined/-/defined-1.0.0.tgz",
+                              "integrity": "sha1-yY2bzvdWdBiOEQlpFRGZ45sfppM=",
+                              "dev": true
+                            }
+                          }
+                        },
+                        "graceful-fs": {
+                          "version": "4.1.9",
+                          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.9.tgz",
+                          "integrity": "sha1-uqy6N9GdEfnRRtNXi8mZWMN4fik=",
+                          "dev": true
+                        },
+                        "iconv-lite": {
+                          "version": "0.4.13",
+                          "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/iconv-lite/-/iconv-lite-0.4.13.tgz",
+                          "integrity": "sha1-H4irpKsLFQjoMSrMOTRfNumS4vI=",
+                          "dev": true
+                        },
+                        "mkdirp": {
+                          "version": "0.5.1",
+                          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+                          "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+                          "dev": true,
+                          "requires": {
+                            "minimist": "0.0.8"
+                          },
+                          "dependencies": {
+                            "minimist": {
+                              "version": "0.0.8",
+                              "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+                              "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+                              "dev": true
+                            }
+                          }
+                        },
+                        "q": {
+                          "version": "1.4.1",
+                          "resolved": "https://registry.npmjs.org/q/-/q-1.4.1.tgz",
+                          "integrity": "sha1-VXBbzZPF82c1MMLCy8DCs63cKG4=",
+                          "dev": true
+                        }
+                      }
+                    },
+                    "defs": {
+                      "version": "1.1.1",
+                      "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/defs/-/defs-1.1.1.tgz",
+                      "integrity": "sha1-siYJ8sehG6ej2xFoBcE5scr/qdI=",
+                      "dev": true,
+                      "requires": {
+                        "alter": "0.2.0",
+                        "ast-traverse": "0.1.1",
+                        "breakable": "1.0.0",
+                        "esprima-fb": "15001.1001.0-dev-harmony-fb",
+                        "simple-fmt": "0.1.0",
+                        "simple-is": "0.2.0",
+                        "stringmap": "0.2.2",
+                        "stringset": "0.2.1",
+                        "tryor": "0.1.2",
+                        "yargs": "3.27.0"
+                      },
+                      "dependencies": {
+                        "alter": {
+                          "version": "0.2.0",
+                          "resolved": "https://registry.npmjs.org/alter/-/alter-0.2.0.tgz",
+                          "integrity": "sha1-x1iICGF1cgNKrmJICvJrHU0cs80=",
+                          "dev": true,
+                          "requires": {
+                            "stable": "0.1.5"
+                          },
+                          "dependencies": {
+                            "stable": {
+                              "version": "0.1.5",
+                              "resolved": "https://registry.npmjs.org/stable/-/stable-0.1.5.tgz",
+                              "integrity": "sha1-CCMvYMcy6YkHhLW+0HNPizKoh7k=",
+                              "dev": true
+                            }
+                          }
+                        },
+                        "ast-traverse": {
+                          "version": "0.1.1",
+                          "resolved": "https://registry.npmjs.org/ast-traverse/-/ast-traverse-0.1.1.tgz",
+                          "integrity": "sha1-ac8rg4bxnc2hux4F1o/jWdiJfeY=",
+                          "dev": true
+                        },
+                        "breakable": {
+                          "version": "1.0.0",
+                          "resolved": "https://registry.npmjs.org/breakable/-/breakable-1.0.0.tgz",
+                          "integrity": "sha1-eEp5eRWjjq0nutRWtVcstLuqeME=",
+                          "dev": true
+                        },
+                        "simple-fmt": {
+                          "version": "0.1.0",
+                          "resolved": "https://registry.npmjs.org/simple-fmt/-/simple-fmt-0.1.0.tgz",
+                          "integrity": "sha1-GRv1ZqWeZTBILLJatTtKjchcOms=",
+                          "dev": true
+                        },
+                        "simple-is": {
+                          "version": "0.2.0",
+                          "resolved": "https://registry.npmjs.org/simple-is/-/simple-is-0.2.0.tgz",
+                          "integrity": "sha1-Krt1qt453rXMgVzhDmGRFkhQuvA=",
+                          "dev": true
+                        },
+                        "stringmap": {
+                          "version": "0.2.2",
+                          "resolved": "https://registry.npmjs.org/stringmap/-/stringmap-0.2.2.tgz",
+                          "integrity": "sha1-VWwTeyWPlCuHdvWy71gqoGnX0bE=",
+                          "dev": true
+                        },
+                        "stringset": {
+                          "version": "0.2.1",
+                          "resolved": "https://registry.npmjs.org/stringset/-/stringset-0.2.1.tgz",
+                          "integrity": "sha1-7yWcTjSTRDd/zRyRPdLoSMnAQrU=",
+                          "dev": true
+                        },
+                        "tryor": {
+                          "version": "0.1.2",
+                          "resolved": "https://registry.npmjs.org/tryor/-/tryor-0.1.2.tgz",
+                          "integrity": "sha1-gUXkynyv9ArN48z5Rui4u3W0Fys=",
+                          "dev": true
+                        },
+                        "yargs": {
+                          "version": "3.27.0",
+                          "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/yargs/-/yargs-3.27.0.tgz",
+                          "integrity": "sha1-ISBUaTFuk5Ex1Z8toMbX+YIh6kA=",
+                          "dev": true,
+                          "requires": {
+                            "camelcase": "1.2.1",
+                            "cliui": "2.1.0",
+                            "decamelize": "1.2.0",
+                            "os-locale": "1.4.0",
+                            "window-size": "0.1.4",
+                            "y18n": "3.2.1"
+                          },
+                          "dependencies": {
+                            "cliui": {
+                              "version": "2.1.0",
+                              "resolved": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
+                              "integrity": "sha1-S0dXYP+AJkx2LDoXGQMukcf+oNE=",
+                              "dev": true,
+                              "requires": {
+                                "center-align": "0.1.3",
+                                "right-align": "0.1.3",
+                                "wordwrap": "0.0.2"
+                              },
+                              "dependencies": {
+                                "center-align": {
+                                  "version": "0.1.3",
+                                  "resolved": "https://registry.npmjs.org/center-align/-/center-align-0.1.3.tgz",
+                                  "integrity": "sha1-qg0yYptu6XIgBBHL1EYckHvCt60=",
+                                  "dev": true,
+                                  "requires": {
+                                    "align-text": "0.1.4",
+                                    "lazy-cache": "1.0.4"
+                                  },
+                                  "dependencies": {
+                                    "align-text": {
+                                      "version": "0.1.4",
+                                      "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
+                                      "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
+                                      "dev": true,
+                                      "requires": {
+                                        "kind-of": "3.0.4",
+                                        "longest": "1.0.1",
+                                        "repeat-string": "1.5.4"
+                                      },
+                                      "dependencies": {
+                                        "kind-of": {
+                                          "version": "3.0.4",
+                                          "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/kind-of/-/kind-of-3.0.4.tgz",
+                                          "integrity": "sha1-e47PGKThf4Jp1ztQHJ8jLJaIenQ=",
+                                          "dev": true,
+                                          "requires": {
+                                            "is-buffer": "1.1.4"
+                                          },
+                                          "dependencies": {
+                                            "is-buffer": {
+                                              "version": "1.1.4",
+                                              "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/is-buffer/-/is-buffer-1.1.4.tgz",
+                                              "integrity": "sha1-z8hszV3FpS+oBIkRHGkgxFfi2Ys=",
+                                              "dev": true
+                                            }
+                                          }
+                                        },
+                                        "longest": {
+                                          "version": "1.0.1",
+                                          "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
+                                          "integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc=",
+                                          "dev": true
+                                        },
+                                        "repeat-string": {
+                                          "version": "1.5.4",
+                                          "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.5.4.tgz",
+                                          "integrity": "sha1-ZOwMkeD0tHX5DVtkNlHj5uW2wtU=",
+                                          "dev": true
+                                        }
+                                      }
+                                    },
+                                    "lazy-cache": {
+                                      "version": "1.0.4",
+                                      "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/lazy-cache/-/lazy-cache-1.0.4.tgz",
+                                      "integrity": "sha1-odePw6UEdMuAhF07O24dpJpEbo4=",
+                                      "dev": true
+                                    }
+                                  }
+                                },
+                                "right-align": {
+                                  "version": "0.1.3",
+                                  "resolved": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
+                                  "integrity": "sha1-YTObci/mo1FWiSENJOFMlhSGE+8=",
+                                  "dev": true,
+                                  "requires": {
+                                    "align-text": "0.1.4"
+                                  },
+                                  "dependencies": {
+                                    "align-text": {
+                                      "version": "0.1.4",
+                                      "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
+                                      "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
+                                      "dev": true,
+                                      "requires": {
+                                        "kind-of": "3.0.4",
+                                        "longest": "1.0.1",
+                                        "repeat-string": "1.5.4"
+                                      },
+                                      "dependencies": {
+                                        "kind-of": {
+                                          "version": "3.0.4",
+                                          "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/kind-of/-/kind-of-3.0.4.tgz",
+                                          "integrity": "sha1-e47PGKThf4Jp1ztQHJ8jLJaIenQ=",
+                                          "dev": true,
+                                          "requires": {
+                                            "is-buffer": "1.1.4"
+                                          },
+                                          "dependencies": {
+                                            "is-buffer": {
+                                              "version": "1.1.4",
+                                              "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/is-buffer/-/is-buffer-1.1.4.tgz",
+                                              "integrity": "sha1-z8hszV3FpS+oBIkRHGkgxFfi2Ys=",
+                                              "dev": true
+                                            }
+                                          }
+                                        },
+                                        "longest": {
+                                          "version": "1.0.1",
+                                          "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
+                                          "integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc=",
+                                          "dev": true
+                                        },
+                                        "repeat-string": {
+                                          "version": "1.5.4",
+                                          "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.5.4.tgz",
+                                          "integrity": "sha1-ZOwMkeD0tHX5DVtkNlHj5uW2wtU=",
+                                          "dev": true
+                                        }
+                                      }
+                                    }
+                                  }
+                                },
+                                "wordwrap": {
+                                  "version": "0.0.2",
+                                  "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
+                                  "integrity": "sha1-t5Zpu0LstAn4PVg8rVLKF+qhZD8=",
+                                  "dev": true
+                                }
+                              }
+                            },
+                            "decamelize": {
+                              "version": "1.2.0",
+                              "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+                              "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
+                              "dev": true
+                            },
+                            "os-locale": {
+                              "version": "1.4.0",
+                              "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/os-locale/-/os-locale-1.4.0.tgz",
+                              "integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
+                              "dev": true,
+                              "requires": {
+                                "lcid": "1.0.0"
+                              },
+                              "dependencies": {
+                                "lcid": {
+                                  "version": "1.0.0",
+                                  "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/lcid/-/lcid-1.0.0.tgz",
+                                  "integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
+                                  "dev": true,
+                                  "requires": {
+                                    "invert-kv": "1.0.0"
+                                  },
+                                  "dependencies": {
+                                    "invert-kv": {
+                                      "version": "1.0.0",
+                                      "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/invert-kv/-/invert-kv-1.0.0.tgz",
+                                      "integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY=",
+                                      "dev": true
+                                    }
+                                  }
+                                }
+                              }
+                            },
+                            "window-size": {
+                              "version": "0.1.4",
+                              "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/window-size/-/window-size-0.1.4.tgz",
+                              "integrity": "sha1-+OGqHuWlPsW/FR/6CXQqatdpeHY=",
+                              "dev": true
+                            },
+                            "y18n": {
+                              "version": "3.2.1",
+                              "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/y18n/-/y18n-3.2.1.tgz",
+                              "integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE=",
+                              "dev": true
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "esprima-fb": {
+                      "version": "15001.1001.0-dev-harmony-fb",
+                      "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/esprima-fb/-/esprima-fb-15001.1001.0-dev-harmony-fb.tgz",
+                      "integrity": "sha1-Q761fsJujPI3092LM+QlM1d/Jlk=",
+                      "dev": true
+                    },
+                    "private": {
+                      "version": "0.1.6",
+                      "resolved": "https://registry.npmjs.org/private/-/private-0.1.6.tgz",
+                      "integrity": "sha1-VcapdtD5uvuZJIUTUP5HubX7t8E=",
+                      "dev": true
+                    },
+                    "recast": {
+                      "version": "0.10.33",
+                      "resolved": "https://registry.npmjs.org/recast/-/recast-0.10.33.tgz",
+                      "integrity": "sha1-lCgI96oBbx+nFCxGHX5XBKqo1pc=",
+                      "dev": true,
+                      "requires": {
+                        "ast-types": "0.8.12",
+                        "esprima-fb": "15001.1001.0-dev-harmony-fb",
+                        "private": "0.1.6",
+                        "source-map": "0.5.6"
+                      },
+                      "dependencies": {
+                        "ast-types": {
+                          "version": "0.8.12",
+                          "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/ast-types/-/ast-types-0.8.12.tgz",
+                          "integrity": "sha1-oNkOQ1G7iHcWyD/WN+v4GK9K38w=",
+                          "dev": true
+                        },
+                        "source-map": {
+                          "version": "0.5.6",
+                          "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/source-map/-/source-map-0.5.6.tgz",
+                          "integrity": "sha1-dc449SvwczxafwwRjYEzSiu19BI=",
+                          "dev": true
+                        }
+                      }
+                    },
+                    "regenerator-runtime": {
+                      "version": "0.9.5",
+                      "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/regenerator-runtime/-/regenerator-runtime-0.9.5.tgz",
+                      "integrity": "sha1-QD1tQKS9/5wzDdk5Lcuy2ai7ofw=",
+                      "dev": true
+                    },
+                    "through": {
+                      "version": "2.3.8",
+                      "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/through/-/through-2.3.8.tgz",
+                      "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
+                      "dev": true
+                    }
+                  }
+                }
+              }
+            },
+            "gray-matter": {
+              "version": "2.0.2",
+              "resolved": "https://registry.npmjs.org/gray-matter/-/gray-matter-2.0.2.tgz",
+              "integrity": "sha1-JYX6okRm2jis1z6k+QrPtKJin/g=",
+              "dev": true,
+              "requires": {
+                "ansi-red": "0.1.1",
+                "extend-shallow": "2.0.1",
+                "js-yaml": "3.6.1"
+              },
+              "dependencies": {
+                "ansi-red": {
+                  "version": "0.1.1",
+                  "resolved": "https://registry.npmjs.org/ansi-red/-/ansi-red-0.1.1.tgz",
+                  "integrity": "sha1-jGOPnRCAgAo1PJwoyKgcpHBdlGw=",
+                  "dev": true,
+                  "requires": {
+                    "ansi-wrap": "0.1.0"
+                  },
+                  "dependencies": {
+                    "ansi-wrap": {
+                      "version": "0.1.0",
+                      "resolved": "https://registry.npmjs.org/ansi-wrap/-/ansi-wrap-0.1.0.tgz",
+                      "integrity": "sha1-qCJQ3bABXponyoLoLqYDu/pF768=",
+                      "dev": true
+                    }
+                  }
+                },
+                "extend-shallow": {
+                  "version": "2.0.1",
+                  "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+                  "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+                  "dev": true,
+                  "requires": {
+                    "is-extendable": "0.1.1"
+                  },
+                  "dependencies": {
+                    "is-extendable": {
+                      "version": "0.1.1",
+                      "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/is-extendable/-/is-extendable-0.1.1.tgz",
+                      "integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik=",
+                      "dev": true
+                    }
+                  }
+                },
+                "js-yaml": {
+                  "version": "3.6.1",
+                  "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/js-yaml/-/js-yaml-3.6.1.tgz",
+                  "integrity": "sha1-bl/mfYsgXOTSL60Ft3geja3MSzA=",
+                  "dev": true,
+                  "requires": {
+                    "argparse": "1.0.9",
+                    "esprima": "2.7.3"
+                  },
+                  "dependencies": {
+                    "argparse": {
+                      "version": "1.0.9",
+                      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.9.tgz",
+                      "integrity": "sha1-c9g7wmP4bpf4zE9rrhsOkKfSLIY=",
+                      "dev": true,
+                      "requires": {
+                        "sprintf-js": "1.0.3"
+                      },
+                      "dependencies": {
+                        "sprintf-js": {
+                          "version": "1.0.3",
+                          "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/sprintf-js/-/sprintf-js-1.0.3.tgz",
+                          "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
+                          "dev": true
+                        }
+                      }
+                    },
+                    "esprima": {
+                      "version": "2.7.3",
+                      "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/esprima/-/esprima-2.7.3.tgz",
+                      "integrity": "sha1-luO3DVd59q1JzQMmc9HDEnZ7pYE=",
+                      "dev": true
+                    }
+                  }
+                }
+              }
+            },
+            "is": {
+              "version": "2.2.1",
+              "resolved": "https://registry.npmjs.org/is/-/is-2.2.1.tgz",
+              "integrity": "sha1-WwVXo9xoCJ2Xjs0RhMyPxSmDegQ=",
+              "dev": true
+            },
+            "is-utf8": {
+              "version": "0.2.1",
+              "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/is-utf8/-/is-utf8-0.2.1.tgz",
+              "integrity": "sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI=",
+              "dev": true
+            },
+            "recursive-readdir": {
+              "version": "1.3.0",
+              "resolved": "https://registry.npmjs.org/recursive-readdir/-/recursive-readdir-1.3.0.tgz",
+              "integrity": "sha1-xuZsmuRz9JKPjmxnoF2A56VlKO8=",
+              "dev": true,
+              "requires": {
+                "minimatch": "0.3.0"
+              },
+              "dependencies": {
+                "minimatch": {
+                  "version": "0.3.0",
+                  "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
+                  "integrity": "sha1-J12O2qxPG7MyZHIInnlJyDlGmd0=",
+                  "dev": true,
+                  "requires": {
+                    "lru-cache": "2.7.3",
+                    "sigmund": "1.0.1"
+                  },
+                  "dependencies": {
+                    "lru-cache": {
+                      "version": "2.7.3",
+                      "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/lru-cache/-/lru-cache-2.7.3.tgz",
+                      "integrity": "sha1-bUUk6LlV+V1PW1iFHOId1y+06VI=",
+                      "dev": true
+                    },
+                    "sigmund": {
+                      "version": "1.0.1",
+                      "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz",
+                      "integrity": "sha1-P/IfGYytIXX587eBhT/ZTQ0ZtZA=",
+                      "dev": true
+                    }
+                  }
+                }
+              }
+            },
+            "rimraf": {
+              "version": "2.5.4",
+              "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/rimraf/-/rimraf-2.5.4.tgz",
+              "integrity": "sha1-loAAk8vxoMhr2VtGJUZ1NcKd+gQ=",
+              "dev": true,
+              "requires": {
+                "glob": "7.1.0"
+              },
+              "dependencies": {
+                "glob": {
+                  "version": "7.1.0",
+                  "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.0.tgz",
+                  "integrity": "sha1-Nq3YVtdG0NmeTMJ5e7oa4sZycv0=",
+                  "dev": true,
+                  "requires": {
+                    "fs.realpath": "1.0.0",
+                    "inflight": "1.0.5",
+                    "inherits": "2.0.3",
+                    "minimatch": "3.0.3",
+                    "once": "1.4.0",
+                    "path-is-absolute": "1.0.1"
+                  },
+                  "dependencies": {
+                    "fs.realpath": {
+                      "version": "1.0.0",
+                      "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/fs.realpath/-/fs.realpath-1.0.0.tgz",
+                      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+                      "dev": true
+                    },
+                    "inflight": {
+                      "version": "1.0.5",
+                      "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/inflight/-/inflight-1.0.5.tgz",
+                      "integrity": "sha1-2zIEzVqd4ubNiQuFxuL2a89PYgo=",
+                      "dev": true,
+                      "requires": {
+                        "once": "1.4.0",
+                        "wrappy": "1.0.2"
+                      },
+                      "dependencies": {
+                        "wrappy": {
+                          "version": "1.0.2",
+                          "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/wrappy/-/wrappy-1.0.2.tgz",
+                          "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+                          "dev": true
+                        }
+                      }
+                    },
+                    "inherits": {
+                      "version": "2.0.3",
+                      "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/inherits/-/inherits-2.0.3.tgz",
+                      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+                      "dev": true
+                    },
+                    "once": {
+                      "version": "1.4.0",
+                      "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/once/-/once-1.4.0.tgz",
+                      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+                      "dev": true,
+                      "requires": {
+                        "wrappy": "1.0.2"
+                      },
+                      "dependencies": {
+                        "wrappy": {
+                          "version": "1.0.2",
+                          "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/wrappy/-/wrappy-1.0.2.tgz",
+                          "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+                          "dev": true
+                        }
+                      }
+                    },
+                    "path-is-absolute": {
+                      "version": "1.0.1",
+                      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+                      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+                      "dev": true
+                    }
+                  }
+                }
+              }
+            },
+            "stat-mode": {
+              "version": "0.2.2",
+              "resolved": "https://registry.npmjs.org/stat-mode/-/stat-mode-0.2.2.tgz",
+              "integrity": "sha1-5sgLYjEj19gM8TLOU480YokHJQI=",
+              "dev": true
+            },
+            "thunkify": {
+              "version": "2.1.2",
+              "resolved": "https://registry.npmjs.org/thunkify/-/thunkify-2.1.2.tgz",
+              "integrity": "sha1-+qDp0jDFGsyVyhOjYawFyn4EVT0=",
+              "dev": true
+            },
+            "unyield": {
+              "version": "0.0.1",
+              "resolved": "https://registry.npmjs.org/unyield/-/unyield-0.0.1.tgz",
+              "integrity": "sha1-FQ5l2kK/d0JEW5WKZOubhdHSsYA=",
+              "dev": true,
+              "requires": {
+                "co": "3.1.0"
+              },
+              "dependencies": {
+                "co": {
+                  "version": "3.1.0",
+                  "resolved": "https://registry.npmjs.org/co/-/co-3.1.0.tgz",
+                  "integrity": "sha1-TqVOpaCJOBUxheFSEMaNkJK8G3g=",
+                  "dev": true
+                }
+              }
+            },
+            "ware": {
+              "version": "1.3.0",
+              "resolved": "https://registry.npmjs.org/ware/-/ware-1.3.0.tgz",
+              "integrity": "sha1-0bFPOdLiy0q4xAmPdW/ksWTkc9Q=",
+              "dev": true,
+              "requires": {
+                "wrap-fn": "0.1.5"
+              },
+              "dependencies": {
+                "wrap-fn": {
+                  "version": "0.1.5",
+                  "resolved": "https://registry.npmjs.org/wrap-fn/-/wrap-fn-0.1.5.tgz",
+                  "integrity": "sha1-8htuQQFv9KfjFyDbxjoJAWvfmEU=",
+                  "dev": true,
+                  "requires": {
+                    "co": "3.1.0"
+                  },
+                  "dependencies": {
+                    "co": {
+                      "version": "3.1.0",
+                      "resolved": "https://registry.npmjs.org/co/-/co-3.1.0.tgz",
+                      "integrity": "sha1-TqVOpaCJOBUxheFSEMaNkJK8G3g=",
+                      "dev": true
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "metalsmith-autoprefixer": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/metalsmith-autoprefixer/-/metalsmith-autoprefixer-1.1.0.tgz",
+          "integrity": "sha1-0ynh3FTyZUD3awCQWWwtobDZqmk=",
+          "dev": true,
+          "requires": {
+            "autoprefixer-core": "5.2.1",
+            "minimatch": "2.0.10",
+            "postcss": "4.1.16"
+          },
+          "dependencies": {
+            "autoprefixer-core": {
+              "version": "5.2.1",
+              "resolved": "https://registry.npmjs.org/autoprefixer-core/-/autoprefixer-core-5.2.1.tgz",
+              "integrity": "sha1-5kDEFK5Bmq4hwa1DyOoPPbgqVm0=",
+              "dev": true,
+              "requires": {
+                "browserslist": "0.4.0",
+                "caniuse-db": "1.0.30000547",
+                "num2fraction": "1.2.2",
+                "postcss": "4.1.16"
+              },
+              "dependencies": {
+                "browserslist": {
+                  "version": "0.4.0",
+                  "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-0.4.0.tgz",
+                  "integrity": "sha1-O9SrkZncG5FQ1NbbpNnTqrvIbdQ=",
+                  "dev": true,
+                  "requires": {
+                    "caniuse-db": "1.0.30000547"
+                  }
+                },
+                "caniuse-db": {
+                  "version": "1.0.30000547",
+                  "resolved": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000547.tgz",
+                  "integrity": "sha1-Xqqk/JrrgM9ELaqB9wP+Ukd+dHc=",
+                  "dev": true
+                },
+                "num2fraction": {
+                  "version": "1.2.2",
+                  "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/num2fraction/-/num2fraction-1.2.2.tgz",
+                  "integrity": "sha1-b2gragJ6Tp3fpFZM0lidHU5mnt4=",
+                  "dev": true
+                }
+              }
+            },
+            "minimatch": {
+              "version": "2.0.10",
+              "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/minimatch/-/minimatch-2.0.10.tgz",
+              "integrity": "sha1-jQh8OcazjAAbl/ynzm0OHoCvusc=",
+              "dev": true,
+              "requires": {
+                "brace-expansion": "1.1.6"
+              },
+              "dependencies": {
+                "brace-expansion": {
+                  "version": "1.1.6",
+                  "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/brace-expansion/-/brace-expansion-1.1.6.tgz",
+                  "integrity": "sha1-cZfX6qm4fmSDkOph/GbIRCdCDfk=",
+                  "dev": true,
+                  "requires": {
+                    "balanced-match": "0.4.2",
+                    "concat-map": "0.0.1"
+                  },
+                  "dependencies": {
+                    "balanced-match": {
+                      "version": "0.4.2",
+                      "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/balanced-match/-/balanced-match-0.4.2.tgz",
+                      "integrity": "sha1-yz8+PHMtwPAe5wtAPzAuYddwmDg=",
+                      "dev": true
+                    },
+                    "concat-map": {
+                      "version": "0.0.1",
+                      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+                      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+                      "dev": true
+                    }
+                  }
+                }
+              }
+            },
+            "postcss": {
+              "version": "4.1.16",
+              "resolved": "https://registry.npmjs.org/postcss/-/postcss-4.1.16.tgz",
+              "integrity": "sha1-TESbTIr53zyvbTf44eV10DYXWNw=",
+              "dev": true,
+              "requires": {
+                "es6-promise": "2.3.0",
+                "js-base64": "2.1.9",
+                "source-map": "0.4.4"
+              },
+              "dependencies": {
+                "es6-promise": {
+                  "version": "2.3.0",
+                  "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-2.3.0.tgz",
+                  "integrity": "sha1-lu258v2wGZWCKyY92KratnSBgbw=",
+                  "dev": true
+                },
+                "js-base64": {
+                  "version": "2.1.9",
+                  "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/js-base64/-/js-base64-2.1.9.tgz",
+                  "integrity": "sha1-8OgK4DmkvWVLXygfyT8EqRSn/M4=",
+                  "dev": true
+                },
+                "source-map": {
+                  "version": "0.4.4",
+                  "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
+                  "integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
+                  "dev": true,
+                  "requires": {
+                    "amdefine": "1.0.0"
+                  },
+                  "dependencies": {
+                    "amdefine": {
+                      "version": "1.0.0",
+                      "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz",
+                      "integrity": "sha1-/RdHRwDLXMnCtwnwvp0jzjwZjDM=",
+                      "dev": true
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "metalsmith-babel": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/metalsmith-babel/-/metalsmith-babel-3.0.0.tgz",
+          "integrity": "sha1-6ABaMBbjPQc7iztCu0NwBjuFJ8Q=",
+          "dev": true,
+          "requires": {
+            "babel-core": "5.8.38",
+            "slash": "1.0.0"
+          },
+          "dependencies": {
+            "babel-core": {
+              "version": "5.8.38",
+              "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/babel-core/-/babel-core-5.8.38.tgz",
+              "integrity": "sha1-H8ruedfmG3ULALjlT238nQr4ZVg=",
+              "dev": true,
+              "requires": {
+                "babel-plugin-constant-folding": "1.0.1",
+                "babel-plugin-dead-code-elimination": "1.0.2",
+                "babel-plugin-eval": "1.0.1",
+                "babel-plugin-inline-environment-variables": "1.0.1",
+                "babel-plugin-jscript": "1.0.4",
+                "babel-plugin-member-expression-literals": "1.0.1",
+                "babel-plugin-property-literals": "1.0.1",
+                "babel-plugin-proto-to-assign": "1.0.4",
+                "babel-plugin-react-constant-elements": "1.0.3",
+                "babel-plugin-react-display-name": "1.0.3",
+                "babel-plugin-remove-console": "1.0.1",
+                "babel-plugin-remove-debugger": "1.0.1",
+                "babel-plugin-runtime": "1.0.7",
+                "babel-plugin-undeclared-variables-check": "1.0.2",
+                "babel-plugin-undefined-to-void": "1.1.6",
+                "babylon": "5.8.38",
+                "bluebird": "2.11.0",
+                "chalk": "1.1.3",
+                "convert-source-map": "1.3.0",
+                "core-js": "1.2.7",
+                "debug": "2.2.0",
+                "detect-indent": "3.0.1",
+                "esutils": "2.0.2",
+                "fs-readdir-recursive": "0.1.2",
+                "globals": "6.4.1",
+                "home-or-tmp": "1.0.0",
+                "is-integer": "1.0.6",
+                "js-tokens": "1.0.1",
+                "json5": "0.4.0",
+                "lodash": "3.10.1",
+                "minimatch": "2.0.10",
+                "output-file-sync": "1.1.2",
+                "path-exists": "1.0.0",
+                "path-is-absolute": "1.0.1",
+                "private": "0.1.6",
+                "regenerator": "0.8.40",
+                "regexpu": "1.3.0",
+                "repeating": "1.1.3",
+                "resolve": "1.1.7",
+                "shebang-regex": "1.0.0",
+                "slash": "1.0.0",
+                "source-map": "0.5.6",
+                "source-map-support": "0.2.10",
+                "to-fast-properties": "1.0.2",
+                "trim-right": "1.0.1",
+                "try-resolve": "1.0.1"
+              },
+              "dependencies": {
+                "babel-plugin-constant-folding": {
+                  "version": "1.0.1",
+                  "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/babel-plugin-constant-folding/-/babel-plugin-constant-folding-1.0.1.tgz",
+                  "integrity": "sha1-g2HTZMmORJw2kr26Ue/whEKQqo4=",
+                  "dev": true
+                },
+                "babel-plugin-dead-code-elimination": {
+                  "version": "1.0.2",
+                  "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/babel-plugin-dead-code-elimination/-/babel-plugin-dead-code-elimination-1.0.2.tgz",
+                  "integrity": "sha1-X3xFEnTc18zNv7s+C4XdKBIfD2U=",
+                  "dev": true
+                },
+                "babel-plugin-eval": {
+                  "version": "1.0.1",
+                  "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/babel-plugin-eval/-/babel-plugin-eval-1.0.1.tgz",
+                  "integrity": "sha1-ovrtJc5r5preS/7CY/cBaRlZUNo=",
+                  "dev": true
+                },
+                "babel-plugin-inline-environment-variables": {
+                  "version": "1.0.1",
+                  "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/babel-plugin-inline-environment-variables/-/babel-plugin-inline-environment-variables-1.0.1.tgz",
+                  "integrity": "sha1-H1jOkSB61qgmqL9kX6/mj/X+P/4=",
+                  "dev": true
+                },
+                "babel-plugin-jscript": {
+                  "version": "1.0.4",
+                  "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/babel-plugin-jscript/-/babel-plugin-jscript-1.0.4.tgz",
+                  "integrity": "sha1-jzQsOCduh6R9X6CovT1etsytj8w=",
+                  "dev": true
+                },
+                "babel-plugin-member-expression-literals": {
+                  "version": "1.0.1",
+                  "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/babel-plugin-member-expression-literals/-/babel-plugin-member-expression-literals-1.0.1.tgz",
+                  "integrity": "sha1-zF7bD6qNyScXDnTW0cAkQAIWJNM=",
+                  "dev": true
+                },
+                "babel-plugin-property-literals": {
+                  "version": "1.0.1",
+                  "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/babel-plugin-property-literals/-/babel-plugin-property-literals-1.0.1.tgz",
+                  "integrity": "sha1-AlIwGQAZKYCxwRjv6kjOk6q4MzY=",
+                  "dev": true
+                },
+                "babel-plugin-proto-to-assign": {
+                  "version": "1.0.4",
+                  "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/babel-plugin-proto-to-assign/-/babel-plugin-proto-to-assign-1.0.4.tgz",
+                  "integrity": "sha1-xJ56/QL1d7xNoF6i3wAiUM980SM=",
+                  "dev": true,
+                  "requires": {
+                    "lodash": "3.10.1"
+                  }
+                },
+                "babel-plugin-react-constant-elements": {
+                  "version": "1.0.3",
+                  "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/babel-plugin-react-constant-elements/-/babel-plugin-react-constant-elements-1.0.3.tgz",
+                  "integrity": "sha1-lGc26DeEKcvDSdz/YvUcFDs041o=",
+                  "dev": true
+                },
+                "babel-plugin-react-display-name": {
+                  "version": "1.0.3",
+                  "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/babel-plugin-react-display-name/-/babel-plugin-react-display-name-1.0.3.tgz",
+                  "integrity": "sha1-dU/jiSboQkpOexWrbqYTne4FFPw=",
+                  "dev": true
+                },
+                "babel-plugin-remove-console": {
+                  "version": "1.0.1",
+                  "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/babel-plugin-remove-console/-/babel-plugin-remove-console-1.0.1.tgz",
+                  "integrity": "sha1-2PJFVsOgUAXUKqqv0neH9T/wE6c=",
+                  "dev": true
+                },
+                "babel-plugin-remove-debugger": {
+                  "version": "1.0.1",
+                  "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/babel-plugin-remove-debugger/-/babel-plugin-remove-debugger-1.0.1.tgz",
+                  "integrity": "sha1-/S6jzWGkKK0fO5yJiC/0KT6MFMc=",
+                  "dev": true
+                },
+                "babel-plugin-runtime": {
+                  "version": "1.0.7",
+                  "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/babel-plugin-runtime/-/babel-plugin-runtime-1.0.7.tgz",
+                  "integrity": "sha1-v3x9lm3Vbs1cF/ocslPJrLflSq8=",
+                  "dev": true
+                },
+                "babel-plugin-undeclared-variables-check": {
+                  "version": "1.0.2",
+                  "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/babel-plugin-undeclared-variables-check/-/babel-plugin-undeclared-variables-check-1.0.2.tgz",
+                  "integrity": "sha1-XPGqU52BP/ZOmWQSkK9iCWX2Xe4=",
+                  "dev": true,
+                  "requires": {
+                    "leven": "1.0.2"
+                  },
+                  "dependencies": {
+                    "leven": {
+                      "version": "1.0.2",
+                      "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/leven/-/leven-1.0.2.tgz",
+                      "integrity": "sha1-kUS27ryl8dBoAWnxpncNzqYLdcM=",
+                      "dev": true
+                    }
+                  }
+                },
+                "babel-plugin-undefined-to-void": {
+                  "version": "1.1.6",
+                  "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/babel-plugin-undefined-to-void/-/babel-plugin-undefined-to-void-1.1.6.tgz",
+                  "integrity": "sha1-f1eO+LeN+uYAM4XYQXph7aBuL4E=",
+                  "dev": true
+                },
+                "babylon": {
+                  "version": "5.8.38",
+                  "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/babylon/-/babylon-5.8.38.tgz",
+                  "integrity": "sha1-7JsSCxG/bM1Bc6GL8hfmC3mFn/0=",
+                  "dev": true
+                },
+                "bluebird": {
+                  "version": "2.11.0",
+                  "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/bluebird/-/bluebird-2.11.0.tgz",
+                  "integrity": "sha1-U0uQM8AiyVecVro7Plpcqvu2UOE=",
+                  "dev": true
+                },
+                "chalk": {
+                  "version": "1.1.3",
+                  "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/chalk/-/chalk-1.1.3.tgz",
+                  "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+                  "dev": true,
+                  "requires": {
+                    "ansi-styles": "2.2.1",
+                    "escape-string-regexp": "1.0.5",
+                    "has-ansi": "2.0.0",
+                    "strip-ansi": "3.0.1",
+                    "supports-color": "2.0.0"
+                  },
+                  "dependencies": {
+                    "ansi-styles": {
+                      "version": "2.2.1",
+                      "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/ansi-styles/-/ansi-styles-2.2.1.tgz",
+                      "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+                      "dev": true
+                    },
+                    "escape-string-regexp": {
+                      "version": "1.0.5",
+                      "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+                      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+                      "dev": true
+                    },
+                    "has-ansi": {
+                      "version": "2.0.0",
+                      "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/has-ansi/-/has-ansi-2.0.0.tgz",
+                      "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
+                      "dev": true,
+                      "requires": {
+                        "ansi-regex": "2.0.0"
+                      },
+                      "dependencies": {
+                        "ansi-regex": {
+                          "version": "2.0.0",
+                          "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/ansi-regex/-/ansi-regex-2.0.0.tgz",
+                          "integrity": "sha1-xQYbbg74qBd15Q9dZhUb9r83EQc=",
+                          "dev": true
+                        }
+                      }
+                    },
+                    "strip-ansi": {
+                      "version": "3.0.1",
+                      "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/strip-ansi/-/strip-ansi-3.0.1.tgz",
+                      "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+                      "dev": true,
+                      "requires": {
+                        "ansi-regex": "2.0.0"
+                      },
+                      "dependencies": {
+                        "ansi-regex": {
+                          "version": "2.0.0",
+                          "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/ansi-regex/-/ansi-regex-2.0.0.tgz",
+                          "integrity": "sha1-xQYbbg74qBd15Q9dZhUb9r83EQc=",
+                          "dev": true
+                        }
+                      }
+                    },
+                    "supports-color": {
+                      "version": "2.0.0",
+                      "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/supports-color/-/supports-color-2.0.0.tgz",
+                      "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+                      "dev": true
+                    }
+                  }
+                },
+                "convert-source-map": {
+                  "version": "1.3.0",
+                  "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/convert-source-map/-/convert-source-map-1.3.0.tgz",
+                  "integrity": "sha1-6fPpxuJyjvwmdmlqcOs4L3MQamc=",
+                  "dev": true
+                },
+                "core-js": {
+                  "version": "1.2.7",
+                  "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/core-js/-/core-js-1.2.7.tgz",
+                  "integrity": "sha1-ZSKUwUZR2yj6k70tX/KYOk8IxjY=",
+                  "dev": true
+                },
+                "detect-indent": {
+                  "version": "3.0.1",
+                  "resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-3.0.1.tgz",
+                  "integrity": "sha1-ncXl3bzu+DJXZLlFGwK8bVQIT3U=",
+                  "dev": true,
+                  "requires": {
+                    "get-stdin": "4.0.1",
+                    "minimist": "1.2.0",
+                    "repeating": "1.1.3"
+                  },
+                  "dependencies": {
+                    "get-stdin": {
+                      "version": "4.0.1",
+                      "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz",
+                      "integrity": "sha1-uWjGsKBDhDJJAui/Gl3zJXmkUP4=",
+                      "dev": true
+                    },
+                    "minimist": {
+                      "version": "1.2.0",
+                      "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/minimist/-/minimist-1.2.0.tgz",
+                      "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+                      "dev": true
+                    }
+                  }
+                },
+                "esutils": {
+                  "version": "2.0.2",
+                  "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
+                  "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=",
+                  "dev": true
+                },
+                "fs-readdir-recursive": {
+                  "version": "0.1.2",
+                  "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/fs-readdir-recursive/-/fs-readdir-recursive-0.1.2.tgz",
+                  "integrity": "sha1-MVtPuMHKW4xH3v7zGdBz2tNWgFk=",
+                  "dev": true
+                },
+                "globals": {
+                  "version": "6.4.1",
+                  "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/globals/-/globals-6.4.1.tgz",
+                  "integrity": "sha1-hJgDKzttHMge68X3lpDY/in6v08=",
+                  "dev": true
+                },
+                "home-or-tmp": {
+                  "version": "1.0.0",
+                  "resolved": "https://registry.npmjs.org/home-or-tmp/-/home-or-tmp-1.0.0.tgz",
+                  "integrity": "sha1-S58eQIAMPlDGwn94FnavzOcfOYU=",
+                  "dev": true,
+                  "requires": {
+                    "os-tmpdir": "1.0.2",
+                    "user-home": "1.1.1"
+                  },
+                  "dependencies": {
+                    "os-tmpdir": {
+                      "version": "1.0.2",
+                      "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+                      "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
+                      "dev": true
+                    },
+                    "user-home": {
+                      "version": "1.1.1",
+                      "resolved": "https://registry.npmjs.org/user-home/-/user-home-1.1.1.tgz",
+                      "integrity": "sha1-K1viOjK2Onyd640PKNSFcko98ZA=",
+                      "dev": true
+                    }
+                  }
+                },
+                "is-integer": {
+                  "version": "1.0.6",
+                  "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/is-integer/-/is-integer-1.0.6.tgz",
+                  "integrity": "sha1-UnOBn62ogNEj4awAqTjnFy3Y2V4=",
+                  "dev": true,
+                  "requires": {
+                    "is-finite": "1.0.2"
+                  },
+                  "dependencies": {
+                    "is-finite": {
+                      "version": "1.0.2",
+                      "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.2.tgz",
+                      "integrity": "sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko=",
+                      "dev": true,
+                      "requires": {
+                        "number-is-nan": "1.0.1"
+                      },
+                      "dependencies": {
+                        "number-is-nan": {
+                          "version": "1.0.1",
+                          "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
+                          "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
+                          "dev": true
+                        }
+                      }
+                    }
+                  }
+                },
+                "js-tokens": {
+                  "version": "1.0.1",
+                  "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/js-tokens/-/js-tokens-1.0.1.tgz",
+                  "integrity": "sha1-zENaXIuUrRWst5gxQPyAGCyJrq4=",
+                  "dev": true
+                },
+                "json5": {
+                  "version": "0.4.0",
+                  "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/json5/-/json5-0.4.0.tgz",
+                  "integrity": "sha1-BUNS5MTIDIbAkjh31EneF2pzLI0=",
+                  "dev": true
+                },
+                "lodash": {
+                  "version": "3.10.1",
+                  "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/lodash/-/lodash-3.10.1.tgz",
+                  "integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y=",
+                  "dev": true
+                },
+                "minimatch": {
+                  "version": "2.0.10",
+                  "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/minimatch/-/minimatch-2.0.10.tgz",
+                  "integrity": "sha1-jQh8OcazjAAbl/ynzm0OHoCvusc=",
+                  "dev": true,
+                  "requires": {
+                    "brace-expansion": "1.1.6"
+                  },
+                  "dependencies": {
+                    "brace-expansion": {
+                      "version": "1.1.6",
+                      "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/brace-expansion/-/brace-expansion-1.1.6.tgz",
+                      "integrity": "sha1-cZfX6qm4fmSDkOph/GbIRCdCDfk=",
+                      "dev": true,
+                      "requires": {
+                        "balanced-match": "0.4.2",
+                        "concat-map": "0.0.1"
+                      },
+                      "dependencies": {
+                        "balanced-match": {
+                          "version": "0.4.2",
+                          "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/balanced-match/-/balanced-match-0.4.2.tgz",
+                          "integrity": "sha1-yz8+PHMtwPAe5wtAPzAuYddwmDg=",
+                          "dev": true
+                        },
+                        "concat-map": {
+                          "version": "0.0.1",
+                          "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+                          "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+                          "dev": true
+                        }
+                      }
+                    }
+                  }
+                },
+                "output-file-sync": {
+                  "version": "1.1.2",
+                  "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/output-file-sync/-/output-file-sync-1.1.2.tgz",
+                  "integrity": "sha1-0KM+7+YaIF+suQCS6CZZjVJFznY=",
+                  "dev": true,
+                  "requires": {
+                    "graceful-fs": "4.1.9",
+                    "mkdirp": "0.5.1",
+                    "object-assign": "4.1.0"
+                  },
+                  "dependencies": {
+                    "graceful-fs": {
+                      "version": "4.1.9",
+                      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.9.tgz",
+                      "integrity": "sha1-uqy6N9GdEfnRRtNXi8mZWMN4fik=",
+                      "dev": true
+                    },
+                    "mkdirp": {
+                      "version": "0.5.1",
+                      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+                      "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+                      "dev": true,
+                      "requires": {
+                        "minimist": "0.0.8"
+                      },
+                      "dependencies": {
+                        "minimist": {
+                          "version": "0.0.8",
+                          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+                          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+                          "dev": true
+                        }
+                      }
+                    },
+                    "object-assign": {
+                      "version": "4.1.0",
+                      "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/object-assign/-/object-assign-4.1.0.tgz",
+                      "integrity": "sha1-ejs9DpgGPUP0wD8uiubNUahog6A=",
+                      "dev": true
+                    }
+                  }
+                },
+                "path-exists": {
+                  "version": "1.0.0",
+                  "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/path-exists/-/path-exists-1.0.0.tgz",
+                  "integrity": "sha1-1aiZjrce83p0w06w2eum6HjuoIE=",
+                  "dev": true
+                },
+                "path-is-absolute": {
+                  "version": "1.0.1",
+                  "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+                  "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+                  "dev": true
+                },
+                "private": {
+                  "version": "0.1.6",
+                  "resolved": "https://registry.npmjs.org/private/-/private-0.1.6.tgz",
+                  "integrity": "sha1-VcapdtD5uvuZJIUTUP5HubX7t8E=",
+                  "dev": true
+                },
+                "regenerator": {
+                  "version": "0.8.40",
+                  "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/regenerator/-/regenerator-0.8.40.tgz",
+                  "integrity": "sha1-oORXxY69uuV1yfjNdRJ+k3VkNdg=",
+                  "dev": true,
+                  "requires": {
+                    "commoner": "0.10.4",
+                    "defs": "1.1.1",
+                    "esprima-fb": "15001.1001.0-dev-harmony-fb",
+                    "private": "0.1.6",
+                    "recast": "0.10.33",
+                    "through": "2.3.8"
+                  },
+                  "dependencies": {
+                    "commoner": {
+                      "version": "0.10.4",
+                      "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/commoner/-/commoner-0.10.4.tgz",
+                      "integrity": "sha1-mPMzPdOtOZWWuy04Sng7tyE9aPg=",
+                      "dev": true,
+                      "requires": {
+                        "commander": "2.9.0",
+                        "detective": "4.3.1",
+                        "glob": "5.0.15",
+                        "graceful-fs": "4.1.9",
+                        "iconv-lite": "0.4.13",
+                        "mkdirp": "0.5.1",
+                        "private": "0.1.6",
+                        "q": "1.4.1",
+                        "recast": "0.10.33"
+                      },
+                      "dependencies": {
+                        "commander": {
+                          "version": "2.9.0",
+                          "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
+                          "integrity": "sha1-nJkJQXbhIkDLItbFFGCYQA/g99Q=",
+                          "dev": true,
+                          "requires": {
+                            "graceful-readlink": "1.0.1"
+                          },
+                          "dependencies": {
+                            "graceful-readlink": {
+                              "version": "1.0.1",
+                              "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz",
+                              "integrity": "sha1-TK+tdrxi8C+gObL5Tpo906ORpyU=",
+                              "dev": true
+                            }
+                          }
+                        },
+                        "detective": {
+                          "version": "4.3.1",
+                          "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/detective/-/detective-4.3.1.tgz",
+                          "integrity": "sha1-n7Bt0e6PDqTbzGB82jnZzh1Pcm8=",
+                          "dev": true,
+                          "requires": {
+                            "acorn": "1.2.2",
+                            "defined": "1.0.0"
+                          },
+                          "dependencies": {
+                            "acorn": {
+                              "version": "1.2.2",
+                              "resolved": "https://registry.npmjs.org/acorn/-/acorn-1.2.2.tgz",
+                              "integrity": "sha1-yM4n3grMdtiW0rH6099YjZ6C8BQ=",
+                              "dev": true
+                            },
+                            "defined": {
+                              "version": "1.0.0",
+                              "resolved": "https://registry.npmjs.org/defined/-/defined-1.0.0.tgz",
+                              "integrity": "sha1-yY2bzvdWdBiOEQlpFRGZ45sfppM=",
+                              "dev": true
+                            }
+                          }
+                        },
+                        "graceful-fs": {
+                          "version": "4.1.9",
+                          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.9.tgz",
+                          "integrity": "sha1-uqy6N9GdEfnRRtNXi8mZWMN4fik=",
+                          "dev": true
+                        },
+                        "iconv-lite": {
+                          "version": "0.4.13",
+                          "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/iconv-lite/-/iconv-lite-0.4.13.tgz",
+                          "integrity": "sha1-H4irpKsLFQjoMSrMOTRfNumS4vI=",
+                          "dev": true
+                        },
+                        "mkdirp": {
+                          "version": "0.5.1",
+                          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+                          "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+                          "dev": true,
+                          "requires": {
+                            "minimist": "0.0.8"
+                          },
+                          "dependencies": {
+                            "minimist": {
+                              "version": "0.0.8",
+                              "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+                              "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+                              "dev": true
+                            }
+                          }
+                        },
+                        "q": {
+                          "version": "1.4.1",
+                          "resolved": "https://registry.npmjs.org/q/-/q-1.4.1.tgz",
+                          "integrity": "sha1-VXBbzZPF82c1MMLCy8DCs63cKG4=",
+                          "dev": true
+                        }
+                      }
+                    },
+                    "defs": {
+                      "version": "1.1.1",
+                      "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/defs/-/defs-1.1.1.tgz",
+                      "integrity": "sha1-siYJ8sehG6ej2xFoBcE5scr/qdI=",
+                      "dev": true,
+                      "requires": {
+                        "alter": "0.2.0",
+                        "ast-traverse": "0.1.1",
+                        "breakable": "1.0.0",
+                        "esprima-fb": "15001.1001.0-dev-harmony-fb",
+                        "simple-fmt": "0.1.0",
+                        "simple-is": "0.2.0",
+                        "stringmap": "0.2.2",
+                        "stringset": "0.2.1",
+                        "tryor": "0.1.2",
+                        "yargs": "3.27.0"
+                      },
+                      "dependencies": {
+                        "alter": {
+                          "version": "0.2.0",
+                          "resolved": "https://registry.npmjs.org/alter/-/alter-0.2.0.tgz",
+                          "integrity": "sha1-x1iICGF1cgNKrmJICvJrHU0cs80=",
+                          "dev": true,
+                          "requires": {
+                            "stable": "0.1.5"
+                          },
+                          "dependencies": {
+                            "stable": {
+                              "version": "0.1.5",
+                              "resolved": "https://registry.npmjs.org/stable/-/stable-0.1.5.tgz",
+                              "integrity": "sha1-CCMvYMcy6YkHhLW+0HNPizKoh7k=",
+                              "dev": true
+                            }
+                          }
+                        },
+                        "ast-traverse": {
+                          "version": "0.1.1",
+                          "resolved": "https://registry.npmjs.org/ast-traverse/-/ast-traverse-0.1.1.tgz",
+                          "integrity": "sha1-ac8rg4bxnc2hux4F1o/jWdiJfeY=",
+                          "dev": true
+                        },
+                        "breakable": {
+                          "version": "1.0.0",
+                          "resolved": "https://registry.npmjs.org/breakable/-/breakable-1.0.0.tgz",
+                          "integrity": "sha1-eEp5eRWjjq0nutRWtVcstLuqeME=",
+                          "dev": true
+                        },
+                        "simple-fmt": {
+                          "version": "0.1.0",
+                          "resolved": "https://registry.npmjs.org/simple-fmt/-/simple-fmt-0.1.0.tgz",
+                          "integrity": "sha1-GRv1ZqWeZTBILLJatTtKjchcOms=",
+                          "dev": true
+                        },
+                        "simple-is": {
+                          "version": "0.2.0",
+                          "resolved": "https://registry.npmjs.org/simple-is/-/simple-is-0.2.0.tgz",
+                          "integrity": "sha1-Krt1qt453rXMgVzhDmGRFkhQuvA=",
+                          "dev": true
+                        },
+                        "stringmap": {
+                          "version": "0.2.2",
+                          "resolved": "https://registry.npmjs.org/stringmap/-/stringmap-0.2.2.tgz",
+                          "integrity": "sha1-VWwTeyWPlCuHdvWy71gqoGnX0bE=",
+                          "dev": true
+                        },
+                        "stringset": {
+                          "version": "0.2.1",
+                          "resolved": "https://registry.npmjs.org/stringset/-/stringset-0.2.1.tgz",
+                          "integrity": "sha1-7yWcTjSTRDd/zRyRPdLoSMnAQrU=",
+                          "dev": true
+                        },
+                        "tryor": {
+                          "version": "0.1.2",
+                          "resolved": "https://registry.npmjs.org/tryor/-/tryor-0.1.2.tgz",
+                          "integrity": "sha1-gUXkynyv9ArN48z5Rui4u3W0Fys=",
+                          "dev": true
+                        },
+                        "yargs": {
+                          "version": "3.27.0",
+                          "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/yargs/-/yargs-3.27.0.tgz",
+                          "integrity": "sha1-ISBUaTFuk5Ex1Z8toMbX+YIh6kA=",
+                          "dev": true,
+                          "requires": {
+                            "camelcase": "1.2.1",
+                            "cliui": "2.1.0",
+                            "decamelize": "1.2.0",
+                            "os-locale": "1.4.0",
+                            "window-size": "0.1.4",
+                            "y18n": "3.2.1"
+                          },
+                          "dependencies": {
+                            "cliui": {
+                              "version": "2.1.0",
+                              "resolved": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
+                              "integrity": "sha1-S0dXYP+AJkx2LDoXGQMukcf+oNE=",
+                              "dev": true,
+                              "requires": {
+                                "center-align": "0.1.3",
+                                "right-align": "0.1.3",
+                                "wordwrap": "0.0.2"
+                              },
+                              "dependencies": {
+                                "center-align": {
+                                  "version": "0.1.3",
+                                  "resolved": "https://registry.npmjs.org/center-align/-/center-align-0.1.3.tgz",
+                                  "integrity": "sha1-qg0yYptu6XIgBBHL1EYckHvCt60=",
+                                  "dev": true,
+                                  "requires": {
+                                    "align-text": "0.1.4",
+                                    "lazy-cache": "1.0.4"
+                                  },
+                                  "dependencies": {
+                                    "align-text": {
+                                      "version": "0.1.4",
+                                      "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
+                                      "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
+                                      "dev": true,
+                                      "requires": {
+                                        "kind-of": "3.0.4",
+                                        "longest": "1.0.1",
+                                        "repeat-string": "1.5.4"
+                                      },
+                                      "dependencies": {
+                                        "kind-of": {
+                                          "version": "3.0.4",
+                                          "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/kind-of/-/kind-of-3.0.4.tgz",
+                                          "integrity": "sha1-e47PGKThf4Jp1ztQHJ8jLJaIenQ=",
+                                          "dev": true,
+                                          "requires": {
+                                            "is-buffer": "1.1.4"
+                                          },
+                                          "dependencies": {
+                                            "is-buffer": {
+                                              "version": "1.1.4",
+                                              "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/is-buffer/-/is-buffer-1.1.4.tgz",
+                                              "integrity": "sha1-z8hszV3FpS+oBIkRHGkgxFfi2Ys=",
+                                              "dev": true
+                                            }
+                                          }
+                                        },
+                                        "longest": {
+                                          "version": "1.0.1",
+                                          "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
+                                          "integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc=",
+                                          "dev": true
+                                        },
+                                        "repeat-string": {
+                                          "version": "1.5.4",
+                                          "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.5.4.tgz",
+                                          "integrity": "sha1-ZOwMkeD0tHX5DVtkNlHj5uW2wtU=",
+                                          "dev": true
+                                        }
+                                      }
+                                    },
+                                    "lazy-cache": {
+                                      "version": "1.0.4",
+                                      "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/lazy-cache/-/lazy-cache-1.0.4.tgz",
+                                      "integrity": "sha1-odePw6UEdMuAhF07O24dpJpEbo4=",
+                                      "dev": true
+                                    }
+                                  }
+                                },
+                                "right-align": {
+                                  "version": "0.1.3",
+                                  "resolved": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
+                                  "integrity": "sha1-YTObci/mo1FWiSENJOFMlhSGE+8=",
+                                  "dev": true,
+                                  "requires": {
+                                    "align-text": "0.1.4"
+                                  },
+                                  "dependencies": {
+                                    "align-text": {
+                                      "version": "0.1.4",
+                                      "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
+                                      "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
+                                      "dev": true,
+                                      "requires": {
+                                        "kind-of": "3.0.4",
+                                        "longest": "1.0.1",
+                                        "repeat-string": "1.5.4"
+                                      },
+                                      "dependencies": {
+                                        "kind-of": {
+                                          "version": "3.0.4",
+                                          "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/kind-of/-/kind-of-3.0.4.tgz",
+                                          "integrity": "sha1-e47PGKThf4Jp1ztQHJ8jLJaIenQ=",
+                                          "dev": true,
+                                          "requires": {
+                                            "is-buffer": "1.1.4"
+                                          },
+                                          "dependencies": {
+                                            "is-buffer": {
+                                              "version": "1.1.4",
+                                              "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/is-buffer/-/is-buffer-1.1.4.tgz",
+                                              "integrity": "sha1-z8hszV3FpS+oBIkRHGkgxFfi2Ys=",
+                                              "dev": true
+                                            }
+                                          }
+                                        },
+                                        "longest": {
+                                          "version": "1.0.1",
+                                          "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
+                                          "integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc=",
+                                          "dev": true
+                                        },
+                                        "repeat-string": {
+                                          "version": "1.5.4",
+                                          "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.5.4.tgz",
+                                          "integrity": "sha1-ZOwMkeD0tHX5DVtkNlHj5uW2wtU=",
+                                          "dev": true
+                                        }
+                                      }
+                                    }
+                                  }
+                                },
+                                "wordwrap": {
+                                  "version": "0.0.2",
+                                  "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
+                                  "integrity": "sha1-t5Zpu0LstAn4PVg8rVLKF+qhZD8=",
+                                  "dev": true
+                                }
+                              }
+                            },
+                            "decamelize": {
+                              "version": "1.2.0",
+                              "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+                              "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
+                              "dev": true
+                            },
+                            "os-locale": {
+                              "version": "1.4.0",
+                              "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/os-locale/-/os-locale-1.4.0.tgz",
+                              "integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
+                              "dev": true,
+                              "requires": {
+                                "lcid": "1.0.0"
+                              },
+                              "dependencies": {
+                                "lcid": {
+                                  "version": "1.0.0",
+                                  "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/lcid/-/lcid-1.0.0.tgz",
+                                  "integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
+                                  "dev": true,
+                                  "requires": {
+                                    "invert-kv": "1.0.0"
+                                  },
+                                  "dependencies": {
+                                    "invert-kv": {
+                                      "version": "1.0.0",
+                                      "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/invert-kv/-/invert-kv-1.0.0.tgz",
+                                      "integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY=",
+                                      "dev": true
+                                    }
+                                  }
+                                }
+                              }
+                            },
+                            "window-size": {
+                              "version": "0.1.4",
+                              "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/window-size/-/window-size-0.1.4.tgz",
+                              "integrity": "sha1-+OGqHuWlPsW/FR/6CXQqatdpeHY=",
+                              "dev": true
+                            },
+                            "y18n": {
+                              "version": "3.2.1",
+                              "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/y18n/-/y18n-3.2.1.tgz",
+                              "integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE=",
+                              "dev": true
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "esprima-fb": {
+                      "version": "15001.1001.0-dev-harmony-fb",
+                      "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/esprima-fb/-/esprima-fb-15001.1001.0-dev-harmony-fb.tgz",
+                      "integrity": "sha1-Q761fsJujPI3092LM+QlM1d/Jlk=",
+                      "dev": true
+                    },
+                    "recast": {
+                      "version": "0.10.33",
+                      "resolved": "https://registry.npmjs.org/recast/-/recast-0.10.33.tgz",
+                      "integrity": "sha1-lCgI96oBbx+nFCxGHX5XBKqo1pc=",
+                      "dev": true,
+                      "requires": {
+                        "ast-types": "0.8.12",
+                        "esprima-fb": "15001.1001.0-dev-harmony-fb",
+                        "private": "0.1.6",
+                        "source-map": "0.5.6"
+                      },
+                      "dependencies": {
+                        "ast-types": {
+                          "version": "0.8.12",
+                          "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/ast-types/-/ast-types-0.8.12.tgz",
+                          "integrity": "sha1-oNkOQ1G7iHcWyD/WN+v4GK9K38w=",
+                          "dev": true
+                        }
+                      }
+                    },
+                    "through": {
+                      "version": "2.3.8",
+                      "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/through/-/through-2.3.8.tgz",
+                      "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
+                      "dev": true
+                    }
+                  }
+                },
+                "regexpu": {
+                  "version": "1.3.0",
+                  "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/regexpu/-/regexpu-1.3.0.tgz",
+                  "integrity": "sha1-5TTcmRqeWEYFDJjebX3UpVyeoW0=",
+                  "dev": true,
+                  "requires": {
+                    "esprima": "2.7.3",
+                    "recast": "0.10.43",
+                    "regenerate": "1.3.1",
+                    "regjsgen": "0.2.0",
+                    "regjsparser": "0.1.5"
+                  },
+                  "dependencies": {
+                    "esprima": {
+                      "version": "2.7.3",
+                      "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/esprima/-/esprima-2.7.3.tgz",
+                      "integrity": "sha1-luO3DVd59q1JzQMmc9HDEnZ7pYE=",
+                      "dev": true
+                    },
+                    "recast": {
+                      "version": "0.10.43",
+                      "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/recast/-/recast-0.10.43.tgz",
+                      "integrity": "sha1-uV1Q9tYHYaX2JS4V2AZ4FoSRzn8=",
+                      "dev": true,
+                      "requires": {
+                        "ast-types": "0.8.15",
+                        "esprima-fb": "15001.1001.0-dev-harmony-fb",
+                        "private": "0.1.6",
+                        "source-map": "0.5.6"
+                      },
+                      "dependencies": {
+                        "ast-types": {
+                          "version": "0.8.15",
+                          "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/ast-types/-/ast-types-0.8.15.tgz",
+                          "integrity": "sha1-ju8IJ/BN/w7IhXupJavj/qYZTlI=",
+                          "dev": true
+                        },
+                        "esprima-fb": {
+                          "version": "15001.1001.0-dev-harmony-fb",
+                          "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/esprima-fb/-/esprima-fb-15001.1001.0-dev-harmony-fb.tgz",
+                          "integrity": "sha1-Q761fsJujPI3092LM+QlM1d/Jlk=",
+                          "dev": true
+                        }
+                      }
+                    },
+                    "regenerate": {
+                      "version": "1.3.1",
+                      "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/regenerate/-/regenerate-1.3.1.tgz",
+                      "integrity": "sha1-AwAgOl0v3PiRFtzoQnXQEfWQPzM=",
+                      "dev": true
+                    },
+                    "regjsgen": {
+                      "version": "0.2.0",
+                      "resolved": "https://registry.npmjs.org/regjsgen/-/regjsgen-0.2.0.tgz",
+                      "integrity": "sha1-bAFq3qxVT3WCP+N6wFuS1aTtsfc=",
+                      "dev": true
+                    },
+                    "regjsparser": {
+                      "version": "0.1.5",
+                      "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/regjsparser/-/regjsparser-0.1.5.tgz",
+                      "integrity": "sha1-fuj4Tcb6eS0/0K4ijSS9lJ6tIFw=",
+                      "dev": true,
+                      "requires": {
+                        "jsesc": "0.5.0"
+                      },
+                      "dependencies": {
+                        "jsesc": {
+                          "version": "0.5.0",
+                          "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz",
+                          "integrity": "sha1-597mbjXW/Bb3EP6R1c9p9w8IkR0=",
+                          "dev": true
+                        }
+                      }
+                    }
+                  }
+                },
+                "repeating": {
+                  "version": "1.1.3",
+                  "resolved": "https://registry.npmjs.org/repeating/-/repeating-1.1.3.tgz",
+                  "integrity": "sha1-PUEUIYh3U3SU+X93+Xhfq4EPpKw=",
+                  "dev": true,
+                  "requires": {
+                    "is-finite": "1.0.2"
+                  },
+                  "dependencies": {
+                    "is-finite": {
+                      "version": "1.0.2",
+                      "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.2.tgz",
+                      "integrity": "sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko=",
+                      "dev": true,
+                      "requires": {
+                        "number-is-nan": "1.0.1"
+                      },
+                      "dependencies": {
+                        "number-is-nan": {
+                          "version": "1.0.1",
+                          "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
+                          "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
+                          "dev": true
+                        }
+                      }
+                    }
+                  }
+                },
+                "resolve": {
+                  "version": "1.1.7",
+                  "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/resolve/-/resolve-1.1.7.tgz",
+                  "integrity": "sha1-IDEU2CrSxe2ejgQRs5ModeiJ6Xs=",
+                  "dev": true
+                },
+                "shebang-regex": {
+                  "version": "1.0.0",
+                  "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
+                  "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
+                  "dev": true
+                },
+                "source-map": {
+                  "version": "0.5.6",
+                  "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/source-map/-/source-map-0.5.6.tgz",
+                  "integrity": "sha1-dc449SvwczxafwwRjYEzSiu19BI=",
+                  "dev": true
+                },
+                "source-map-support": {
+                  "version": "0.2.10",
+                  "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.2.10.tgz",
+                  "integrity": "sha1-6lo5AKHByyUJagrozFwrSxDe09w=",
+                  "dev": true,
+                  "requires": {
+                    "source-map": "0.1.32"
+                  },
+                  "dependencies": {
+                    "source-map": {
+                      "version": "0.1.32",
+                      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.32.tgz",
+                      "integrity": "sha1-yLbBZ3l7pHQKjqMyUhYv8IWRsmY=",
+                      "dev": true,
+                      "requires": {
+                        "amdefine": "1.0.0"
+                      },
+                      "dependencies": {
+                        "amdefine": {
+                          "version": "1.0.0",
+                          "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz",
+                          "integrity": "sha1-/RdHRwDLXMnCtwnwvp0jzjwZjDM=",
+                          "dev": true
+                        }
+                      }
+                    }
+                  }
+                },
+                "to-fast-properties": {
+                  "version": "1.0.2",
+                  "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/to-fast-properties/-/to-fast-properties-1.0.2.tgz",
+                  "integrity": "sha1-8/XAw7pymafvmUJ+RGMyV63kMyA=",
+                  "dev": true
+                },
+                "trim-right": {
+                  "version": "1.0.1",
+                  "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/trim-right/-/trim-right-1.0.1.tgz",
+                  "integrity": "sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM=",
+                  "dev": true
+                },
+                "try-resolve": {
+                  "version": "1.0.1",
+                  "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/try-resolve/-/try-resolve-1.0.1.tgz",
+                  "integrity": "sha1-z95vq9ctY+V5fPqrhzq76OcA6RI=",
+                  "dev": true
+                }
+              }
+            },
+            "slash": {
+              "version": "1.0.0",
+              "resolved": "https://registry.npmjs.org/slash/-/slash-1.0.0.tgz",
+              "integrity": "sha1-xB8vbDn8FtHNF61LXYlhFK5HDVU=",
+              "dev": true
+            }
+          }
+        },
+        "metalsmith-build-date": {
+          "version": "0.1.0",
+          "resolved": "https://registry.npmjs.org/metalsmith-build-date/-/metalsmith-build-date-0.1.0.tgz",
+          "integrity": "sha1-PVFJ1L/qEriaMoJzbMr1HfEn/m0=",
+          "dev": true
+        },
+        "metalsmith-collections": {
+          "version": "0.7.0",
+          "resolved": "https://registry.npmjs.org/metalsmith-collections/-/metalsmith-collections-0.7.0.tgz",
+          "integrity": "sha1-vjCB3bbEqKijwD0JWkvxtXP7nfY=",
+          "dev": true,
+          "requires": {
+            "debug": "0.7.4",
+            "extend": "1.2.1",
+            "minimatch": "0.2.14",
+            "read-metadata": "0.0.2",
+            "uniq": "0.0.2"
+          },
+          "dependencies": {
+            "debug": {
+              "version": "0.7.4",
+              "resolved": "https://registry.npmjs.org/debug/-/debug-0.7.4.tgz",
+              "integrity": "sha1-BuHqgILCyxTjmAbiLi9vdX+Srzk=",
+              "dev": true
+            },
+            "extend": {
+              "version": "1.2.1",
+              "resolved": "https://registry.npmjs.org/extend/-/extend-1.2.1.tgz",
+              "integrity": "sha1-oPX9bPyDpf5J72mNYOyKYk3UV2w=",
+              "dev": true
+            },
+            "minimatch": {
+              "version": "0.2.14",
+              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
+              "integrity": "sha1-x054BXT2PG+aCQ6Q775u9TpqdWo=",
+              "dev": true,
+              "requires": {
+                "lru-cache": "2.7.3",
+                "sigmund": "1.0.1"
+              },
+              "dependencies": {
+                "lru-cache": {
+                  "version": "2.7.3",
+                  "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/lru-cache/-/lru-cache-2.7.3.tgz",
+                  "integrity": "sha1-bUUk6LlV+V1PW1iFHOId1y+06VI=",
+                  "dev": true
+                },
+                "sigmund": {
+                  "version": "1.0.1",
+                  "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz",
+                  "integrity": "sha1-P/IfGYytIXX587eBhT/ZTQ0ZtZA=",
+                  "dev": true
+                }
+              }
+            },
+            "read-metadata": {
+              "version": "0.0.2",
+              "resolved": "https://registry.npmjs.org/read-metadata/-/read-metadata-0.0.2.tgz",
+              "integrity": "sha1-SzktqGYx7SUN4PaJeHhgHzgZ5JE=",
+              "dev": true,
+              "requires": {
+                "yaml-js": "0.0.8"
+              },
+              "dependencies": {
+                "yaml-js": {
+                  "version": "0.0.8",
+                  "resolved": "https://registry.npmjs.org/yaml-js/-/yaml-js-0.0.8.tgz",
+                  "integrity": "sha1-h8+lqWE/SOJgBUINao7g2m/o2uw=",
+                  "dev": true
+                }
+              }
+            },
+            "uniq": {
+              "version": "0.0.2",
+              "resolved": "https://registry.npmjs.org/uniq/-/uniq-0.0.2.tgz",
+              "integrity": "sha1-YU6Gi6KIZR01EmI2kxesxDuQGCM=",
+              "dev": true
+            }
+          }
+        },
+        "metalsmith-copy": {
+          "version": "0.2.1",
+          "resolved": "https://registry.npmjs.org/metalsmith-copy/-/metalsmith-copy-0.2.1.tgz",
+          "integrity": "sha1-FzOtxlYICZNNKJvKXNTZ+qs1bgI=",
+          "dev": true,
+          "requires": {
+            "debug": "0.8.1",
+            "lodash": "2.4.2",
+            "minimatch": "0.2.14"
+          },
+          "dependencies": {
+            "debug": {
+              "version": "0.8.1",
+              "resolved": "https://registry.npmjs.org/debug/-/debug-0.8.1.tgz",
+              "integrity": "sha1-IP9NJvXkIstoobrLu2EDmtjBwTA=",
+              "dev": true
+            },
+            "lodash": {
+              "version": "2.4.2",
+              "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz",
+              "integrity": "sha1-+t2DS5aDBz2hebPq5tnA0VBT9z4=",
+              "dev": true
+            },
+            "minimatch": {
+              "version": "0.2.14",
+              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
+              "integrity": "sha1-x054BXT2PG+aCQ6Q775u9TpqdWo=",
+              "dev": true,
+              "requires": {
+                "lru-cache": "2.7.3",
+                "sigmund": "1.0.1"
+              },
+              "dependencies": {
+                "lru-cache": {
+                  "version": "2.7.3",
+                  "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/lru-cache/-/lru-cache-2.7.3.tgz",
+                  "integrity": "sha1-bUUk6LlV+V1PW1iFHOId1y+06VI=",
+                  "dev": true
+                },
+                "sigmund": {
+                  "version": "1.0.1",
+                  "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz",
+                  "integrity": "sha1-P/IfGYytIXX587eBhT/ZTQ0ZtZA=",
+                  "dev": true
+                }
+              }
+            }
+          }
+        },
+        "metalsmith-drafts": {
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/metalsmith-drafts/-/metalsmith-drafts-0.0.1.tgz",
+          "integrity": "sha1-cnhYuiZpNKN6KHATvsqbYDMnL3c=",
+          "dev": true
+        },
+        "metalsmith-html-minifier": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/metalsmith-html-minifier/-/metalsmith-html-minifier-1.1.0.tgz",
+          "integrity": "sha1-PBhPOwkJbXeXiPhSTQh29xSJPp8=",
+          "dev": true,
+          "requires": {
+            "html-minifier": "0.6.9"
+          },
+          "dependencies": {
+            "html-minifier": {
+              "version": "0.6.9",
+              "resolved": "https://registry.npmjs.org/html-minifier/-/html-minifier-0.6.9.tgz",
+              "integrity": "sha1-UQXcI29efhqLplHUq5gThvx6vlM=",
+              "dev": true,
+              "requires": {
+                "change-case": "2.1.6",
+                "clean-css": "2.2.23",
+                "cli": "0.6.6",
+                "relateurl": "0.2.7",
+                "uglify-js": "2.4.24"
+              },
+              "dependencies": {
+                "change-case": {
+                  "version": "2.1.6",
+                  "resolved": "https://registry.npmjs.org/change-case/-/change-case-2.1.6.tgz",
+                  "integrity": "sha1-UUryBRMVimj+fwDf9MMy1sKY0vk=",
+                  "dev": true,
+                  "requires": {
+                    "camel-case": "1.2.2",
+                    "constant-case": "1.1.2",
+                    "dot-case": "1.1.2",
+                    "is-lower-case": "1.1.3",
+                    "is-upper-case": "1.1.2",
+                    "lower-case": "1.1.3",
+                    "param-case": "1.1.2",
+                    "pascal-case": "1.1.2",
+                    "path-case": "1.1.2",
+                    "sentence-case": "1.1.3",
+                    "snake-case": "1.1.2",
+                    "swap-case": "1.1.2",
+                    "title-case": "1.1.2",
+                    "upper-case": "1.1.3",
+                    "upper-case-first": "1.1.2"
+                  },
+                  "dependencies": {
+                    "camel-case": {
+                      "version": "1.2.2",
+                      "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/camel-case/-/camel-case-1.2.2.tgz",
+                      "integrity": "sha1-Gsp8TRlTWaLOmVV5NDPG5VQlEfI=",
+                      "dev": true,
+                      "requires": {
+                        "sentence-case": "1.1.3",
+                        "upper-case": "1.1.3"
+                      }
+                    },
+                    "constant-case": {
+                      "version": "1.1.2",
+                      "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/constant-case/-/constant-case-1.1.2.tgz",
+                      "integrity": "sha1-jsLKW6ND4Aqjjb9OIA/VrJB+/WM=",
+                      "dev": true,
+                      "requires": {
+                        "snake-case": "1.1.2",
+                        "upper-case": "1.1.3"
+                      }
+                    },
+                    "dot-case": {
+                      "version": "1.1.2",
+                      "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/dot-case/-/dot-case-1.1.2.tgz",
+                      "integrity": "sha1-HnOCaQDeKNbeVIC8HeMdCEKwa+w=",
+                      "dev": true,
+                      "requires": {
+                        "sentence-case": "1.1.3"
+                      }
+                    },
+                    "is-lower-case": {
+                      "version": "1.1.3",
+                      "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/is-lower-case/-/is-lower-case-1.1.3.tgz",
+                      "integrity": "sha1-fhR75HaNxGbbO/shzGCzHmrWk5M=",
+                      "dev": true,
+                      "requires": {
+                        "lower-case": "1.1.3"
+                      }
+                    },
+                    "is-upper-case": {
+                      "version": "1.1.2",
+                      "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/is-upper-case/-/is-upper-case-1.1.2.tgz",
+                      "integrity": "sha1-jQsfp+eTOh5YSDYA7H2WYcuvdW8=",
+                      "dev": true,
+                      "requires": {
+                        "upper-case": "1.1.3"
+                      }
+                    },
+                    "lower-case": {
+                      "version": "1.1.3",
+                      "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/lower-case/-/lower-case-1.1.3.tgz",
+                      "integrity": "sha1-ySOT2XZ5Pu5bpO21g8+OrjW9m/s=",
+                      "dev": true
+                    },
+                    "param-case": {
+                      "version": "1.1.2",
+                      "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/param-case/-/param-case-1.1.2.tgz",
+                      "integrity": "sha1-3LCRpDwlm5Io8cNB57akTqC/l0M=",
+                      "dev": true,
+                      "requires": {
+                        "sentence-case": "1.1.3"
+                      }
+                    },
+                    "pascal-case": {
+                      "version": "1.1.2",
+                      "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/pascal-case/-/pascal-case-1.1.2.tgz",
+                      "integrity": "sha1-Pl1kogBDgwp8STRMLXS0G+DJyZs=",
+                      "dev": true,
+                      "requires": {
+                        "camel-case": "1.2.2",
+                        "upper-case-first": "1.1.2"
+                      }
+                    },
+                    "path-case": {
+                      "version": "1.1.2",
+                      "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/path-case/-/path-case-1.1.2.tgz",
+                      "integrity": "sha1-UM5roNO+090LXCqcRVNpdDRAlRQ=",
+                      "dev": true,
+                      "requires": {
+                        "sentence-case": "1.1.3"
+                      }
+                    },
+                    "sentence-case": {
+                      "version": "1.1.3",
+                      "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/sentence-case/-/sentence-case-1.1.3.tgz",
+                      "integrity": "sha1-gDSq/CFFdy06vhUJqkLJ4QQtwTk=",
+                      "dev": true,
+                      "requires": {
+                        "lower-case": "1.1.3"
+                      }
+                    },
+                    "snake-case": {
+                      "version": "1.1.2",
+                      "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/snake-case/-/snake-case-1.1.2.tgz",
+                      "integrity": "sha1-DC8l4wUVjZoY09l3BmGH/vilpmo=",
+                      "dev": true,
+                      "requires": {
+                        "sentence-case": "1.1.3"
+                      }
+                    },
+                    "swap-case": {
+                      "version": "1.1.2",
+                      "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/swap-case/-/swap-case-1.1.2.tgz",
+                      "integrity": "sha1-w5IDpFhzhfrTyFCgvRvK+ggZdOM=",
+                      "dev": true,
+                      "requires": {
+                        "lower-case": "1.1.3",
+                        "upper-case": "1.1.3"
+                      }
+                    },
+                    "title-case": {
+                      "version": "1.1.2",
+                      "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/title-case/-/title-case-1.1.2.tgz",
+                      "integrity": "sha1-+uSmrlRr+iLQg6DuqRCkDRLtT1o=",
+                      "dev": true,
+                      "requires": {
+                        "sentence-case": "1.1.3",
+                        "upper-case": "1.1.3"
+                      }
+                    },
+                    "upper-case": {
+                      "version": "1.1.3",
+                      "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/upper-case/-/upper-case-1.1.3.tgz",
+                      "integrity": "sha1-9rRQHC7EzdJrp4vnIilh3ndiFZg=",
+                      "dev": true
+                    },
+                    "upper-case-first": {
+                      "version": "1.1.2",
+                      "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/upper-case-first/-/upper-case-first-1.1.2.tgz",
+                      "integrity": "sha1-XXm+3P8UQZUY/S7bCgUHybaFkRU=",
+                      "dev": true,
+                      "requires": {
+                        "upper-case": "1.1.3"
+                      }
+                    }
+                  }
+                },
+                "clean-css": {
+                  "version": "2.2.23",
+                  "resolved": "https://registry.npmjs.org/clean-css/-/clean-css-2.2.23.tgz",
+                  "integrity": "sha1-BZC1R4tRbEkD7cLYm9P9vdKGMow=",
+                  "dev": true,
+                  "requires": {
+                    "commander": "2.2.0"
+                  },
+                  "dependencies": {
+                    "commander": {
+                      "version": "2.2.0",
+                      "resolved": "https://registry.npmjs.org/commander/-/commander-2.2.0.tgz",
+                      "integrity": "sha1-F1rUuTF/P/YV8gHB5XIk9Vo+kd8=",
+                      "dev": true
+                    }
+                  }
+                },
+                "cli": {
+                  "version": "0.6.6",
+                  "resolved": "https://registry.npmjs.org/cli/-/cli-0.6.6.tgz",
+                  "integrity": "sha1-Aq1Eo4Cr8nraxebwzdewQ9dMU+M=",
+                  "dev": true,
+                  "requires": {
+                    "exit": "0.1.2",
+                    "glob": "3.2.11"
+                  },
+                  "dependencies": {
+                    "exit": {
+                      "version": "0.1.2",
+                      "resolved": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz",
+                      "integrity": "sha1-BjJjj42HfMghB9MKD/8aF8uhzQw=",
+                      "dev": true
+                    },
+                    "glob": {
+                      "version": "3.2.11",
+                      "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
+                      "integrity": "sha1-Spc/Y1uRkPcV0QmH1cAP0oFevj0=",
+                      "dev": true,
+                      "requires": {
+                        "inherits": "2.0.3",
+                        "minimatch": "0.3.0"
+                      },
+                      "dependencies": {
+                        "inherits": {
+                          "version": "2.0.3",
+                          "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/inherits/-/inherits-2.0.3.tgz",
+                          "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+                          "dev": true
+                        },
+                        "minimatch": {
+                          "version": "0.3.0",
+                          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
+                          "integrity": "sha1-J12O2qxPG7MyZHIInnlJyDlGmd0=",
+                          "dev": true,
+                          "requires": {
+                            "lru-cache": "2.7.3",
+                            "sigmund": "1.0.1"
+                          },
+                          "dependencies": {
+                            "lru-cache": {
+                              "version": "2.7.3",
+                              "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/lru-cache/-/lru-cache-2.7.3.tgz",
+                              "integrity": "sha1-bUUk6LlV+V1PW1iFHOId1y+06VI=",
+                              "dev": true
+                            },
+                            "sigmund": {
+                              "version": "1.0.1",
+                              "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz",
+                              "integrity": "sha1-P/IfGYytIXX587eBhT/ZTQ0ZtZA=",
+                              "dev": true
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                },
+                "relateurl": {
+                  "version": "0.2.7",
+                  "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/relateurl/-/relateurl-0.2.7.tgz",
+                  "integrity": "sha1-VNvzd+UUQKypCkzSdGANP/LYiKk=",
+                  "dev": true
+                },
+                "uglify-js": {
+                  "version": "2.4.24",
+                  "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/uglify-js/-/uglify-js-2.4.24.tgz",
+                  "integrity": "sha1-+tV1XB4Vd2WLsG/5q25UjJW+vW4=",
+                  "dev": true,
+                  "requires": {
+                    "async": "0.2.10",
+                    "source-map": "0.1.34",
+                    "uglify-to-browserify": "1.0.2",
+                    "yargs": "3.5.4"
+                  },
+                  "dependencies": {
+                    "async": {
+                      "version": "0.2.10",
+                      "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz",
+                      "integrity": "sha1-trvgsGdLnXGXCMo43owjfLUmw9E=",
+                      "dev": true
+                    },
+                    "source-map": {
+                      "version": "0.1.34",
+                      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.34.tgz",
+                      "integrity": "sha1-p8/omux7FoLDsZjQrPtH19CQVms=",
+                      "dev": true,
+                      "requires": {
+                        "amdefine": "1.0.0"
+                      },
+                      "dependencies": {
+                        "amdefine": {
+                          "version": "1.0.0",
+                          "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz",
+                          "integrity": "sha1-/RdHRwDLXMnCtwnwvp0jzjwZjDM=",
+                          "dev": true
+                        }
+                      }
+                    },
+                    "uglify-to-browserify": {
+                      "version": "1.0.2",
+                      "resolved": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz",
+                      "integrity": "sha1-bgkk1r2mta/jSeOabWMoUKD4grc=",
+                      "dev": true
+                    },
+                    "yargs": {
+                      "version": "3.5.4",
+                      "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.5.4.tgz",
+                      "integrity": "sha1-2K/49mXpTDS9JZvevRv68N3TU2E=",
+                      "dev": true,
+                      "requires": {
+                        "camelcase": "1.2.1",
+                        "decamelize": "1.2.0",
+                        "window-size": "0.1.0",
+                        "wordwrap": "0.0.2"
+                      },
+                      "dependencies": {
+                        "decamelize": {
+                          "version": "1.2.0",
+                          "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+                          "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
+                          "dev": true
+                        },
+                        "window-size": {
+                          "version": "0.1.0",
+                          "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz",
+                          "integrity": "sha1-VDjNLqk7IC76Ohn+iIeu58lPnJ0=",
+                          "dev": true
+                        },
+                        "wordwrap": {
+                          "version": "0.0.2",
+                          "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
+                          "integrity": "sha1-t5Zpu0LstAn4PVg8rVLKF+qhZD8=",
+                          "dev": true
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "metalsmith-in-place": {
+          "version": "1.4.4",
+          "resolved": "https://registry.npmjs.org/metalsmith-in-place/-/metalsmith-in-place-1.4.4.tgz",
+          "integrity": "sha1-adKWG41Zd1B3fgsUO3vV56j05PI=",
+          "dev": true,
+          "requires": {
+            "async": "1.5.2",
+            "consolidate": "0.14.1",
+            "debug": "2.2.0",
+            "extend": "3.0.0",
+            "fs-readdir-recursive": "1.0.0",
+            "is-utf8": "0.2.1",
+            "lodash.omit": "4.5.0",
+            "multimatch": "2.1.0"
+          },
+          "dependencies": {
+            "async": {
+              "version": "1.5.2",
+              "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/async/-/async-1.5.2.tgz",
+              "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=",
+              "dev": true
+            },
+            "consolidate": {
+              "version": "0.14.1",
+              "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/consolidate/-/consolidate-0.14.1.tgz",
+              "integrity": "sha1-UG1SnvfiEWJNLkpfM334vhNu9yc=",
+              "dev": true,
+              "requires": {
+                "bluebird": "3.4.6"
+              },
+              "dependencies": {
+                "bluebird": {
+                  "version": "3.4.6",
+                  "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/bluebird/-/bluebird-3.4.6.tgz",
+                  "integrity": "sha1-AdqNgh2HgT0ViWfnQ9X+bGLPjA8=",
+                  "dev": true
+                }
+              }
+            },
+            "extend": {
+              "version": "3.0.0",
+              "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/extend/-/extend-3.0.0.tgz",
+              "integrity": "sha1-WkdDU7nzNT3dgXbf03uRyDpG8dQ=",
+              "dev": true
+            },
+            "fs-readdir-recursive": {
+              "version": "1.0.0",
+              "resolved": "https://registry.npmjs.org/fs-readdir-recursive/-/fs-readdir-recursive-1.0.0.tgz",
+              "integrity": "sha1-jNF0XItPiinIyuw5JHaSG6GV9WA=",
+              "dev": true
+            },
+            "is-utf8": {
+              "version": "0.2.1",
+              "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/is-utf8/-/is-utf8-0.2.1.tgz",
+              "integrity": "sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI=",
+              "dev": true
+            },
+            "lodash.omit": {
+              "version": "4.5.0",
+              "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/lodash.omit/-/lodash.omit-4.5.0.tgz",
+              "integrity": "sha1-brGa5aHuHdnfC5aeZs4Lf6MLXmA=",
+              "dev": true
+            },
+            "multimatch": {
+              "version": "2.1.0",
+              "resolved": "https://registry.npmjs.org/multimatch/-/multimatch-2.1.0.tgz",
+              "integrity": "sha1-nHkGoi+0wCkZ4vX3UWG0zb1LKis=",
+              "dev": true,
+              "requires": {
+                "array-differ": "1.0.0",
+                "array-union": "1.0.2",
+                "arrify": "1.0.1",
+                "minimatch": "3.0.3"
+              },
+              "dependencies": {
+                "array-differ": {
+                  "version": "1.0.0",
+                  "resolved": "https://registry.npmjs.org/array-differ/-/array-differ-1.0.0.tgz",
+                  "integrity": "sha1-7/UuN1gknTO+QCuLuOVkuytdQDE=",
+                  "dev": true
+                },
+                "array-union": {
+                  "version": "1.0.2",
+                  "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/array-union/-/array-union-1.0.2.tgz",
+                  "integrity": "sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=",
+                  "dev": true,
+                  "requires": {
+                    "array-uniq": "1.0.3"
+                  },
+                  "dependencies": {
+                    "array-uniq": {
+                      "version": "1.0.3",
+                      "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/array-uniq/-/array-uniq-1.0.3.tgz",
+                      "integrity": "sha1-r2rId6Jcx/dOBYiUdThY39sk/bY=",
+                      "dev": true
+                    }
+                  }
+                },
+                "arrify": {
+                  "version": "1.0.1",
+                  "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/arrify/-/arrify-1.0.1.tgz",
+                  "integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=",
+                  "dev": true
+                }
+              }
+            }
+          }
+        },
+        "metalsmith-layouts": {
+          "version": "1.6.5",
+          "resolved": "https://registry.npmjs.org/metalsmith-layouts/-/metalsmith-layouts-1.6.5.tgz",
+          "integrity": "sha1-S7BEAtJSLAzBkb5xmNLsv1Bai2w=",
+          "dev": true,
+          "requires": {
+            "async": "1.5.2",
+            "consolidate": "0.14.1",
+            "debug": "2.2.0",
+            "extend": "3.0.0",
+            "fs-readdir-recursive": "1.0.0",
+            "is-utf8": "0.2.1",
+            "lodash.omit": "4.5.0",
+            "multimatch": "2.1.0"
+          },
+          "dependencies": {
+            "async": {
+              "version": "1.5.2",
+              "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/async/-/async-1.5.2.tgz",
+              "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=",
+              "dev": true
+            },
+            "consolidate": {
+              "version": "0.14.1",
+              "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/consolidate/-/consolidate-0.14.1.tgz",
+              "integrity": "sha1-UG1SnvfiEWJNLkpfM334vhNu9yc=",
+              "dev": true,
+              "requires": {
+                "bluebird": "3.4.6"
+              },
+              "dependencies": {
+                "bluebird": {
+                  "version": "3.4.6",
+                  "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/bluebird/-/bluebird-3.4.6.tgz",
+                  "integrity": "sha1-AdqNgh2HgT0ViWfnQ9X+bGLPjA8=",
+                  "dev": true
+                }
+              }
+            },
+            "extend": {
+              "version": "3.0.0",
+              "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/extend/-/extend-3.0.0.tgz",
+              "integrity": "sha1-WkdDU7nzNT3dgXbf03uRyDpG8dQ=",
+              "dev": true
+            },
+            "fs-readdir-recursive": {
+              "version": "1.0.0",
+              "resolved": "https://registry.npmjs.org/fs-readdir-recursive/-/fs-readdir-recursive-1.0.0.tgz",
+              "integrity": "sha1-jNF0XItPiinIyuw5JHaSG6GV9WA=",
+              "dev": true
+            },
+            "is-utf8": {
+              "version": "0.2.1",
+              "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/is-utf8/-/is-utf8-0.2.1.tgz",
+              "integrity": "sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI=",
+              "dev": true
+            },
+            "lodash.omit": {
+              "version": "4.5.0",
+              "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/lodash.omit/-/lodash.omit-4.5.0.tgz",
+              "integrity": "sha1-brGa5aHuHdnfC5aeZs4Lf6MLXmA=",
+              "dev": true
+            },
+            "multimatch": {
+              "version": "2.1.0",
+              "resolved": "https://registry.npmjs.org/multimatch/-/multimatch-2.1.0.tgz",
+              "integrity": "sha1-nHkGoi+0wCkZ4vX3UWG0zb1LKis=",
+              "dev": true,
+              "requires": {
+                "array-differ": "1.0.0",
+                "array-union": "1.0.2",
+                "arrify": "1.0.1",
+                "minimatch": "3.0.3"
+              },
+              "dependencies": {
+                "array-differ": {
+                  "version": "1.0.0",
+                  "resolved": "https://registry.npmjs.org/array-differ/-/array-differ-1.0.0.tgz",
+                  "integrity": "sha1-7/UuN1gknTO+QCuLuOVkuytdQDE=",
+                  "dev": true
+                },
+                "array-union": {
+                  "version": "1.0.2",
+                  "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/array-union/-/array-union-1.0.2.tgz",
+                  "integrity": "sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=",
+                  "dev": true,
+                  "requires": {
+                    "array-uniq": "1.0.3"
+                  },
+                  "dependencies": {
+                    "array-uniq": {
+                      "version": "1.0.3",
+                      "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/array-uniq/-/array-uniq-1.0.3.tgz",
+                      "integrity": "sha1-r2rId6Jcx/dOBYiUdThY39sk/bY=",
+                      "dev": true
+                    }
+                  }
+                },
+                "arrify": {
+                  "version": "1.0.1",
+                  "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/arrify/-/arrify-1.0.1.tgz",
+                  "integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=",
+                  "dev": true
+                }
+              }
+            }
+          }
+        },
+        "metalsmith-markdown": {
+          "version": "0.2.1",
+          "resolved": "https://registry.npmjs.org/metalsmith-markdown/-/metalsmith-markdown-0.2.1.tgz",
+          "integrity": "sha1-Gh/utsdtFUB7dScdqBUJ0Hky11M=",
+          "dev": true,
+          "requires": {
+            "debug": "0.7.4",
+            "marked": "0.3.6"
+          },
+          "dependencies": {
+            "debug": {
+              "version": "0.7.4",
+              "resolved": "https://registry.npmjs.org/debug/-/debug-0.7.4.tgz",
+              "integrity": "sha1-BuHqgILCyxTjmAbiLi9vdX+Srzk=",
+              "dev": true
+            },
+            "marked": {
+              "version": "0.3.6",
+              "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/marked/-/marked-0.3.6.tgz",
+              "integrity": "sha1-ssbGGPzOzk74bE/Gy4p8v1rtqNc=",
+              "dev": true
+            }
+          }
+        },
+        "metalsmith-paginate": {
+          "version": "0.3.0",
+          "resolved": "https://registry.npmjs.org/metalsmith-paginate/-/metalsmith-paginate-0.3.0.tgz",
+          "integrity": "sha1-YozjmI7iqQ1gLW7GyMXBbYi8+JM=",
+          "dev": true,
+          "requires": {
+            "lodash.clone": "2.4.1"
+          },
+          "dependencies": {
+            "lodash.clone": {
+              "version": "2.4.1",
+              "resolved": "https://registry.npmjs.org/lodash.clone/-/lodash.clone-2.4.1.tgz",
+              "integrity": "sha1-+eSV5z0Ulh2YgfJCNJUfIm31G90=",
+              "dev": true,
+              "requires": {
+                "lodash._baseclone": "2.4.1",
+                "lodash._basecreatecallback": "2.4.1"
+              },
+              "dependencies": {
+                "lodash._baseclone": {
+                  "version": "2.4.1",
+                  "resolved": "https://registry.npmjs.org/lodash._baseclone/-/lodash._baseclone-2.4.1.tgz",
+                  "integrity": "sha1-MPgj5X4X43NdODvWK2Czh1Q7QYY=",
+                  "dev": true,
+                  "requires": {
+                    "lodash._getarray": "2.4.1",
+                    "lodash._releasearray": "2.4.1",
+                    "lodash._slice": "2.4.1",
+                    "lodash.assign": "2.4.1",
+                    "lodash.foreach": "2.4.1",
+                    "lodash.forown": "2.4.1",
+                    "lodash.isarray": "2.4.1",
+                    "lodash.isobject": "2.4.1"
+                  },
+                  "dependencies": {
+                    "lodash._getarray": {
+                      "version": "2.4.1",
+                      "resolved": "https://registry.npmjs.org/lodash._getarray/-/lodash._getarray-2.4.1.tgz",
+                      "integrity": "sha1-+vH3+BD6mFolHCGHQESBCUg55e4=",
+                      "dev": true,
+                      "requires": {
+                        "lodash._arraypool": "2.4.1"
+                      },
+                      "dependencies": {
+                        "lodash._arraypool": {
+                          "version": "2.4.1",
+                          "resolved": "https://registry.npmjs.org/lodash._arraypool/-/lodash._arraypool-2.4.1.tgz",
+                          "integrity": "sha1-6I7suS4ruEyQZWEv2VigcZzUf5Q=",
+                          "dev": true
+                        }
+                      }
+                    },
+                    "lodash._releasearray": {
+                      "version": "2.4.1",
+                      "resolved": "https://registry.npmjs.org/lodash._releasearray/-/lodash._releasearray-2.4.1.tgz",
+                      "integrity": "sha1-phOWMNdtFTawfdyAliiJsIL2pkE=",
+                      "dev": true,
+                      "requires": {
+                        "lodash._arraypool": "2.4.1",
+                        "lodash._maxpoolsize": "2.4.1"
+                      },
+                      "dependencies": {
+                        "lodash._arraypool": {
+                          "version": "2.4.1",
+                          "resolved": "https://registry.npmjs.org/lodash._arraypool/-/lodash._arraypool-2.4.1.tgz",
+                          "integrity": "sha1-6I7suS4ruEyQZWEv2VigcZzUf5Q=",
+                          "dev": true
+                        },
+                        "lodash._maxpoolsize": {
+                          "version": "2.4.1",
+                          "resolved": "https://registry.npmjs.org/lodash._maxpoolsize/-/lodash._maxpoolsize-2.4.1.tgz",
+                          "integrity": "sha1-nUgvRjuOZq++WcLBTtsRcGAXIzQ=",
+                          "dev": true
+                        }
+                      }
+                    },
+                    "lodash._slice": {
+                      "version": "2.4.1",
+                      "resolved": "https://registry.npmjs.org/lodash._slice/-/lodash._slice-2.4.1.tgz",
+                      "integrity": "sha1-dFz0GlNZexj2iImFREBe+isG2Q8=",
+                      "dev": true
+                    },
+                    "lodash.assign": {
+                      "version": "2.4.1",
+                      "resolved": "https://registry.npmjs.org/lodash.assign/-/lodash.assign-2.4.1.tgz",
+                      "integrity": "sha1-hMOVlt1xGBqXsGUpE6fJZ15Jsao=",
+                      "dev": true,
+                      "requires": {
+                        "lodash._basecreatecallback": "2.4.1",
+                        "lodash._objecttypes": "2.4.1",
+                        "lodash.keys": "2.4.1"
+                      },
+                      "dependencies": {
+                        "lodash._objecttypes": {
+                          "version": "2.4.1",
+                          "resolved": "https://registry.npmjs.org/lodash._objecttypes/-/lodash._objecttypes-2.4.1.tgz",
+                          "integrity": "sha1-fAt/admKH3ZSn4kLDNsbTf7BHBE=",
+                          "dev": true
+                        },
+                        "lodash.keys": {
+                          "version": "2.4.1",
+                          "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-2.4.1.tgz",
+                          "integrity": "sha1-SN6kbfj/djKxDXBrissmWR4rNyc=",
+                          "dev": true,
+                          "requires": {
+                            "lodash._isnative": "2.4.1",
+                            "lodash._shimkeys": "2.4.1",
+                            "lodash.isobject": "2.4.1"
+                          },
+                          "dependencies": {
+                            "lodash._isnative": {
+                              "version": "2.4.1",
+                              "resolved": "https://registry.npmjs.org/lodash._isnative/-/lodash._isnative-2.4.1.tgz",
+                              "integrity": "sha1-PqZAS3hKe+g2x7V1gOHN95sUgyw=",
+                              "dev": true
+                            },
+                            "lodash._shimkeys": {
+                              "version": "2.4.1",
+                              "resolved": "https://registry.npmjs.org/lodash._shimkeys/-/lodash._shimkeys-2.4.1.tgz",
+                              "integrity": "sha1-bpzJZm/wgfC1psl4uD4kLmlJ0gM=",
+                              "dev": true,
+                              "requires": {
+                                "lodash._objecttypes": "2.4.1"
+                              }
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "lodash.foreach": {
+                      "version": "2.4.1",
+                      "resolved": "https://registry.npmjs.org/lodash.foreach/-/lodash.foreach-2.4.1.tgz",
+                      "integrity": "sha1-/j/Do0yGyUyrb5UiVgKCdB4BYwk=",
+                      "dev": true,
+                      "requires": {
+                        "lodash._basecreatecallback": "2.4.1",
+                        "lodash.forown": "2.4.1"
+                      }
+                    },
+                    "lodash.forown": {
+                      "version": "2.4.1",
+                      "resolved": "https://registry.npmjs.org/lodash.forown/-/lodash.forown-2.4.1.tgz",
+                      "integrity": "sha1-eLQer+FAX6lmRZ6kGT/VAtCEUks=",
+                      "dev": true,
+                      "requires": {
+                        "lodash._basecreatecallback": "2.4.1",
+                        "lodash._objecttypes": "2.4.1",
+                        "lodash.keys": "2.4.1"
+                      },
+                      "dependencies": {
+                        "lodash._objecttypes": {
+                          "version": "2.4.1",
+                          "resolved": "https://registry.npmjs.org/lodash._objecttypes/-/lodash._objecttypes-2.4.1.tgz",
+                          "integrity": "sha1-fAt/admKH3ZSn4kLDNsbTf7BHBE=",
+                          "dev": true
+                        },
+                        "lodash.keys": {
+                          "version": "2.4.1",
+                          "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-2.4.1.tgz",
+                          "integrity": "sha1-SN6kbfj/djKxDXBrissmWR4rNyc=",
+                          "dev": true,
+                          "requires": {
+                            "lodash._isnative": "2.4.1",
+                            "lodash._shimkeys": "2.4.1",
+                            "lodash.isobject": "2.4.1"
+                          },
+                          "dependencies": {
+                            "lodash._isnative": {
+                              "version": "2.4.1",
+                              "resolved": "https://registry.npmjs.org/lodash._isnative/-/lodash._isnative-2.4.1.tgz",
+                              "integrity": "sha1-PqZAS3hKe+g2x7V1gOHN95sUgyw=",
+                              "dev": true
+                            },
+                            "lodash._shimkeys": {
+                              "version": "2.4.1",
+                              "resolved": "https://registry.npmjs.org/lodash._shimkeys/-/lodash._shimkeys-2.4.1.tgz",
+                              "integrity": "sha1-bpzJZm/wgfC1psl4uD4kLmlJ0gM=",
+                              "dev": true,
+                              "requires": {
+                                "lodash._objecttypes": "2.4.1"
+                              }
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "lodash.isarray": {
+                      "version": "2.4.1",
+                      "resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-2.4.1.tgz",
+                      "integrity": "sha1-tSoybB9i9tfac6MdVAHfbvRPD6E=",
+                      "dev": true,
+                      "requires": {
+                        "lodash._isnative": "2.4.1"
+                      },
+                      "dependencies": {
+                        "lodash._isnative": {
+                          "version": "2.4.1",
+                          "resolved": "https://registry.npmjs.org/lodash._isnative/-/lodash._isnative-2.4.1.tgz",
+                          "integrity": "sha1-PqZAS3hKe+g2x7V1gOHN95sUgyw=",
+                          "dev": true
+                        }
+                      }
+                    },
+                    "lodash.isobject": {
+                      "version": "2.4.1",
+                      "resolved": "https://registry.npmjs.org/lodash.isobject/-/lodash.isobject-2.4.1.tgz",
+                      "integrity": "sha1-Wi5H/mmVPx7mMafrof5k0tBlWPU=",
+                      "dev": true,
+                      "requires": {
+                        "lodash._objecttypes": "2.4.1"
+                      },
+                      "dependencies": {
+                        "lodash._objecttypes": {
+                          "version": "2.4.1",
+                          "resolved": "https://registry.npmjs.org/lodash._objecttypes/-/lodash._objecttypes-2.4.1.tgz",
+                          "integrity": "sha1-fAt/admKH3ZSn4kLDNsbTf7BHBE=",
+                          "dev": true
+                        }
+                      }
+                    }
+                  }
+                },
+                "lodash._basecreatecallback": {
+                  "version": "2.4.1",
+                  "resolved": "https://registry.npmjs.org/lodash._basecreatecallback/-/lodash._basecreatecallback-2.4.1.tgz",
+                  "integrity": "sha1-fQsmdknLKeehOdAQO3wR+uhOSFE=",
+                  "dev": true,
+                  "requires": {
+                    "lodash._setbinddata": "2.4.1",
+                    "lodash.bind": "2.4.1",
+                    "lodash.identity": "2.4.1",
+                    "lodash.support": "2.4.1"
+                  },
+                  "dependencies": {
+                    "lodash._setbinddata": {
+                      "version": "2.4.1",
+                      "resolved": "https://registry.npmjs.org/lodash._setbinddata/-/lodash._setbinddata-2.4.1.tgz",
+                      "integrity": "sha1-98IAzRuS7yNrOZ7s9zxkjReqlNI=",
+                      "dev": true,
+                      "requires": {
+                        "lodash._isnative": "2.4.1",
+                        "lodash.noop": "2.4.1"
+                      },
+                      "dependencies": {
+                        "lodash._isnative": {
+                          "version": "2.4.1",
+                          "resolved": "https://registry.npmjs.org/lodash._isnative/-/lodash._isnative-2.4.1.tgz",
+                          "integrity": "sha1-PqZAS3hKe+g2x7V1gOHN95sUgyw=",
+                          "dev": true
+                        },
+                        "lodash.noop": {
+                          "version": "2.4.1",
+                          "resolved": "https://registry.npmjs.org/lodash.noop/-/lodash.noop-2.4.1.tgz",
+                          "integrity": "sha1-T7VPgWZS5a4Q6PcvcXo4jHMmU4o=",
+                          "dev": true
+                        }
+                      }
+                    },
+                    "lodash.bind": {
+                      "version": "2.4.1",
+                      "resolved": "https://registry.npmjs.org/lodash.bind/-/lodash.bind-2.4.1.tgz",
+                      "integrity": "sha1-XRn6AFyMTSNvr0dCx7eh/Kvikmc=",
+                      "dev": true,
+                      "requires": {
+                        "lodash._createwrapper": "2.4.1",
+                        "lodash._slice": "2.4.1"
+                      },
+                      "dependencies": {
+                        "lodash._createwrapper": {
+                          "version": "2.4.1",
+                          "resolved": "https://registry.npmjs.org/lodash._createwrapper/-/lodash._createwrapper-2.4.1.tgz",
+                          "integrity": "sha1-UdaVeXPaTtVW43KQ2MGhjFPeFgc=",
+                          "dev": true,
+                          "requires": {
+                            "lodash._basebind": "2.4.1",
+                            "lodash._basecreatewrapper": "2.4.1",
+                            "lodash._slice": "2.4.1",
+                            "lodash.isfunction": "2.4.1"
+                          },
+                          "dependencies": {
+                            "lodash._basebind": {
+                              "version": "2.4.1",
+                              "resolved": "https://registry.npmjs.org/lodash._basebind/-/lodash._basebind-2.4.1.tgz",
+                              "integrity": "sha1-6UC5690nwyfgqNqxtVkWxTQelXU=",
+                              "dev": true,
+                              "requires": {
+                                "lodash._basecreate": "2.4.1",
+                                "lodash._setbinddata": "2.4.1",
+                                "lodash._slice": "2.4.1",
+                                "lodash.isobject": "2.4.1"
+                              },
+                              "dependencies": {
+                                "lodash._basecreate": {
+                                  "version": "2.4.1",
+                                  "resolved": "https://registry.npmjs.org/lodash._basecreate/-/lodash._basecreate-2.4.1.tgz",
+                                  "integrity": "sha1-+Ob1tXip405UEXm1a47uv0oofgg=",
+                                  "dev": true,
+                                  "requires": {
+                                    "lodash._isnative": "2.4.1",
+                                    "lodash.isobject": "2.4.1",
+                                    "lodash.noop": "2.4.1"
+                                  },
+                                  "dependencies": {
+                                    "lodash._isnative": {
+                                      "version": "2.4.1",
+                                      "resolved": "https://registry.npmjs.org/lodash._isnative/-/lodash._isnative-2.4.1.tgz",
+                                      "integrity": "sha1-PqZAS3hKe+g2x7V1gOHN95sUgyw=",
+                                      "dev": true
+                                    },
+                                    "lodash.noop": {
+                                      "version": "2.4.1",
+                                      "resolved": "https://registry.npmjs.org/lodash.noop/-/lodash.noop-2.4.1.tgz",
+                                      "integrity": "sha1-T7VPgWZS5a4Q6PcvcXo4jHMmU4o=",
+                                      "dev": true
+                                    }
+                                  }
+                                },
+                                "lodash.isobject": {
+                                  "version": "2.4.1",
+                                  "resolved": "https://registry.npmjs.org/lodash.isobject/-/lodash.isobject-2.4.1.tgz",
+                                  "integrity": "sha1-Wi5H/mmVPx7mMafrof5k0tBlWPU=",
+                                  "dev": true,
+                                  "requires": {
+                                    "lodash._objecttypes": "2.4.1"
+                                  },
+                                  "dependencies": {
+                                    "lodash._objecttypes": {
+                                      "version": "2.4.1",
+                                      "resolved": "https://registry.npmjs.org/lodash._objecttypes/-/lodash._objecttypes-2.4.1.tgz",
+                                      "integrity": "sha1-fAt/admKH3ZSn4kLDNsbTf7BHBE=",
+                                      "dev": true
+                                    }
+                                  }
+                                }
+                              }
+                            },
+                            "lodash._basecreatewrapper": {
+                              "version": "2.4.1",
+                              "resolved": "https://registry.npmjs.org/lodash._basecreatewrapper/-/lodash._basecreatewrapper-2.4.1.tgz",
+                              "integrity": "sha1-TTHy595+E0+/KAN2K4FQsyUZZm8=",
+                              "dev": true,
+                              "requires": {
+                                "lodash._basecreate": "2.4.1",
+                                "lodash._setbinddata": "2.4.1",
+                                "lodash._slice": "2.4.1",
+                                "lodash.isobject": "2.4.1"
+                              },
+                              "dependencies": {
+                                "lodash._basecreate": {
+                                  "version": "2.4.1",
+                                  "resolved": "https://registry.npmjs.org/lodash._basecreate/-/lodash._basecreate-2.4.1.tgz",
+                                  "integrity": "sha1-+Ob1tXip405UEXm1a47uv0oofgg=",
+                                  "dev": true,
+                                  "requires": {
+                                    "lodash._isnative": "2.4.1",
+                                    "lodash.isobject": "2.4.1",
+                                    "lodash.noop": "2.4.1"
+                                  },
+                                  "dependencies": {
+                                    "lodash._isnative": {
+                                      "version": "2.4.1",
+                                      "resolved": "https://registry.npmjs.org/lodash._isnative/-/lodash._isnative-2.4.1.tgz",
+                                      "integrity": "sha1-PqZAS3hKe+g2x7V1gOHN95sUgyw=",
+                                      "dev": true
+                                    },
+                                    "lodash.noop": {
+                                      "version": "2.4.1",
+                                      "resolved": "https://registry.npmjs.org/lodash.noop/-/lodash.noop-2.4.1.tgz",
+                                      "integrity": "sha1-T7VPgWZS5a4Q6PcvcXo4jHMmU4o=",
+                                      "dev": true
+                                    }
+                                  }
+                                },
+                                "lodash.isobject": {
+                                  "version": "2.4.1",
+                                  "resolved": "https://registry.npmjs.org/lodash.isobject/-/lodash.isobject-2.4.1.tgz",
+                                  "integrity": "sha1-Wi5H/mmVPx7mMafrof5k0tBlWPU=",
+                                  "dev": true,
+                                  "requires": {
+                                    "lodash._objecttypes": "2.4.1"
+                                  },
+                                  "dependencies": {
+                                    "lodash._objecttypes": {
+                                      "version": "2.4.1",
+                                      "resolved": "https://registry.npmjs.org/lodash._objecttypes/-/lodash._objecttypes-2.4.1.tgz",
+                                      "integrity": "sha1-fAt/admKH3ZSn4kLDNsbTf7BHBE=",
+                                      "dev": true
+                                    }
+                                  }
+                                }
+                              }
+                            },
+                            "lodash.isfunction": {
+                              "version": "2.4.1",
+                              "resolved": "https://registry.npmjs.org/lodash.isfunction/-/lodash.isfunction-2.4.1.tgz",
+                              "integrity": "sha1-LP1XXHPkmKtX4xm3f6Aq3vE6lNE=",
+                              "dev": true
+                            }
+                          }
+                        },
+                        "lodash._slice": {
+                          "version": "2.4.1",
+                          "resolved": "https://registry.npmjs.org/lodash._slice/-/lodash._slice-2.4.1.tgz",
+                          "integrity": "sha1-dFz0GlNZexj2iImFREBe+isG2Q8=",
+                          "dev": true
+                        }
+                      }
+                    },
+                    "lodash.identity": {
+                      "version": "2.4.1",
+                      "resolved": "https://registry.npmjs.org/lodash.identity/-/lodash.identity-2.4.1.tgz",
+                      "integrity": "sha1-ZpTP+mX++TH3wxzobHRZfPVg9PE=",
+                      "dev": true
+                    },
+                    "lodash.support": {
+                      "version": "2.4.1",
+                      "resolved": "https://registry.npmjs.org/lodash.support/-/lodash.support-2.4.1.tgz",
+                      "integrity": "sha1-Mg4LZwMWc8KNeiu12eAzGkUkBRU=",
+                      "dev": true,
+                      "requires": {
+                        "lodash._isnative": "2.4.1"
+                      },
+                      "dependencies": {
+                        "lodash._isnative": {
+                          "version": "2.4.1",
+                          "resolved": "https://registry.npmjs.org/lodash._isnative/-/lodash._isnative-2.4.1.tgz",
+                          "integrity": "sha1-PqZAS3hKe+g2x7V1gOHN95sUgyw=",
+                          "dev": true
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "metalsmith-permalinks": {
+          "version": "0.4.1",
+          "resolved": "https://registry.npmjs.org/metalsmith-permalinks/-/metalsmith-permalinks-0.4.1.tgz",
+          "integrity": "sha1-eJHcJsytLi/YYAOMD1KT8uyupAI=",
+          "dev": true,
+          "requires": {
+            "debug": "0.7.4",
+            "moment": "2.15.1",
+            "slug-component": "1.1.0",
+            "substitute": "https://github.com/segmentio/substitute/archive/0.0.1.tar.gz"
+          },
+          "dependencies": {
+            "debug": {
+              "version": "0.7.4",
+              "resolved": "https://registry.npmjs.org/debug/-/debug-0.7.4.tgz",
+              "integrity": "sha1-BuHqgILCyxTjmAbiLi9vdX+Srzk=",
+              "dev": true
+            },
+            "slug-component": {
+              "version": "1.1.0",
+              "resolved": "https://registry.npmjs.org/slug-component/-/slug-component-1.1.0.tgz",
+              "integrity": "sha1-IkKQoEWRv5rAi5xiLToU9D46Dfc=",
+              "dev": true
+            },
+            "substitute": {
+              "version": "https://github.com/segmentio/substitute/archive/0.0.1.tar.gz",
+              "integrity": "sha1-QyhmmFsDw7DT9xrGPRrhoY369H0=",
+              "dev": true
+            }
+          }
+        },
+        "metalsmith-redirect": {
+          "version": "1.3.1",
+          "resolved": "https://registry.npmjs.org/metalsmith-redirect/-/metalsmith-redirect-1.3.1.tgz",
+          "integrity": "sha1-o5UUzV5EMvp7IhWzVks/fiacVHs=",
+          "dev": true,
+          "requires": {
+            "jade": "1.11.0"
+          },
+          "dependencies": {
+            "acorn": {
+              "version": "2.7.0",
+              "resolved": "https://registry.npmjs.org/acorn/-/acorn-2.7.0.tgz",
+              "integrity": "sha1-q259nYhqrKiwhbwzEreaGYQz8Oc=",
+              "dev": true
+            },
+            "acorn-globals": {
+              "version": "1.0.9",
+              "resolved": "https://registry.npmjs.org/acorn-globals/-/acorn-globals-1.0.9.tgz",
+              "integrity": "sha1-VbtemGkVB7dFedBRNBMhfDgMVM8=",
+              "dev": true,
+              "requires": {
+                "acorn": "2.7.0"
+              }
+            },
+            "align-text": {
+              "version": "0.1.4",
+              "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
+              "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
+              "dev": true,
+              "requires": {
+                "kind-of": "3.0.2",
+                "longest": "1.0.1",
+                "repeat-string": "1.5.4"
+              }
+            },
+            "amdefine": {
+              "version": "1.0.0",
+              "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz",
+              "integrity": "sha1-/RdHRwDLXMnCtwnwvp0jzjwZjDM=",
+              "dev": true
+            },
+            "asap": {
+              "version": "1.0.0",
+              "resolved": "https://registry.npmjs.org/asap/-/asap-1.0.0.tgz",
+              "integrity": "sha1-sqRdpf36ILBJb8N2jMJ8EvqRan0=",
+              "dev": true
+            },
+            "async": {
+              "version": "0.2.10",
+              "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz",
+              "integrity": "sha1-trvgsGdLnXGXCMo43owjfLUmw9E=",
+              "dev": true
+            },
+            "camelcase": {
+              "version": "1.2.1",
+              "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
+              "integrity": "sha1-m7UwTS4LVmmLLHWLCKPqqdqlijk=",
+              "dev": true
+            },
+            "center-align": {
+              "version": "0.1.3",
+              "resolved": "https://registry.npmjs.org/center-align/-/center-align-0.1.3.tgz",
+              "integrity": "sha1-qg0yYptu6XIgBBHL1EYckHvCt60=",
+              "dev": true,
+              "requires": {
+                "align-text": "0.1.4",
+                "lazy-cache": "1.0.3"
+              }
+            },
+            "character-parser": {
+              "version": "1.2.1",
+              "resolved": "https://registry.npmjs.org/character-parser/-/character-parser-1.2.1.tgz",
+              "integrity": "sha1-wN3kqxgnE7kZuXCVmhI+zBow/NY=",
+              "dev": true
+            },
+            "clean-css": {
+              "version": "3.4.10",
+              "resolved": "https://registry.npmjs.org/clean-css/-/clean-css-3.4.10.tgz",
+              "integrity": "sha1-fIW6R0SLE2o+SSXTl739xaQIa38=",
+              "dev": true,
+              "requires": {
+                "commander": "2.8.1",
+                "source-map": "0.4.4"
+              },
+              "dependencies": {
+                "commander": {
+                  "version": "2.8.1",
+                  "resolved": "https://registry.npmjs.org/commander/-/commander-2.8.1.tgz",
+                  "integrity": "sha1-Br42f+v9oMMwqh4qBy09yXYkJdQ=",
+                  "dev": true,
+                  "requires": {
+                    "graceful-readlink": "1.0.1"
+                  }
+                }
+              }
+            },
+            "cliui": {
+              "version": "2.1.0",
+              "resolved": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
+              "integrity": "sha1-S0dXYP+AJkx2LDoXGQMukcf+oNE=",
+              "dev": true,
+              "requires": {
+                "center-align": "0.1.3",
+                "right-align": "0.1.3",
+                "wordwrap": "0.0.2"
+              },
+              "dependencies": {
+                "wordwrap": {
+                  "version": "0.0.2",
+                  "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
+                  "integrity": "sha1-t5Zpu0LstAn4PVg8rVLKF+qhZD8=",
+                  "dev": true
+                }
+              }
+            },
+            "commander": {
+              "version": "2.6.0",
+              "resolved": "https://registry.npmjs.org/commander/-/commander-2.6.0.tgz",
+              "integrity": "sha1-nfflL7Kgyw+4kFjugMMQQiXzfh0=",
+              "dev": true
+            },
+            "constantinople": {
+              "version": "3.0.2",
+              "resolved": "https://registry.npmjs.org/constantinople/-/constantinople-3.0.2.tgz",
+              "integrity": "sha1-S5RdmTeQe82Y7ldRIsOBdRZUQUE=",
+              "dev": true,
+              "requires": {
+                "acorn": "2.7.0"
+              }
+            },
+            "css": {
+              "version": "1.0.8",
+              "resolved": "https://registry.npmjs.org/css/-/css-1.0.8.tgz",
+              "integrity": "sha1-k4aBHKgrzMnuf7WnMrHioxfIo+c=",
+              "dev": true,
+              "requires": {
+                "css-parse": "1.0.4",
+                "css-stringify": "1.0.5"
+              }
+            },
+            "css-parse": {
+              "version": "1.0.4",
+              "resolved": "https://registry.npmjs.org/css-parse/-/css-parse-1.0.4.tgz",
+              "integrity": "sha1-OLBQP7+dqfVOnB29pg4UXHcRe90=",
+              "dev": true
+            },
+            "css-stringify": {
+              "version": "1.0.5",
+              "resolved": "https://registry.npmjs.org/css-stringify/-/css-stringify-1.0.5.tgz",
+              "integrity": "sha1-sNBClG2ylTu50pKQCmy19tASIDE=",
+              "dev": true
+            },
+            "decamelize": {
+              "version": "1.2.0",
+              "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+              "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
+              "dev": true
+            },
+            "graceful-readlink": {
+              "version": "1.0.1",
+              "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz",
+              "integrity": "sha1-TK+tdrxi8C+gObL5Tpo906ORpyU=",
+              "dev": true
+            },
+            "is-buffer": {
+              "version": "1.1.3",
+              "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.3.tgz",
+              "integrity": "sha1-24l/w/esotUN6UtsjCiWpHcWJ68=",
+              "dev": true
+            },
+            "is-promise": {
+              "version": "2.1.0",
+              "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.1.0.tgz",
+              "integrity": "sha1-eaKp7OfwlugPNtKy87wWwf9L8/o=",
+              "dev": true
+            },
+            "jade": {
+              "version": "1.11.0",
+              "resolved": "https://registry.npmjs.org/jade/-/jade-1.11.0.tgz",
+              "integrity": "sha1-nIDlOMEtP7lcjZu5VZ+gzAQEBf0=",
+              "dev": true,
+              "requires": {
+                "character-parser": "1.2.1",
+                "clean-css": "3.4.10",
+                "commander": "2.6.0",
+                "constantinople": "3.0.2",
+                "jstransformer": "0.0.2",
+                "mkdirp": "0.5.1",
+                "transformers": "2.1.0",
+                "uglify-js": "2.6.2",
+                "void-elements": "2.0.1",
+                "with": "4.0.3"
+              }
+            },
+            "jstransformer": {
+              "version": "0.0.2",
+              "resolved": "https://registry.npmjs.org/jstransformer/-/jstransformer-0.0.2.tgz",
+              "integrity": "sha1-eq4pqQPRls+glz2IXT5HlH7Ndqs=",
+              "dev": true,
+              "requires": {
+                "is-promise": "2.1.0",
+                "promise": "6.1.0"
+              }
+            },
+            "kind-of": {
+              "version": "3.0.2",
+              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.0.2.tgz",
+              "integrity": "sha1-GH20JwRufpCUVpLmdoZovWkA3qA=",
+              "dev": true,
+              "requires": {
+                "is-buffer": "1.1.3"
+              }
+            },
+            "lazy-cache": {
+              "version": "1.0.3",
+              "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.3.tgz",
+              "integrity": "sha1-6XdUYY+ciGu5mbL/aceLgkU9ZnQ=",
+              "dev": true
+            },
+            "longest": {
+              "version": "1.0.1",
+              "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
+              "integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc=",
+              "dev": true
+            },
+            "minimist": {
+              "version": "0.0.8",
+              "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+              "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+              "dev": true
+            },
+            "mkdirp": {
+              "version": "0.5.1",
+              "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+              "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+              "dev": true,
+              "requires": {
+                "minimist": "0.0.8"
+              }
+            },
+            "optimist": {
+              "version": "0.3.7",
+              "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.3.7.tgz",
+              "integrity": "sha1-yQlBrVnkJzMokjB00s8ufLxuwNk=",
+              "dev": true,
+              "requires": {
+                "wordwrap": "0.0.3"
+              }
+            },
+            "promise": {
+              "version": "6.1.0",
+              "resolved": "https://registry.npmjs.org/promise/-/promise-6.1.0.tgz",
+              "integrity": "sha1-LOcp9rlLRcJoka0GAsXJDgTG7vY=",
+              "dev": true,
+              "requires": {
+                "asap": "1.0.0"
+              }
+            },
+            "repeat-string": {
+              "version": "1.5.4",
+              "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.5.4.tgz",
+              "integrity": "sha1-ZOwMkeD0tHX5DVtkNlHj5uW2wtU=",
+              "dev": true
+            },
+            "right-align": {
+              "version": "0.1.3",
+              "resolved": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
+              "integrity": "sha1-YTObci/mo1FWiSENJOFMlhSGE+8=",
+              "dev": true,
+              "requires": {
+                "align-text": "0.1.4"
+              }
+            },
+            "source-map": {
+              "version": "0.4.4",
+              "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
+              "integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
+              "dev": true,
+              "requires": {
+                "amdefine": "1.0.0"
+              }
+            },
+            "transformers": {
+              "version": "2.1.0",
+              "resolved": "https://registry.npmjs.org/transformers/-/transformers-2.1.0.tgz",
+              "integrity": "sha1-XSPLNVYd2F3Gf7hIIwm0fVPM6ac=",
+              "dev": true,
+              "requires": {
+                "css": "1.0.8",
+                "promise": "2.0.0",
+                "uglify-js": "2.2.5"
+              },
+              "dependencies": {
+                "is-promise": {
+                  "version": "1.0.1",
+                  "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-1.0.1.tgz",
+                  "integrity": "sha1-MVc3YcBX4zwukaq56W2gjO++duU=",
+                  "dev": true
+                },
+                "promise": {
+                  "version": "2.0.0",
+                  "resolved": "https://registry.npmjs.org/promise/-/promise-2.0.0.tgz",
+                  "integrity": "sha1-RmSKqdYFr10ucMMCS/WUNtoCuA4=",
+                  "dev": true,
+                  "requires": {
+                    "is-promise": "1.0.1"
+                  }
+                },
+                "source-map": {
+                  "version": "0.1.43",
+                  "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
+                  "integrity": "sha1-wkvBRspRfBRx9drL4lcbK3+eM0Y=",
+                  "dev": true,
+                  "requires": {
+                    "amdefine": "1.0.0"
+                  }
+                },
+                "uglify-js": {
+                  "version": "2.2.5",
+                  "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.2.5.tgz",
+                  "integrity": "sha1-puAqcNg5eSuXgEiLe4sYTAlcmcc=",
+                  "dev": true,
+                  "requires": {
+                    "optimist": "0.3.7",
+                    "source-map": "0.1.43"
+                  }
+                }
+              }
+            },
+            "uglify-js": {
+              "version": "2.6.2",
+              "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.6.2.tgz",
+              "integrity": "sha1-9QvoikLNOWpiUdxSqzcvccwS/vA=",
+              "dev": true,
+              "requires": {
+                "async": "0.2.10",
+                "source-map": "0.5.3",
+                "uglify-to-browserify": "1.0.2",
+                "yargs": "3.10.0"
+              },
+              "dependencies": {
+                "source-map": {
+                  "version": "0.5.3",
+                  "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.3.tgz",
+                  "integrity": "sha1-gmdLhacbC+dsPnQW0V6fUlLrO+A=",
+                  "dev": true
+                }
+              }
+            },
+            "uglify-to-browserify": {
+              "version": "1.0.2",
+              "resolved": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz",
+              "integrity": "sha1-bgkk1r2mta/jSeOabWMoUKD4grc=",
+              "dev": true
+            },
+            "void-elements": {
+              "version": "2.0.1",
+              "resolved": "https://registry.npmjs.org/void-elements/-/void-elements-2.0.1.tgz",
+              "integrity": "sha1-wGavtYK7HLQSjWDqkjkulNXp2+w=",
+              "dev": true
+            },
+            "window-size": {
+              "version": "0.1.0",
+              "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz",
+              "integrity": "sha1-VDjNLqk7IC76Ohn+iIeu58lPnJ0=",
+              "dev": true
+            },
+            "with": {
+              "version": "4.0.3",
+              "resolved": "https://registry.npmjs.org/with/-/with-4.0.3.tgz",
+              "integrity": "sha1-7v0VTp550sjTQXtkeo8U2f7M4U4=",
+              "dev": true,
+              "requires": {
+                "acorn": "1.2.2",
+                "acorn-globals": "1.0.9"
+              },
+              "dependencies": {
+                "acorn": {
+                  "version": "1.2.2",
+                  "resolved": "https://registry.npmjs.org/acorn/-/acorn-1.2.2.tgz",
+                  "integrity": "sha1-yM4n3grMdtiW0rH6099YjZ6C8BQ=",
+                  "dev": true
+                }
+              }
+            },
+            "wordwrap": {
+              "version": "0.0.3",
+              "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
+              "integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc=",
+              "dev": true
+            },
+            "yargs": {
+              "version": "3.10.0",
+              "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
+              "integrity": "sha1-9+572FfdfB0tOMDnTvvWgdFDH9E=",
+              "dev": true,
+              "requires": {
+                "camelcase": "1.2.1",
+                "cliui": "2.1.0",
+                "decamelize": "1.2.0",
+                "window-size": "0.1.0"
+              }
+            }
+          }
+        },
+        "metalsmith-sass": {
+          "version": "1.3.0",
+          "resolved": "https://registry.npmjs.org/metalsmith-sass/-/metalsmith-sass-1.3.0.tgz",
+          "integrity": "sha1-6uWb010YNIPhmNkkXyWVZS9u0NQ=",
+          "dev": true,
+          "requires": {
+            "async": "1.5.2",
+            "node-sass": "3.10.1"
+          },
+          "dependencies": {
+            "async": {
+              "version": "1.5.2",
+              "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/async/-/async-1.5.2.tgz",
+              "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=",
+              "dev": true
+            }
+          }
+        },
+        "metalsmith-serve": {
+          "version": "0.0.4",
+          "resolved": "https://registry.npmjs.org/metalsmith-serve/-/metalsmith-serve-0.0.4.tgz",
+          "integrity": "sha1-zpwxxbx+vlgnKNonJezcxKLyvGI=",
+          "dev": true,
+          "requires": {
+            "chalk": "0.4.0",
+            "http-status": "0.2.3",
+            "node-static": "0.7.9"
+          },
+          "dependencies": {
+            "chalk": {
+              "version": "0.4.0",
+              "resolved": "https://registry.npmjs.org/chalk/-/chalk-0.4.0.tgz",
+              "integrity": "sha1-UZmj3c0MHv4jvAjBsCewYXbgxk8=",
+              "dev": true,
+              "requires": {
+                "ansi-styles": "1.0.0",
+                "has-color": "0.1.7",
+                "strip-ansi": "0.1.1"
+              },
+              "dependencies": {
+                "ansi-styles": {
+                  "version": "1.0.0",
+                  "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.0.0.tgz",
+                  "integrity": "sha1-yxAt8cVvUSPquLZ817mAJ6AnkXg=",
+                  "dev": true
+                },
+                "has-color": {
+                  "version": "0.1.7",
+                  "resolved": "https://registry.npmjs.org/has-color/-/has-color-0.1.7.tgz",
+                  "integrity": "sha1-ZxRKUmDDT8PMpnfQQdr1L+e3iy8=",
+                  "dev": true
+                },
+                "strip-ansi": {
+                  "version": "0.1.1",
+                  "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.1.1.tgz",
+                  "integrity": "sha1-OeipjQRNFQZgq+SmgIrPcLt7yZE=",
+                  "dev": true
+                }
+              }
+            },
+            "http-status": {
+              "version": "0.2.3",
+              "resolved": "https://registry.npmjs.org/http-status/-/http-status-0.2.3.tgz",
+              "integrity": "sha1-uPuiCNZyPQ/g3lr+w65iT2uuA9s=",
+              "dev": true
+            },
+            "node-static": {
+              "version": "0.7.9",
+              "resolved": "https://registry.npmjs.org/node-static/-/node-static-0.7.9.tgz",
+              "integrity": "sha1-m7afziKB96480fuYPp6g7AzZ/ss=",
+              "dev": true,
+              "requires": {
+                "colors": "1.1.2",
+                "mime": "1.3.4",
+                "optimist": "0.6.1"
+              },
+              "dependencies": {
+                "colors": {
+                  "version": "1.1.2",
+                  "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/colors/-/colors-1.1.2.tgz",
+                  "integrity": "sha1-FopHAXVran9RoSzgyXv6KMCE7WM=",
+                  "dev": true
+                },
+                "mime": {
+                  "version": "1.3.4",
+                  "resolved": "https://registry.npmjs.org/mime/-/mime-1.3.4.tgz",
+                  "integrity": "sha1-EV+eO2s9rylZmDyzjxSaLUDrXVM=",
+                  "dev": true
+                },
+                "optimist": {
+                  "version": "0.6.1",
+                  "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
+                  "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
+                  "dev": true,
+                  "requires": {
+                    "minimist": "0.0.10",
+                    "wordwrap": "0.0.3"
+                  },
+                  "dependencies": {
+                    "minimist": {
+                      "version": "0.0.10",
+                      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
+                      "integrity": "sha1-3j+YVD2/lggr5IrRoMfNqDYwHc8=",
+                      "dev": true
+                    },
+                    "wordwrap": {
+                      "version": "0.0.3",
+                      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
+                      "integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc=",
+                      "dev": true
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "metalsmith-tags": {
+          "version": "0.13.0",
+          "resolved": "https://registry.npmjs.org/metalsmith-tags/-/metalsmith-tags-0.13.0.tgz",
+          "integrity": "sha1-J6F6l3nISd7iydziyXBVuoEMK8E=",
+          "dev": true
+        },
+        "metalsmith-templates": {
+          "version": "0.7.0",
+          "resolved": "https://registry.npmjs.org/metalsmith-templates/-/metalsmith-templates-0.7.0.tgz",
+          "integrity": "sha1-Ccjo1TxofCwidEzNlfmbUBy6ibo=",
+          "dev": true,
+          "requires": {
+            "async": "0.2.10",
+            "consolidate": "0.10.0",
+            "debug": "0.7.4",
+            "extend": "1.2.1",
+            "is-utf8": "0.2.1",
+            "lodash.omit": "2.4.1",
+            "multimatch": "0.1.0"
+          },
+          "dependencies": {
+            "async": {
+              "version": "0.2.10",
+              "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz",
+              "integrity": "sha1-trvgsGdLnXGXCMo43owjfLUmw9E=",
+              "dev": true
+            },
+            "consolidate": {
+              "version": "0.10.0",
+              "resolved": "https://registry.npmjs.org/consolidate/-/consolidate-0.10.0.tgz",
+              "integrity": "sha1-gfGmzroSR9+c73omHOUnws5Tj3o=",
+              "dev": true
+            },
+            "debug": {
+              "version": "0.7.4",
+              "resolved": "https://registry.npmjs.org/debug/-/debug-0.7.4.tgz",
+              "integrity": "sha1-BuHqgILCyxTjmAbiLi9vdX+Srzk=",
+              "dev": true
+            },
+            "extend": {
+              "version": "1.2.1",
+              "resolved": "https://registry.npmjs.org/extend/-/extend-1.2.1.tgz",
+              "integrity": "sha1-oPX9bPyDpf5J72mNYOyKYk3UV2w=",
+              "dev": true
+            },
+            "is-utf8": {
+              "version": "0.2.1",
+              "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/is-utf8/-/is-utf8-0.2.1.tgz",
+              "integrity": "sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI=",
+              "dev": true
+            },
+            "lodash.omit": {
+              "version": "2.4.1",
+              "resolved": "https://registry.npmjs.org/lodash.omit/-/lodash.omit-2.4.1.tgz",
+              "integrity": "sha1-isNsKE8eIDXb04QPos+kDgjeS5w=",
+              "dev": true,
+              "requires": {
+                "lodash._basedifference": "2.4.1",
+                "lodash._baseflatten": "2.4.1",
+                "lodash.createcallback": "2.4.4",
+                "lodash.forin": "2.4.1"
+              },
+              "dependencies": {
+                "lodash._basedifference": {
+                  "version": "2.4.1",
+                  "resolved": "https://registry.npmjs.org/lodash._basedifference/-/lodash._basedifference-2.4.1.tgz",
+                  "integrity": "sha1-eGl8pnQSyeW12+q1TRslc7iaYzQ=",
+                  "dev": true,
+                  "requires": {
+                    "lodash._baseindexof": "2.4.1",
+                    "lodash._cacheindexof": "2.4.1",
+                    "lodash._createcache": "2.4.1",
+                    "lodash._largearraysize": "2.4.1",
+                    "lodash._releaseobject": "2.4.1"
+                  },
+                  "dependencies": {
+                    "lodash._baseindexof": {
+                      "version": "2.4.1",
+                      "resolved": "https://registry.npmjs.org/lodash._baseindexof/-/lodash._baseindexof-2.4.1.tgz",
+                      "integrity": "sha1-WdtYQStAYEykUxq696Q88cw2vVk=",
+                      "dev": true
+                    },
+                    "lodash._cacheindexof": {
+                      "version": "2.4.1",
+                      "resolved": "https://registry.npmjs.org/lodash._cacheindexof/-/lodash._cacheindexof-2.4.1.tgz",
+                      "integrity": "sha1-qf0HzCeO64gqaxjQ/tbFXghzz0s=",
+                      "dev": true,
+                      "requires": {
+                        "lodash._baseindexof": "2.4.1",
+                        "lodash._keyprefix": "2.4.2"
+                      },
+                      "dependencies": {
+                        "lodash._keyprefix": {
+                          "version": "2.4.2",
+                          "resolved": "https://registry.npmjs.org/lodash._keyprefix/-/lodash._keyprefix-2.4.2.tgz",
+                          "integrity": "sha1-GOQp0NveIAOVg1HH0utmTzdPhVg=",
+                          "dev": true
+                        }
+                      }
+                    },
+                    "lodash._createcache": {
+                      "version": "2.4.1",
+                      "resolved": "https://registry.npmjs.org/lodash._createcache/-/lodash._createcache-2.4.1.tgz",
+                      "integrity": "sha1-9MIoLDvKGY0S9BhKwrYhLmkdyFQ=",
+                      "dev": true,
+                      "requires": {
+                        "lodash._cachepush": "2.4.1",
+                        "lodash._getobject": "2.4.1",
+                        "lodash._releaseobject": "2.4.1"
+                      },
+                      "dependencies": {
+                        "lodash._cachepush": {
+                          "version": "2.4.1",
+                          "resolved": "https://registry.npmjs.org/lodash._cachepush/-/lodash._cachepush-2.4.1.tgz",
+                          "integrity": "sha1-z97RJYuRm3om1rASZmpYSXIzCJk=",
+                          "dev": true,
+                          "requires": {
+                            "lodash._keyprefix": "2.4.2"
+                          },
+                          "dependencies": {
+                            "lodash._keyprefix": {
+                              "version": "2.4.2",
+                              "resolved": "https://registry.npmjs.org/lodash._keyprefix/-/lodash._keyprefix-2.4.2.tgz",
+                              "integrity": "sha1-GOQp0NveIAOVg1HH0utmTzdPhVg=",
+                              "dev": true
+                            }
+                          }
+                        },
+                        "lodash._getobject": {
+                          "version": "2.4.1",
+                          "resolved": "https://registry.npmjs.org/lodash._getobject/-/lodash._getobject-2.4.1.tgz",
+                          "integrity": "sha1-Q4B1pQRudyOOHWoBRXtTV6W1yxY=",
+                          "dev": true,
+                          "requires": {
+                            "lodash._objectpool": "2.4.1"
+                          },
+                          "dependencies": {
+                            "lodash._objectpool": {
+                              "version": "2.4.1",
+                              "resolved": "https://registry.npmjs.org/lodash._objectpool/-/lodash._objectpool-2.4.1.tgz",
+                              "integrity": "sha1-UssUtmaHuuoIDb91FlKNA+Ud6bE=",
+                              "dev": true
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "lodash._largearraysize": {
+                      "version": "2.4.1",
+                      "resolved": "https://registry.npmjs.org/lodash._largearraysize/-/lodash._largearraysize-2.4.1.tgz",
+                      "integrity": "sha1-jTj/N45ge65VQ1WSOph02xF8o6g=",
+                      "dev": true
+                    },
+                    "lodash._releaseobject": {
+                      "version": "2.4.1",
+                      "resolved": "https://registry.npmjs.org/lodash._releaseobject/-/lodash._releaseobject-2.4.1.tgz",
+                      "integrity": "sha1-oBjnG+cEZRDrq60TzVHdLBRQWTg=",
+                      "dev": true,
+                      "requires": {
+                        "lodash._maxpoolsize": "2.4.1",
+                        "lodash._objectpool": "2.4.1"
+                      },
+                      "dependencies": {
+                        "lodash._maxpoolsize": {
+                          "version": "2.4.1",
+                          "resolved": "https://registry.npmjs.org/lodash._maxpoolsize/-/lodash._maxpoolsize-2.4.1.tgz",
+                          "integrity": "sha1-nUgvRjuOZq++WcLBTtsRcGAXIzQ=",
+                          "dev": true
+                        },
+                        "lodash._objectpool": {
+                          "version": "2.4.1",
+                          "resolved": "https://registry.npmjs.org/lodash._objectpool/-/lodash._objectpool-2.4.1.tgz",
+                          "integrity": "sha1-UssUtmaHuuoIDb91FlKNA+Ud6bE=",
+                          "dev": true
+                        }
+                      }
+                    }
+                  }
+                },
+                "lodash._baseflatten": {
+                  "version": "2.4.1",
+                  "resolved": "https://registry.npmjs.org/lodash._baseflatten/-/lodash._baseflatten-2.4.1.tgz",
+                  "integrity": "sha1-rrvn5tKMe1GwW9kusdyiexSYyNI=",
+                  "dev": true,
+                  "requires": {
+                    "lodash.isarguments": "2.4.1",
+                    "lodash.isarray": "2.4.1"
+                  },
+                  "dependencies": {
+                    "lodash.isarguments": {
+                      "version": "2.4.1",
+                      "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-2.4.1.tgz",
+                      "integrity": "sha1-STGpwIJTrfCRrnyhkiWKlzh27Mo=",
+                      "dev": true
+                    },
+                    "lodash.isarray": {
+                      "version": "2.4.1",
+                      "resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-2.4.1.tgz",
+                      "integrity": "sha1-tSoybB9i9tfac6MdVAHfbvRPD6E=",
+                      "dev": true,
+                      "requires": {
+                        "lodash._isnative": "2.4.1"
+                      },
+                      "dependencies": {
+                        "lodash._isnative": {
+                          "version": "2.4.1",
+                          "resolved": "https://registry.npmjs.org/lodash._isnative/-/lodash._isnative-2.4.1.tgz",
+                          "integrity": "sha1-PqZAS3hKe+g2x7V1gOHN95sUgyw=",
+                          "dev": true
+                        }
+                      }
+                    }
+                  }
+                },
+                "lodash.createcallback": {
+                  "version": "2.4.4",
+                  "resolved": "https://registry.npmjs.org/lodash.createcallback/-/lodash.createcallback-2.4.4.tgz",
+                  "integrity": "sha1-SkUwhJsBZVAD/L31Y1JO/zzrAsQ=",
+                  "dev": true,
+                  "requires": {
+                    "lodash._basecreatecallback": "2.4.1",
+                    "lodash._baseisequal": "2.4.1",
+                    "lodash.isobject": "2.4.1",
+                    "lodash.keys": "2.4.1",
+                    "lodash.property": "2.4.1"
+                  },
+                  "dependencies": {
+                    "lodash._basecreatecallback": {
+                      "version": "2.4.1",
+                      "resolved": "https://registry.npmjs.org/lodash._basecreatecallback/-/lodash._basecreatecallback-2.4.1.tgz",
+                      "integrity": "sha1-fQsmdknLKeehOdAQO3wR+uhOSFE=",
+                      "dev": true,
+                      "requires": {
+                        "lodash._setbinddata": "2.4.1",
+                        "lodash.bind": "2.4.1",
+                        "lodash.identity": "2.4.1",
+                        "lodash.support": "2.4.1"
+                      },
+                      "dependencies": {
+                        "lodash._setbinddata": {
+                          "version": "2.4.1",
+                          "resolved": "https://registry.npmjs.org/lodash._setbinddata/-/lodash._setbinddata-2.4.1.tgz",
+                          "integrity": "sha1-98IAzRuS7yNrOZ7s9zxkjReqlNI=",
+                          "dev": true,
+                          "requires": {
+                            "lodash._isnative": "2.4.1",
+                            "lodash.noop": "2.4.1"
+                          },
+                          "dependencies": {
+                            "lodash._isnative": {
+                              "version": "2.4.1",
+                              "resolved": "https://registry.npmjs.org/lodash._isnative/-/lodash._isnative-2.4.1.tgz",
+                              "integrity": "sha1-PqZAS3hKe+g2x7V1gOHN95sUgyw=",
+                              "dev": true
+                            },
+                            "lodash.noop": {
+                              "version": "2.4.1",
+                              "resolved": "https://registry.npmjs.org/lodash.noop/-/lodash.noop-2.4.1.tgz",
+                              "integrity": "sha1-T7VPgWZS5a4Q6PcvcXo4jHMmU4o=",
+                              "dev": true
+                            }
+                          }
+                        },
+                        "lodash.bind": {
+                          "version": "2.4.1",
+                          "resolved": "https://registry.npmjs.org/lodash.bind/-/lodash.bind-2.4.1.tgz",
+                          "integrity": "sha1-XRn6AFyMTSNvr0dCx7eh/Kvikmc=",
+                          "dev": true,
+                          "requires": {
+                            "lodash._createwrapper": "2.4.1",
+                            "lodash._slice": "2.4.1"
+                          },
+                          "dependencies": {
+                            "lodash._createwrapper": {
+                              "version": "2.4.1",
+                              "resolved": "https://registry.npmjs.org/lodash._createwrapper/-/lodash._createwrapper-2.4.1.tgz",
+                              "integrity": "sha1-UdaVeXPaTtVW43KQ2MGhjFPeFgc=",
+                              "dev": true,
+                              "requires": {
+                                "lodash._basebind": "2.4.1",
+                                "lodash._basecreatewrapper": "2.4.1",
+                                "lodash._slice": "2.4.1",
+                                "lodash.isfunction": "2.4.1"
+                              },
+                              "dependencies": {
+                                "lodash._basebind": {
+                                  "version": "2.4.1",
+                                  "resolved": "https://registry.npmjs.org/lodash._basebind/-/lodash._basebind-2.4.1.tgz",
+                                  "integrity": "sha1-6UC5690nwyfgqNqxtVkWxTQelXU=",
+                                  "dev": true,
+                                  "requires": {
+                                    "lodash._basecreate": "2.4.1",
+                                    "lodash._setbinddata": "2.4.1",
+                                    "lodash._slice": "2.4.1",
+                                    "lodash.isobject": "2.4.1"
+                                  },
+                                  "dependencies": {
+                                    "lodash._basecreate": {
+                                      "version": "2.4.1",
+                                      "resolved": "https://registry.npmjs.org/lodash._basecreate/-/lodash._basecreate-2.4.1.tgz",
+                                      "integrity": "sha1-+Ob1tXip405UEXm1a47uv0oofgg=",
+                                      "dev": true,
+                                      "requires": {
+                                        "lodash._isnative": "2.4.1",
+                                        "lodash.isobject": "2.4.1",
+                                        "lodash.noop": "2.4.1"
+                                      },
+                                      "dependencies": {
+                                        "lodash._isnative": {
+                                          "version": "2.4.1",
+                                          "resolved": "https://registry.npmjs.org/lodash._isnative/-/lodash._isnative-2.4.1.tgz",
+                                          "integrity": "sha1-PqZAS3hKe+g2x7V1gOHN95sUgyw=",
+                                          "dev": true
+                                        },
+                                        "lodash.noop": {
+                                          "version": "2.4.1",
+                                          "resolved": "https://registry.npmjs.org/lodash.noop/-/lodash.noop-2.4.1.tgz",
+                                          "integrity": "sha1-T7VPgWZS5a4Q6PcvcXo4jHMmU4o=",
+                                          "dev": true
+                                        }
+                                      }
+                                    }
+                                  }
+                                },
+                                "lodash._basecreatewrapper": {
+                                  "version": "2.4.1",
+                                  "resolved": "https://registry.npmjs.org/lodash._basecreatewrapper/-/lodash._basecreatewrapper-2.4.1.tgz",
+                                  "integrity": "sha1-TTHy595+E0+/KAN2K4FQsyUZZm8=",
+                                  "dev": true,
+                                  "requires": {
+                                    "lodash._basecreate": "2.4.1",
+                                    "lodash._setbinddata": "2.4.1",
+                                    "lodash._slice": "2.4.1",
+                                    "lodash.isobject": "2.4.1"
+                                  },
+                                  "dependencies": {
+                                    "lodash._basecreate": {
+                                      "version": "2.4.1",
+                                      "resolved": "https://registry.npmjs.org/lodash._basecreate/-/lodash._basecreate-2.4.1.tgz",
+                                      "integrity": "sha1-+Ob1tXip405UEXm1a47uv0oofgg=",
+                                      "dev": true,
+                                      "requires": {
+                                        "lodash._isnative": "2.4.1",
+                                        "lodash.isobject": "2.4.1",
+                                        "lodash.noop": "2.4.1"
+                                      },
+                                      "dependencies": {
+                                        "lodash._isnative": {
+                                          "version": "2.4.1",
+                                          "resolved": "https://registry.npmjs.org/lodash._isnative/-/lodash._isnative-2.4.1.tgz",
+                                          "integrity": "sha1-PqZAS3hKe+g2x7V1gOHN95sUgyw=",
+                                          "dev": true
+                                        },
+                                        "lodash.noop": {
+                                          "version": "2.4.1",
+                                          "resolved": "https://registry.npmjs.org/lodash.noop/-/lodash.noop-2.4.1.tgz",
+                                          "integrity": "sha1-T7VPgWZS5a4Q6PcvcXo4jHMmU4o=",
+                                          "dev": true
+                                        }
+                                      }
+                                    }
+                                  }
+                                },
+                                "lodash.isfunction": {
+                                  "version": "2.4.1",
+                                  "resolved": "https://registry.npmjs.org/lodash.isfunction/-/lodash.isfunction-2.4.1.tgz",
+                                  "integrity": "sha1-LP1XXHPkmKtX4xm3f6Aq3vE6lNE=",
+                                  "dev": true
+                                }
+                              }
+                            },
+                            "lodash._slice": {
+                              "version": "2.4.1",
+                              "resolved": "https://registry.npmjs.org/lodash._slice/-/lodash._slice-2.4.1.tgz",
+                              "integrity": "sha1-dFz0GlNZexj2iImFREBe+isG2Q8=",
+                              "dev": true
+                            }
+                          }
+                        },
+                        "lodash.identity": {
+                          "version": "2.4.1",
+                          "resolved": "https://registry.npmjs.org/lodash.identity/-/lodash.identity-2.4.1.tgz",
+                          "integrity": "sha1-ZpTP+mX++TH3wxzobHRZfPVg9PE=",
+                          "dev": true
+                        },
+                        "lodash.support": {
+                          "version": "2.4.1",
+                          "resolved": "https://registry.npmjs.org/lodash.support/-/lodash.support-2.4.1.tgz",
+                          "integrity": "sha1-Mg4LZwMWc8KNeiu12eAzGkUkBRU=",
+                          "dev": true,
+                          "requires": {
+                            "lodash._isnative": "2.4.1"
+                          },
+                          "dependencies": {
+                            "lodash._isnative": {
+                              "version": "2.4.1",
+                              "resolved": "https://registry.npmjs.org/lodash._isnative/-/lodash._isnative-2.4.1.tgz",
+                              "integrity": "sha1-PqZAS3hKe+g2x7V1gOHN95sUgyw=",
+                              "dev": true
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "lodash._baseisequal": {
+                      "version": "2.4.1",
+                      "resolved": "https://registry.npmjs.org/lodash._baseisequal/-/lodash._baseisequal-2.4.1.tgz",
+                      "integrity": "sha1-ax5i5YfFUjER9vIoVT2rGeRF/AM=",
+                      "dev": true,
+                      "requires": {
+                        "lodash._getarray": "2.4.1",
+                        "lodash._objecttypes": "2.4.1",
+                        "lodash._releasearray": "2.4.1",
+                        "lodash.forin": "2.4.1",
+                        "lodash.isfunction": "2.4.1"
+                      },
+                      "dependencies": {
+                        "lodash._getarray": {
+                          "version": "2.4.1",
+                          "resolved": "https://registry.npmjs.org/lodash._getarray/-/lodash._getarray-2.4.1.tgz",
+                          "integrity": "sha1-+vH3+BD6mFolHCGHQESBCUg55e4=",
+                          "dev": true,
+                          "requires": {
+                            "lodash._arraypool": "2.4.1"
+                          },
+                          "dependencies": {
+                            "lodash._arraypool": {
+                              "version": "2.4.1",
+                              "resolved": "https://registry.npmjs.org/lodash._arraypool/-/lodash._arraypool-2.4.1.tgz",
+                              "integrity": "sha1-6I7suS4ruEyQZWEv2VigcZzUf5Q=",
+                              "dev": true
+                            }
+                          }
+                        },
+                        "lodash._objecttypes": {
+                          "version": "2.4.1",
+                          "resolved": "https://registry.npmjs.org/lodash._objecttypes/-/lodash._objecttypes-2.4.1.tgz",
+                          "integrity": "sha1-fAt/admKH3ZSn4kLDNsbTf7BHBE=",
+                          "dev": true
+                        },
+                        "lodash._releasearray": {
+                          "version": "2.4.1",
+                          "resolved": "https://registry.npmjs.org/lodash._releasearray/-/lodash._releasearray-2.4.1.tgz",
+                          "integrity": "sha1-phOWMNdtFTawfdyAliiJsIL2pkE=",
+                          "dev": true,
+                          "requires": {
+                            "lodash._arraypool": "2.4.1",
+                            "lodash._maxpoolsize": "2.4.1"
+                          },
+                          "dependencies": {
+                            "lodash._arraypool": {
+                              "version": "2.4.1",
+                              "resolved": "https://registry.npmjs.org/lodash._arraypool/-/lodash._arraypool-2.4.1.tgz",
+                              "integrity": "sha1-6I7suS4ruEyQZWEv2VigcZzUf5Q=",
+                              "dev": true
+                            },
+                            "lodash._maxpoolsize": {
+                              "version": "2.4.1",
+                              "resolved": "https://registry.npmjs.org/lodash._maxpoolsize/-/lodash._maxpoolsize-2.4.1.tgz",
+                              "integrity": "sha1-nUgvRjuOZq++WcLBTtsRcGAXIzQ=",
+                              "dev": true
+                            }
+                          }
+                        },
+                        "lodash.isfunction": {
+                          "version": "2.4.1",
+                          "resolved": "https://registry.npmjs.org/lodash.isfunction/-/lodash.isfunction-2.4.1.tgz",
+                          "integrity": "sha1-LP1XXHPkmKtX4xm3f6Aq3vE6lNE=",
+                          "dev": true
+                        }
+                      }
+                    },
+                    "lodash.isobject": {
+                      "version": "2.4.1",
+                      "resolved": "https://registry.npmjs.org/lodash.isobject/-/lodash.isobject-2.4.1.tgz",
+                      "integrity": "sha1-Wi5H/mmVPx7mMafrof5k0tBlWPU=",
+                      "dev": true,
+                      "requires": {
+                        "lodash._objecttypes": "2.4.1"
+                      },
+                      "dependencies": {
+                        "lodash._objecttypes": {
+                          "version": "2.4.1",
+                          "resolved": "https://registry.npmjs.org/lodash._objecttypes/-/lodash._objecttypes-2.4.1.tgz",
+                          "integrity": "sha1-fAt/admKH3ZSn4kLDNsbTf7BHBE=",
+                          "dev": true
+                        }
+                      }
+                    },
+                    "lodash.keys": {
+                      "version": "2.4.1",
+                      "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-2.4.1.tgz",
+                      "integrity": "sha1-SN6kbfj/djKxDXBrissmWR4rNyc=",
+                      "dev": true,
+                      "requires": {
+                        "lodash._isnative": "2.4.1",
+                        "lodash._shimkeys": "2.4.1",
+                        "lodash.isobject": "2.4.1"
+                      },
+                      "dependencies": {
+                        "lodash._isnative": {
+                          "version": "2.4.1",
+                          "resolved": "https://registry.npmjs.org/lodash._isnative/-/lodash._isnative-2.4.1.tgz",
+                          "integrity": "sha1-PqZAS3hKe+g2x7V1gOHN95sUgyw=",
+                          "dev": true
+                        },
+                        "lodash._shimkeys": {
+                          "version": "2.4.1",
+                          "resolved": "https://registry.npmjs.org/lodash._shimkeys/-/lodash._shimkeys-2.4.1.tgz",
+                          "integrity": "sha1-bpzJZm/wgfC1psl4uD4kLmlJ0gM=",
+                          "dev": true,
+                          "requires": {
+                            "lodash._objecttypes": "2.4.1"
+                          },
+                          "dependencies": {
+                            "lodash._objecttypes": {
+                              "version": "2.4.1",
+                              "resolved": "https://registry.npmjs.org/lodash._objecttypes/-/lodash._objecttypes-2.4.1.tgz",
+                              "integrity": "sha1-fAt/admKH3ZSn4kLDNsbTf7BHBE=",
+                              "dev": true
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "lodash.property": {
+                      "version": "2.4.1",
+                      "resolved": "https://registry.npmjs.org/lodash.property/-/lodash.property-2.4.1.tgz",
+                      "integrity": "sha1-QEnAVJ2vWnECvF6T7q67N53rEy8=",
+                      "dev": true
+                    }
+                  }
+                },
+                "lodash.forin": {
+                  "version": "2.4.1",
+                  "resolved": "https://registry.npmjs.org/lodash.forin/-/lodash.forin-2.4.1.tgz",
+                  "integrity": "sha1-gInq7X0lsIZyt8Zv0HrFXQYjIOs=",
+                  "dev": true,
+                  "requires": {
+                    "lodash._basecreatecallback": "2.4.1",
+                    "lodash._objecttypes": "2.4.1"
+                  },
+                  "dependencies": {
+                    "lodash._basecreatecallback": {
+                      "version": "2.4.1",
+                      "resolved": "https://registry.npmjs.org/lodash._basecreatecallback/-/lodash._basecreatecallback-2.4.1.tgz",
+                      "integrity": "sha1-fQsmdknLKeehOdAQO3wR+uhOSFE=",
+                      "dev": true,
+                      "requires": {
+                        "lodash._setbinddata": "2.4.1",
+                        "lodash.bind": "2.4.1",
+                        "lodash.identity": "2.4.1",
+                        "lodash.support": "2.4.1"
+                      },
+                      "dependencies": {
+                        "lodash._setbinddata": {
+                          "version": "2.4.1",
+                          "resolved": "https://registry.npmjs.org/lodash._setbinddata/-/lodash._setbinddata-2.4.1.tgz",
+                          "integrity": "sha1-98IAzRuS7yNrOZ7s9zxkjReqlNI=",
+                          "dev": true,
+                          "requires": {
+                            "lodash._isnative": "2.4.1",
+                            "lodash.noop": "2.4.1"
+                          },
+                          "dependencies": {
+                            "lodash._isnative": {
+                              "version": "2.4.1",
+                              "resolved": "https://registry.npmjs.org/lodash._isnative/-/lodash._isnative-2.4.1.tgz",
+                              "integrity": "sha1-PqZAS3hKe+g2x7V1gOHN95sUgyw=",
+                              "dev": true
+                            },
+                            "lodash.noop": {
+                              "version": "2.4.1",
+                              "resolved": "https://registry.npmjs.org/lodash.noop/-/lodash.noop-2.4.1.tgz",
+                              "integrity": "sha1-T7VPgWZS5a4Q6PcvcXo4jHMmU4o=",
+                              "dev": true
+                            }
+                          }
+                        },
+                        "lodash.bind": {
+                          "version": "2.4.1",
+                          "resolved": "https://registry.npmjs.org/lodash.bind/-/lodash.bind-2.4.1.tgz",
+                          "integrity": "sha1-XRn6AFyMTSNvr0dCx7eh/Kvikmc=",
+                          "dev": true,
+                          "requires": {
+                            "lodash._createwrapper": "2.4.1",
+                            "lodash._slice": "2.4.1"
+                          },
+                          "dependencies": {
+                            "lodash._createwrapper": {
+                              "version": "2.4.1",
+                              "resolved": "https://registry.npmjs.org/lodash._createwrapper/-/lodash._createwrapper-2.4.1.tgz",
+                              "integrity": "sha1-UdaVeXPaTtVW43KQ2MGhjFPeFgc=",
+                              "dev": true,
+                              "requires": {
+                                "lodash._basebind": "2.4.1",
+                                "lodash._basecreatewrapper": "2.4.1",
+                                "lodash._slice": "2.4.1",
+                                "lodash.isfunction": "2.4.1"
+                              },
+                              "dependencies": {
+                                "lodash._basebind": {
+                                  "version": "2.4.1",
+                                  "resolved": "https://registry.npmjs.org/lodash._basebind/-/lodash._basebind-2.4.1.tgz",
+                                  "integrity": "sha1-6UC5690nwyfgqNqxtVkWxTQelXU=",
+                                  "dev": true,
+                                  "requires": {
+                                    "lodash._basecreate": "2.4.1",
+                                    "lodash._setbinddata": "2.4.1",
+                                    "lodash._slice": "2.4.1",
+                                    "lodash.isobject": "2.4.1"
+                                  },
+                                  "dependencies": {
+                                    "lodash._basecreate": {
+                                      "version": "2.4.1",
+                                      "resolved": "https://registry.npmjs.org/lodash._basecreate/-/lodash._basecreate-2.4.1.tgz",
+                                      "integrity": "sha1-+Ob1tXip405UEXm1a47uv0oofgg=",
+                                      "dev": true,
+                                      "requires": {
+                                        "lodash._isnative": "2.4.1",
+                                        "lodash.isobject": "2.4.1",
+                                        "lodash.noop": "2.4.1"
+                                      },
+                                      "dependencies": {
+                                        "lodash._isnative": {
+                                          "version": "2.4.1",
+                                          "resolved": "https://registry.npmjs.org/lodash._isnative/-/lodash._isnative-2.4.1.tgz",
+                                          "integrity": "sha1-PqZAS3hKe+g2x7V1gOHN95sUgyw=",
+                                          "dev": true
+                                        },
+                                        "lodash.noop": {
+                                          "version": "2.4.1",
+                                          "resolved": "https://registry.npmjs.org/lodash.noop/-/lodash.noop-2.4.1.tgz",
+                                          "integrity": "sha1-T7VPgWZS5a4Q6PcvcXo4jHMmU4o=",
+                                          "dev": true
+                                        }
+                                      }
+                                    },
+                                    "lodash.isobject": {
+                                      "version": "2.4.1",
+                                      "resolved": "https://registry.npmjs.org/lodash.isobject/-/lodash.isobject-2.4.1.tgz",
+                                      "integrity": "sha1-Wi5H/mmVPx7mMafrof5k0tBlWPU=",
+                                      "dev": true,
+                                      "requires": {
+                                        "lodash._objecttypes": "2.4.1"
+                                      }
+                                    }
+                                  }
+                                },
+                                "lodash._basecreatewrapper": {
+                                  "version": "2.4.1",
+                                  "resolved": "https://registry.npmjs.org/lodash._basecreatewrapper/-/lodash._basecreatewrapper-2.4.1.tgz",
+                                  "integrity": "sha1-TTHy595+E0+/KAN2K4FQsyUZZm8=",
+                                  "dev": true,
+                                  "requires": {
+                                    "lodash._basecreate": "2.4.1",
+                                    "lodash._setbinddata": "2.4.1",
+                                    "lodash._slice": "2.4.1",
+                                    "lodash.isobject": "2.4.1"
+                                  },
+                                  "dependencies": {
+                                    "lodash._basecreate": {
+                                      "version": "2.4.1",
+                                      "resolved": "https://registry.npmjs.org/lodash._basecreate/-/lodash._basecreate-2.4.1.tgz",
+                                      "integrity": "sha1-+Ob1tXip405UEXm1a47uv0oofgg=",
+                                      "dev": true,
+                                      "requires": {
+                                        "lodash._isnative": "2.4.1",
+                                        "lodash.isobject": "2.4.1",
+                                        "lodash.noop": "2.4.1"
+                                      },
+                                      "dependencies": {
+                                        "lodash._isnative": {
+                                          "version": "2.4.1",
+                                          "resolved": "https://registry.npmjs.org/lodash._isnative/-/lodash._isnative-2.4.1.tgz",
+                                          "integrity": "sha1-PqZAS3hKe+g2x7V1gOHN95sUgyw=",
+                                          "dev": true
+                                        },
+                                        "lodash.noop": {
+                                          "version": "2.4.1",
+                                          "resolved": "https://registry.npmjs.org/lodash.noop/-/lodash.noop-2.4.1.tgz",
+                                          "integrity": "sha1-T7VPgWZS5a4Q6PcvcXo4jHMmU4o=",
+                                          "dev": true
+                                        }
+                                      }
+                                    },
+                                    "lodash.isobject": {
+                                      "version": "2.4.1",
+                                      "resolved": "https://registry.npmjs.org/lodash.isobject/-/lodash.isobject-2.4.1.tgz",
+                                      "integrity": "sha1-Wi5H/mmVPx7mMafrof5k0tBlWPU=",
+                                      "dev": true,
+                                      "requires": {
+                                        "lodash._objecttypes": "2.4.1"
+                                      }
+                                    }
+                                  }
+                                },
+                                "lodash.isfunction": {
+                                  "version": "2.4.1",
+                                  "resolved": "https://registry.npmjs.org/lodash.isfunction/-/lodash.isfunction-2.4.1.tgz",
+                                  "integrity": "sha1-LP1XXHPkmKtX4xm3f6Aq3vE6lNE=",
+                                  "dev": true
+                                }
+                              }
+                            },
+                            "lodash._slice": {
+                              "version": "2.4.1",
+                              "resolved": "https://registry.npmjs.org/lodash._slice/-/lodash._slice-2.4.1.tgz",
+                              "integrity": "sha1-dFz0GlNZexj2iImFREBe+isG2Q8=",
+                              "dev": true
+                            }
+                          }
+                        },
+                        "lodash.identity": {
+                          "version": "2.4.1",
+                          "resolved": "https://registry.npmjs.org/lodash.identity/-/lodash.identity-2.4.1.tgz",
+                          "integrity": "sha1-ZpTP+mX++TH3wxzobHRZfPVg9PE=",
+                          "dev": true
+                        },
+                        "lodash.support": {
+                          "version": "2.4.1",
+                          "resolved": "https://registry.npmjs.org/lodash.support/-/lodash.support-2.4.1.tgz",
+                          "integrity": "sha1-Mg4LZwMWc8KNeiu12eAzGkUkBRU=",
+                          "dev": true,
+                          "requires": {
+                            "lodash._isnative": "2.4.1"
+                          },
+                          "dependencies": {
+                            "lodash._isnative": {
+                              "version": "2.4.1",
+                              "resolved": "https://registry.npmjs.org/lodash._isnative/-/lodash._isnative-2.4.1.tgz",
+                              "integrity": "sha1-PqZAS3hKe+g2x7V1gOHN95sUgyw=",
+                              "dev": true
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "lodash._objecttypes": {
+                      "version": "2.4.1",
+                      "resolved": "https://registry.npmjs.org/lodash._objecttypes/-/lodash._objecttypes-2.4.1.tgz",
+                      "integrity": "sha1-fAt/admKH3ZSn4kLDNsbTf7BHBE=",
+                      "dev": true
+                    }
+                  }
+                }
+              }
+            },
+            "multimatch": {
+              "version": "0.1.0",
+              "resolved": "https://registry.npmjs.org/multimatch/-/multimatch-0.1.0.tgz",
+              "integrity": "sha1-CZ2fj4RjrDbPv6JzYLwWzuh97WQ=",
+              "dev": true,
+              "requires": {
+                "lodash": "2.4.2",
+                "minimatch": "0.2.14"
+              },
+              "dependencies": {
+                "lodash": {
+                  "version": "2.4.2",
+                  "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz",
+                  "integrity": "sha1-+t2DS5aDBz2hebPq5tnA0VBT9z4=",
+                  "dev": true
+                },
+                "minimatch": {
+                  "version": "0.2.14",
+                  "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
+                  "integrity": "sha1-x054BXT2PG+aCQ6Q775u9TpqdWo=",
+                  "dev": true,
+                  "requires": {
+                    "lru-cache": "2.7.3",
+                    "sigmund": "1.0.1"
+                  },
+                  "dependencies": {
+                    "lru-cache": {
+                      "version": "2.7.3",
+                      "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/lru-cache/-/lru-cache-2.7.3.tgz",
+                      "integrity": "sha1-bUUk6LlV+V1PW1iFHOId1y+06VI=",
+                      "dev": true
+                    },
+                    "sigmund": {
+                      "version": "1.0.1",
+                      "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz",
+                      "integrity": "sha1-P/IfGYytIXX587eBhT/ZTQ0ZtZA=",
+                      "dev": true
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "metalsmith-uglify": {
+          "version": "1.5.1",
+          "resolved": "https://registry.npmjs.org/metalsmith-uglify/-/metalsmith-uglify-1.5.1.tgz",
+          "integrity": "sha1-8+ReRd5RhrZdQKKnNCmHp8uAOAg=",
+          "dev": true,
+          "requires": {
+            "arrify": "1.0.1",
+            "is-string": "1.0.4",
+            "minimatch": "3.0.3",
+            "object-assign": "4.1.0",
+            "uglify-js": "2.7.3",
+            "upath": "0.2.0"
+          },
+          "dependencies": {
+            "arrify": {
+              "version": "1.0.1",
+              "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/arrify/-/arrify-1.0.1.tgz",
+              "integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=",
+              "dev": true
+            },
+            "is-string": {
+              "version": "1.0.4",
+              "resolved": "https://registry.npmjs.org/is-string/-/is-string-1.0.4.tgz",
+              "integrity": "sha1-zDqbaYV9Yh6WNyWiTK7shzuCbmQ=",
+              "dev": true
+            },
+            "object-assign": {
+              "version": "4.1.0",
+              "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/object-assign/-/object-assign-4.1.0.tgz",
+              "integrity": "sha1-ejs9DpgGPUP0wD8uiubNUahog6A=",
+              "dev": true
+            },
+            "uglify-js": {
+              "version": "2.7.3",
+              "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/uglify-js/-/uglify-js-2.7.3.tgz",
+              "integrity": "sha1-ObOnMpuJ9exQfjRMbiJWhpjvSGg=",
+              "dev": true,
+              "requires": {
+                "async": "0.2.10",
+                "source-map": "0.5.6",
+                "uglify-to-browserify": "1.0.2",
+                "yargs": "3.10.0"
+              },
+              "dependencies": {
+                "async": {
+                  "version": "0.2.10",
+                  "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz",
+                  "integrity": "sha1-trvgsGdLnXGXCMo43owjfLUmw9E=",
+                  "dev": true
+                },
+                "source-map": {
+                  "version": "0.5.6",
+                  "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/source-map/-/source-map-0.5.6.tgz",
+                  "integrity": "sha1-dc449SvwczxafwwRjYEzSiu19BI=",
+                  "dev": true
+                },
+                "uglify-to-browserify": {
+                  "version": "1.0.2",
+                  "resolved": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz",
+                  "integrity": "sha1-bgkk1r2mta/jSeOabWMoUKD4grc=",
+                  "dev": true
+                },
+                "yargs": {
+                  "version": "3.10.0",
+                  "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
+                  "integrity": "sha1-9+572FfdfB0tOMDnTvvWgdFDH9E=",
+                  "dev": true,
+                  "requires": {
+                    "camelcase": "1.2.1",
+                    "cliui": "2.1.0",
+                    "decamelize": "1.2.0",
+                    "window-size": "0.1.0"
+                  },
+                  "dependencies": {
+                    "cliui": {
+                      "version": "2.1.0",
+                      "resolved": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
+                      "integrity": "sha1-S0dXYP+AJkx2LDoXGQMukcf+oNE=",
+                      "dev": true,
+                      "requires": {
+                        "center-align": "0.1.3",
+                        "right-align": "0.1.3",
+                        "wordwrap": "0.0.2"
+                      },
+                      "dependencies": {
+                        "center-align": {
+                          "version": "0.1.3",
+                          "resolved": "https://registry.npmjs.org/center-align/-/center-align-0.1.3.tgz",
+                          "integrity": "sha1-qg0yYptu6XIgBBHL1EYckHvCt60=",
+                          "dev": true,
+                          "requires": {
+                            "align-text": "0.1.4",
+                            "lazy-cache": "1.0.4"
+                          },
+                          "dependencies": {
+                            "align-text": {
+                              "version": "0.1.4",
+                              "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
+                              "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
+                              "dev": true,
+                              "requires": {
+                                "kind-of": "3.0.4",
+                                "longest": "1.0.1",
+                                "repeat-string": "1.5.4"
+                              },
+                              "dependencies": {
+                                "kind-of": {
+                                  "version": "3.0.4",
+                                  "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/kind-of/-/kind-of-3.0.4.tgz",
+                                  "integrity": "sha1-e47PGKThf4Jp1ztQHJ8jLJaIenQ=",
+                                  "dev": true,
+                                  "requires": {
+                                    "is-buffer": "1.1.4"
+                                  },
+                                  "dependencies": {
+                                    "is-buffer": {
+                                      "version": "1.1.4",
+                                      "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/is-buffer/-/is-buffer-1.1.4.tgz",
+                                      "integrity": "sha1-z8hszV3FpS+oBIkRHGkgxFfi2Ys=",
+                                      "dev": true
+                                    }
+                                  }
+                                },
+                                "longest": {
+                                  "version": "1.0.1",
+                                  "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
+                                  "integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc=",
+                                  "dev": true
+                                },
+                                "repeat-string": {
+                                  "version": "1.5.4",
+                                  "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.5.4.tgz",
+                                  "integrity": "sha1-ZOwMkeD0tHX5DVtkNlHj5uW2wtU=",
+                                  "dev": true
+                                }
+                              }
+                            },
+                            "lazy-cache": {
+                              "version": "1.0.4",
+                              "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/lazy-cache/-/lazy-cache-1.0.4.tgz",
+                              "integrity": "sha1-odePw6UEdMuAhF07O24dpJpEbo4=",
+                              "dev": true
+                            }
+                          }
+                        },
+                        "right-align": {
+                          "version": "0.1.3",
+                          "resolved": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
+                          "integrity": "sha1-YTObci/mo1FWiSENJOFMlhSGE+8=",
+                          "dev": true,
+                          "requires": {
+                            "align-text": "0.1.4"
+                          },
+                          "dependencies": {
+                            "align-text": {
+                              "version": "0.1.4",
+                              "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
+                              "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
+                              "dev": true,
+                              "requires": {
+                                "kind-of": "3.0.4",
+                                "longest": "1.0.1",
+                                "repeat-string": "1.5.4"
+                              },
+                              "dependencies": {
+                                "kind-of": {
+                                  "version": "3.0.4",
+                                  "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/kind-of/-/kind-of-3.0.4.tgz",
+                                  "integrity": "sha1-e47PGKThf4Jp1ztQHJ8jLJaIenQ=",
+                                  "dev": true,
+                                  "requires": {
+                                    "is-buffer": "1.1.4"
+                                  },
+                                  "dependencies": {
+                                    "is-buffer": {
+                                      "version": "1.1.4",
+                                      "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/is-buffer/-/is-buffer-1.1.4.tgz",
+                                      "integrity": "sha1-z8hszV3FpS+oBIkRHGkgxFfi2Ys=",
+                                      "dev": true
+                                    }
+                                  }
+                                },
+                                "longest": {
+                                  "version": "1.0.1",
+                                  "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
+                                  "integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc=",
+                                  "dev": true
+                                },
+                                "repeat-string": {
+                                  "version": "1.5.4",
+                                  "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.5.4.tgz",
+                                  "integrity": "sha1-ZOwMkeD0tHX5DVtkNlHj5uW2wtU=",
+                                  "dev": true
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "wordwrap": {
+                          "version": "0.0.2",
+                          "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
+                          "integrity": "sha1-t5Zpu0LstAn4PVg8rVLKF+qhZD8=",
+                          "dev": true
+                        }
+                      }
+                    },
+                    "decamelize": {
+                      "version": "1.2.0",
+                      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+                      "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
+                      "dev": true
+                    },
+                    "window-size": {
+                      "version": "0.1.0",
+                      "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz",
+                      "integrity": "sha1-VDjNLqk7IC76Ohn+iIeu58lPnJ0=",
+                      "dev": true
+                    }
+                  }
+                }
+              }
+            },
+            "upath": {
+              "version": "0.2.0",
+              "resolved": "https://registry.npmjs.org/upath/-/upath-0.2.0.tgz",
+              "integrity": "sha1-vbrQ8sYK/qFl+BJ9uxtb3uUArYE=",
+              "dev": true,
+              "requires": {
+                "lodash": "3.10.1",
+                "underscore.string": "2.3.3"
+              },
+              "dependencies": {
+                "lodash": {
+                  "version": "3.10.1",
+                  "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/lodash/-/lodash-3.10.1.tgz",
+                  "integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y=",
+                  "dev": true
+                },
+                "underscore.string": {
+                  "version": "2.3.3",
+                  "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/underscore.string/-/underscore.string-2.3.3.tgz",
+                  "integrity": "sha1-ccCL9rQosRM/N+ePo6Icgvcymw0=",
+                  "dev": true
+                }
+              }
+            }
+          }
+        },
+        "metalsmith-watch": {
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/metalsmith-watch/-/metalsmith-watch-1.0.3.tgz",
+          "integrity": "sha1-80/TLn4tdd4OUFhEvOspfJmr4/g=",
+          "dev": true,
+          "requires": {
+            "async": "0.9.2",
+            "chalk": "1.1.3",
+            "gaze": "1.1.2",
+            "metalsmith-filenames": "1.0.0",
+            "multimatch": "2.1.0",
+            "tiny-lr": "0.1.7",
+            "unyield": "0.0.1"
+          },
+          "dependencies": {
+            "async": {
+              "version": "0.9.2",
+              "resolved": "https://registry.npmjs.org/async/-/async-0.9.2.tgz",
+              "integrity": "sha1-rqdNXmHB+JlhO/ZL2mbUx48v0X0=",
+              "dev": true
+            },
+            "chalk": {
+              "version": "1.1.3",
+              "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/chalk/-/chalk-1.1.3.tgz",
+              "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+              "dev": true,
+              "requires": {
+                "ansi-styles": "2.2.1",
+                "escape-string-regexp": "1.0.5",
+                "has-ansi": "2.0.0",
+                "strip-ansi": "3.0.1",
+                "supports-color": "2.0.0"
+              },
+              "dependencies": {
+                "ansi-styles": {
+                  "version": "2.2.1",
+                  "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/ansi-styles/-/ansi-styles-2.2.1.tgz",
+                  "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+                  "dev": true
+                },
+                "escape-string-regexp": {
+                  "version": "1.0.5",
+                  "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+                  "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+                  "dev": true
+                },
+                "has-ansi": {
+                  "version": "2.0.0",
+                  "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/has-ansi/-/has-ansi-2.0.0.tgz",
+                  "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
+                  "dev": true,
+                  "requires": {
+                    "ansi-regex": "2.0.0"
+                  },
+                  "dependencies": {
+                    "ansi-regex": {
+                      "version": "2.0.0",
+                      "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/ansi-regex/-/ansi-regex-2.0.0.tgz",
+                      "integrity": "sha1-xQYbbg74qBd15Q9dZhUb9r83EQc=",
+                      "dev": true
+                    }
+                  }
+                },
+                "strip-ansi": {
+                  "version": "3.0.1",
+                  "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/strip-ansi/-/strip-ansi-3.0.1.tgz",
+                  "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+                  "dev": true,
+                  "requires": {
+                    "ansi-regex": "2.0.0"
+                  },
+                  "dependencies": {
+                    "ansi-regex": {
+                      "version": "2.0.0",
+                      "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/ansi-regex/-/ansi-regex-2.0.0.tgz",
+                      "integrity": "sha1-xQYbbg74qBd15Q9dZhUb9r83EQc=",
+                      "dev": true
+                    }
+                  }
+                },
+                "supports-color": {
+                  "version": "2.0.0",
+                  "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/supports-color/-/supports-color-2.0.0.tgz",
+                  "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+                  "dev": true
+                }
+              }
+            },
+            "gaze": {
+              "version": "1.1.2",
+              "resolved": "https://registry.npmjs.org/gaze/-/gaze-1.1.2.tgz",
+              "integrity": "sha1-hHIkZ3rbiHDWeSV+0ziP22HkAQU=",
+              "dev": true,
+              "requires": {
+                "globule": "1.0.0"
+              },
+              "dependencies": {
+                "globule": {
+                  "version": "1.0.0",
+                  "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/globule/-/globule-1.0.0.tgz",
+                  "integrity": "sha1-8irrqszgK+SSRT6XnDrptpg/HGw=",
+                  "dev": true,
+                  "requires": {
+                    "glob": "7.0.6",
+                    "lodash": "4.9.0",
+                    "minimatch": "3.0.3"
+                  },
+                  "dependencies": {
+                    "glob": {
+                      "version": "7.0.6",
+                      "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/glob/-/glob-7.0.6.tgz",
+                      "integrity": "sha1-IRuvr0nlJbjNkyYNFKsTYVKz9Xo=",
+                      "dev": true,
+                      "requires": {
+                        "fs.realpath": "1.0.0",
+                        "inflight": "1.0.5",
+                        "inherits": "2.0.3",
+                        "minimatch": "3.0.3",
+                        "once": "1.4.0",
+                        "path-is-absolute": "1.0.1"
+                      },
+                      "dependencies": {
+                        "fs.realpath": {
+                          "version": "1.0.0",
+                          "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/fs.realpath/-/fs.realpath-1.0.0.tgz",
+                          "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+                          "dev": true
+                        },
+                        "inflight": {
+                          "version": "1.0.5",
+                          "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/inflight/-/inflight-1.0.5.tgz",
+                          "integrity": "sha1-2zIEzVqd4ubNiQuFxuL2a89PYgo=",
+                          "dev": true,
+                          "requires": {
+                            "once": "1.4.0",
+                            "wrappy": "1.0.2"
+                          },
+                          "dependencies": {
+                            "wrappy": {
+                              "version": "1.0.2",
+                              "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/wrappy/-/wrappy-1.0.2.tgz",
+                              "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+                              "dev": true
+                            }
+                          }
+                        },
+                        "inherits": {
+                          "version": "2.0.3",
+                          "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/inherits/-/inherits-2.0.3.tgz",
+                          "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+                          "dev": true
+                        },
+                        "once": {
+                          "version": "1.4.0",
+                          "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/once/-/once-1.4.0.tgz",
+                          "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+                          "dev": true,
+                          "requires": {
+                            "wrappy": "1.0.2"
+                          },
+                          "dependencies": {
+                            "wrappy": {
+                              "version": "1.0.2",
+                              "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/wrappy/-/wrappy-1.0.2.tgz",
+                              "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+                              "dev": true
+                            }
+                          }
+                        },
+                        "path-is-absolute": {
+                          "version": "1.0.1",
+                          "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+                          "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+                          "dev": true
+                        }
+                      }
+                    },
+                    "lodash": {
+                      "version": "4.9.0",
+                      "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/lodash/-/lodash-4.9.0.tgz",
+                      "integrity": "sha1-TCDXQvA86F3HAODderm8q4Xm/BQ=",
+                      "dev": true
+                    }
+                  }
+                }
+              }
+            },
+            "metalsmith-filenames": {
+              "version": "1.0.0",
+              "resolved": "https://registry.npmjs.org/metalsmith-filenames/-/metalsmith-filenames-1.0.0.tgz",
+              "integrity": "sha1-305p8ka4Mlu5GJ4Cc9LucImdAN4=",
+              "dev": true
+            },
+            "multimatch": {
+              "version": "2.1.0",
+              "resolved": "https://registry.npmjs.org/multimatch/-/multimatch-2.1.0.tgz",
+              "integrity": "sha1-nHkGoi+0wCkZ4vX3UWG0zb1LKis=",
+              "dev": true,
+              "requires": {
+                "array-differ": "1.0.0",
+                "array-union": "1.0.2",
+                "arrify": "1.0.1",
+                "minimatch": "3.0.3"
+              },
+              "dependencies": {
+                "array-differ": {
+                  "version": "1.0.0",
+                  "resolved": "https://registry.npmjs.org/array-differ/-/array-differ-1.0.0.tgz",
+                  "integrity": "sha1-7/UuN1gknTO+QCuLuOVkuytdQDE=",
+                  "dev": true
+                },
+                "array-union": {
+                  "version": "1.0.2",
+                  "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/array-union/-/array-union-1.0.2.tgz",
+                  "integrity": "sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=",
+                  "dev": true,
+                  "requires": {
+                    "array-uniq": "1.0.3"
+                  },
+                  "dependencies": {
+                    "array-uniq": {
+                      "version": "1.0.3",
+                      "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/array-uniq/-/array-uniq-1.0.3.tgz",
+                      "integrity": "sha1-r2rId6Jcx/dOBYiUdThY39sk/bY=",
+                      "dev": true
+                    }
+                  }
+                },
+                "arrify": {
+                  "version": "1.0.1",
+                  "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/arrify/-/arrify-1.0.1.tgz",
+                  "integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=",
+                  "dev": true
+                }
+              }
+            },
+            "tiny-lr": {
+              "version": "0.1.7",
+              "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/tiny-lr/-/tiny-lr-0.1.7.tgz",
+              "integrity": "sha1-vgJNCfHrsi4nSYNMYOoXs4UjQXU=",
+              "dev": true,
+              "requires": {
+                "body-parser": "1.8.4",
+                "debug": "2.0.0",
+                "faye-websocket": "0.7.3",
+                "livereload-js": "2.2.2",
+                "parseurl": "1.3.1",
+                "qs": "2.2.5"
+              },
+              "dependencies": {
+                "body-parser": {
+                  "version": "1.8.4",
+                  "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.8.4.tgz",
+                  "integrity": "sha1-1JfgS8E7P5qL2McLsM3Bby4CiJg=",
+                  "dev": true,
+                  "requires": {
+                    "bytes": "1.0.0",
+                    "depd": "0.4.5",
+                    "iconv-lite": "0.4.4",
+                    "media-typer": "0.3.0",
+                    "on-finished": "2.1.0",
+                    "qs": "2.2.4",
+                    "raw-body": "1.3.0",
+                    "type-is": "1.5.7"
+                  },
+                  "dependencies": {
+                    "bytes": {
+                      "version": "1.0.0",
+                      "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/bytes/-/bytes-1.0.0.tgz",
+                      "integrity": "sha1-NWnt6Lo0MV+rmcPpLLBMciDeH6g=",
+                      "dev": true
+                    },
+                    "depd": {
+                      "version": "0.4.5",
+                      "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/depd/-/depd-0.4.5.tgz",
+                      "integrity": "sha1-GmZLUziLSmVz6K5ntfdnxpPKl/E=",
+                      "dev": true
+                    },
+                    "iconv-lite": {
+                      "version": "0.4.4",
+                      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.4.tgz",
+                      "integrity": "sha1-6V8uQdsHNfwhZS94J6XuMuY8g6g=",
+                      "dev": true
+                    },
+                    "media-typer": {
+                      "version": "0.3.0",
+                      "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/media-typer/-/media-typer-0.3.0.tgz",
+                      "integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g=",
+                      "dev": true
+                    },
+                    "on-finished": {
+                      "version": "2.1.0",
+                      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.1.0.tgz",
+                      "integrity": "sha1-DFOfCSkej/rd4MiiWFD7LO3HAi0=",
+                      "dev": true,
+                      "requires": {
+                        "ee-first": "1.0.5"
+                      },
+                      "dependencies": {
+                        "ee-first": {
+                          "version": "1.0.5",
+                          "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.0.5.tgz",
+                          "integrity": "sha1-jJshKJjYzZ8alDZlDOe+ICyen/A=",
+                          "dev": true
+                        }
+                      }
+                    },
+                    "qs": {
+                      "version": "2.2.4",
+                      "resolved": "https://registry.npmjs.org/qs/-/qs-2.2.4.tgz",
+                      "integrity": "sha1-Lp+800tUDjQhySTs0B6QqpdTGcg=",
+                      "dev": true
+                    },
+                    "raw-body": {
+                      "version": "1.3.0",
+                      "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/raw-body/-/raw-body-1.3.0.tgz",
+                      "integrity": "sha1-l4IwoValVI9C7vFN4i0PT2EAg9E=",
+                      "dev": true,
+                      "requires": {
+                        "bytes": "1.0.0",
+                        "iconv-lite": "0.4.4"
+                      }
+                    },
+                    "type-is": {
+                      "version": "1.5.7",
+                      "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.5.7.tgz",
+                      "integrity": "sha1-uTaKWTzG730GReeLL0xky+zQXpA=",
+                      "dev": true,
+                      "requires": {
+                        "media-typer": "0.3.0",
+                        "mime-types": "2.0.14"
+                      },
+                      "dependencies": {
+                        "mime-types": {
+                          "version": "2.0.14",
+                          "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/mime-types/-/mime-types-2.0.14.tgz",
+                          "integrity": "sha1-MQ4VnbI+B3+Lsit0jav6SVcUCqY=",
+                          "dev": true,
+                          "requires": {
+                            "mime-db": "1.12.0"
+                          },
+                          "dependencies": {
+                            "mime-db": {
+                              "version": "1.12.0",
+                              "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/mime-db/-/mime-db-1.12.0.tgz",
+                              "integrity": "sha1-PQxjGA9FjrENMlqqN9fFiuMS6dc=",
+                              "dev": true
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                },
+                "debug": {
+                  "version": "2.0.0",
+                  "resolved": "https://registry.npmjs.org/debug/-/debug-2.0.0.tgz",
+                  "integrity": "sha1-ib2d9nMrUSVrxnBTQrugLtEhMe8=",
+                  "dev": true,
+                  "requires": {
+                    "ms": "0.6.2"
+                  },
+                  "dependencies": {
+                    "ms": {
+                      "version": "0.6.2",
+                      "resolved": "https://registry.npmjs.org/ms/-/ms-0.6.2.tgz",
+                      "integrity": "sha1-2JwhJMb9wTU9Zai3e/GqxLGTcIw=",
+                      "dev": true
+                    }
+                  }
+                },
+                "faye-websocket": {
+                  "version": "0.7.3",
+                  "resolved": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.7.3.tgz",
+                  "integrity": "sha1-zEB0x/Sk39A69U3WXDVLE1EyzhE=",
+                  "dev": true,
+                  "requires": {
+                    "websocket-driver": "0.6.5"
+                  },
+                  "dependencies": {
+                    "websocket-driver": {
+                      "version": "0.6.5",
+                      "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/websocket-driver/-/websocket-driver-0.6.5.tgz",
+                      "integrity": "sha1-XLJVbOuF9Dc8bYI4qmkchFThOjY=",
+                      "dev": true,
+                      "requires": {
+                        "websocket-extensions": "0.1.1"
+                      },
+                      "dependencies": {
+                        "websocket-extensions": {
+                          "version": "0.1.1",
+                          "resolved": "https://registry.npmjs.org/websocket-extensions/-/websocket-extensions-0.1.1.tgz",
+                          "integrity": "sha1-domUmcGEtu91Q3fC27DNbLVdKec=",
+                          "dev": true
+                        }
+                      }
+                    }
+                  }
+                },
+                "livereload-js": {
+                  "version": "2.2.2",
+                  "resolved": "https://registry.npmjs.org/livereload-js/-/livereload-js-2.2.2.tgz",
+                  "integrity": "sha1-bIclfmSKtHW8JOoldFftzB+NC8I=",
+                  "dev": true
+                },
+                "parseurl": {
+                  "version": "1.3.1",
+                  "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/parseurl/-/parseurl-1.3.1.tgz",
+                  "integrity": "sha1-yKuMkiO6NIiKpkopeyiFO+wY2lY=",
+                  "dev": true
+                },
+                "qs": {
+                  "version": "2.2.5",
+                  "resolved": "https://registry.npmjs.org/qs/-/qs-2.2.5.tgz",
+                  "integrity": "sha1-EIirr53MCuWuRbcJ5sa1iIsjkjw=",
+                  "dev": true
+                }
+              }
+            },
+            "unyield": {
+              "version": "0.0.1",
+              "resolved": "https://registry.npmjs.org/unyield/-/unyield-0.0.1.tgz",
+              "integrity": "sha1-FQ5l2kK/d0JEW5WKZOubhdHSsYA=",
+              "dev": true,
+              "requires": {
+                "co": "3.1.0"
+              },
+              "dependencies": {
+                "co": {
+                  "version": "3.1.0",
+                  "resolved": "https://registry.npmjs.org/co/-/co-3.1.0.tgz",
+                  "integrity": "sha1-TqVOpaCJOBUxheFSEMaNkJK8G3g=",
+                  "dev": true
+                }
+              }
+            }
+          }
+        },
+        "minimatch": {
+          "version": "3.0.3",
+          "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/minimatch/-/minimatch-3.0.3.tgz",
+          "integrity": "sha1-Kk5AkLlrLbBqnX3wEFWmKnfJt3Q=",
+          "dev": true,
+          "requires": {
+            "brace-expansion": "1.1.6"
+          },
+          "dependencies": {
+            "brace-expansion": {
+              "version": "1.1.6",
+              "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/brace-expansion/-/brace-expansion-1.1.6.tgz",
+              "integrity": "sha1-cZfX6qm4fmSDkOph/GbIRCdCDfk=",
+              "dev": true,
+              "requires": {
+                "balanced-match": "0.4.2",
+                "concat-map": "0.0.1"
+              },
+              "dependencies": {
+                "balanced-match": {
+                  "version": "0.4.2",
+                  "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/balanced-match/-/balanced-match-0.4.2.tgz",
+                  "integrity": "sha1-yz8+PHMtwPAe5wtAPzAuYddwmDg=",
+                  "dev": true
+                },
+                "concat-map": {
+                  "version": "0.0.1",
+                  "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+                  "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+                  "dev": true
+                }
+              }
+            }
+          }
+        },
+        "moment": {
+          "version": "2.15.1",
+          "resolved": "https://registry.npmjs.org/moment/-/moment-2.15.1.tgz",
+          "integrity": "sha1-6XnCop4iiI5g85byIgphGPhc2Uw=",
+          "dev": true
+        },
+        "node-uuid": {
+          "version": "1.4.7",
+          "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/node-uuid/-/node-uuid-1.4.7.tgz",
+          "integrity": "sha1-baWhdmjEs91ZYjvaEc9/pMH2Cm8=",
+          "dev": true
+        },
+        "request": {
+          "version": "2.75.0",
+          "resolved": "https://registry.npmjs.org/request/-/request-2.75.0.tgz",
+          "integrity": "sha1-0rgmiihtoT6qXQGt9dGMyQ9lfZM=",
+          "dev": true,
+          "requires": {
+            "aws-sign2": "0.6.0",
+            "aws4": "1.4.1",
+            "bl": "1.1.2",
+            "caseless": "0.11.0",
+            "combined-stream": "1.0.5",
+            "extend": "3.0.0",
+            "forever-agent": "0.6.1",
+            "form-data": "2.0.0",
+            "har-validator": "2.0.6",
+            "hawk": "3.1.3",
+            "http-signature": "1.1.1",
+            "is-typedarray": "1.0.0",
+            "isstream": "0.1.2",
+            "json-stringify-safe": "5.0.1",
+            "mime-types": "2.1.12",
+            "node-uuid": "1.4.7",
+            "oauth-sign": "0.8.2",
+            "qs": "6.2.1",
+            "stringstream": "0.0.5",
+            "tough-cookie": "2.3.1",
+            "tunnel-agent": "0.4.3"
+          },
+          "dependencies": {
+            "aws-sign2": {
+              "version": "0.6.0",
+              "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/aws-sign2/-/aws-sign2-0.6.0.tgz",
+              "integrity": "sha1-FDQt0428yU0OW4fXY81jYSwOeU8=",
+              "dev": true
+            },
+            "aws4": {
+              "version": "1.4.1",
+              "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/aws4/-/aws4-1.4.1.tgz",
+              "integrity": "sha1-/efVKSRm0jDl7g9OA42d+qsI/GE=",
+              "dev": true
+            },
+            "bl": {
+              "version": "1.1.2",
+              "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/bl/-/bl-1.1.2.tgz",
+              "integrity": "sha1-/cqHGplxOqANGeO7ukHER4emU5g=",
+              "dev": true,
+              "requires": {
+                "readable-stream": "2.0.6"
+              },
+              "dependencies": {
+                "readable-stream": {
+                  "version": "2.0.6",
+                  "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/readable-stream/-/readable-stream-2.0.6.tgz",
+                  "integrity": "sha1-j5A0HmilPMySh4jaz80Rs265t44=",
+                  "dev": true,
+                  "requires": {
+                    "core-util-is": "1.0.2",
+                    "inherits": "2.0.3",
+                    "isarray": "1.0.0",
+                    "process-nextick-args": "1.0.7",
+                    "string_decoder": "0.10.31",
+                    "util-deprecate": "1.0.2"
+                  },
+                  "dependencies": {
+                    "core-util-is": {
+                      "version": "1.0.2",
+                      "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/core-util-is/-/core-util-is-1.0.2.tgz",
+                      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
+                      "dev": true
+                    },
+                    "inherits": {
+                      "version": "2.0.3",
+                      "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/inherits/-/inherits-2.0.3.tgz",
+                      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+                      "dev": true
+                    },
+                    "isarray": {
+                      "version": "1.0.0",
+                      "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/isarray/-/isarray-1.0.0.tgz",
+                      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+                      "dev": true
+                    },
+                    "process-nextick-args": {
+                      "version": "1.0.7",
+                      "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
+                      "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M=",
+                      "dev": true
+                    },
+                    "string_decoder": {
+                      "version": "0.10.31",
+                      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+                      "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
+                      "dev": true
+                    },
+                    "util-deprecate": {
+                      "version": "1.0.2",
+                      "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/util-deprecate/-/util-deprecate-1.0.2.tgz",
+                      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
+                      "dev": true
+                    }
+                  }
+                }
+              }
+            },
+            "caseless": {
+              "version": "0.11.0",
+              "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/caseless/-/caseless-0.11.0.tgz",
+              "integrity": "sha1-cVuW6phBWTzDMGeSP17GDr2k99c=",
+              "dev": true
+            },
+            "combined-stream": {
+              "version": "1.0.5",
+              "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/combined-stream/-/combined-stream-1.0.5.tgz",
+              "integrity": "sha1-k4NwpXtKUd6ix3wV1cX9+JUWQAk=",
+              "dev": true,
+              "requires": {
+                "delayed-stream": "1.0.0"
+              },
+              "dependencies": {
+                "delayed-stream": {
+                  "version": "1.0.0",
+                  "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/delayed-stream/-/delayed-stream-1.0.0.tgz",
+                  "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
+                  "dev": true
+                }
+              }
+            },
+            "extend": {
+              "version": "3.0.0",
+              "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/extend/-/extend-3.0.0.tgz",
+              "integrity": "sha1-WkdDU7nzNT3dgXbf03uRyDpG8dQ=",
+              "dev": true
+            },
+            "forever-agent": {
+              "version": "0.6.1",
+              "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
+              "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=",
+              "dev": true
+            },
+            "form-data": {
+              "version": "2.0.0",
+              "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.0.0.tgz",
+              "integrity": "sha1-bwrrrcxdoWwT4ezBETfYX5uIOyU=",
+              "dev": true,
+              "requires": {
+                "asynckit": "0.4.0",
+                "combined-stream": "1.0.5",
+                "mime-types": "2.1.12"
+              },
+              "dependencies": {
+                "asynckit": {
+                  "version": "0.4.0",
+                  "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+                  "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
+                  "dev": true
+                }
+              }
+            },
+            "har-validator": {
+              "version": "2.0.6",
+              "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/har-validator/-/har-validator-2.0.6.tgz",
+              "integrity": "sha1-zcvAgYgmWtEZtqWnyKtw7s+10n0=",
+              "dev": true,
+              "requires": {
+                "chalk": "1.1.3",
+                "commander": "2.9.0",
+                "is-my-json-valid": "2.15.0",
+                "pinkie-promise": "2.0.1"
+              },
+              "dependencies": {
+                "chalk": {
+                  "version": "1.1.3",
+                  "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/chalk/-/chalk-1.1.3.tgz",
+                  "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+                  "dev": true,
+                  "requires": {
+                    "ansi-styles": "2.2.1",
+                    "escape-string-regexp": "1.0.5",
+                    "has-ansi": "2.0.0",
+                    "strip-ansi": "3.0.1",
+                    "supports-color": "2.0.0"
+                  },
+                  "dependencies": {
+                    "ansi-styles": {
+                      "version": "2.2.1",
+                      "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/ansi-styles/-/ansi-styles-2.2.1.tgz",
+                      "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+                      "dev": true
+                    },
+                    "escape-string-regexp": {
+                      "version": "1.0.5",
+                      "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+                      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+                      "dev": true
+                    },
+                    "has-ansi": {
+                      "version": "2.0.0",
+                      "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/has-ansi/-/has-ansi-2.0.0.tgz",
+                      "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
+                      "dev": true,
+                      "requires": {
+                        "ansi-regex": "2.0.0"
+                      },
+                      "dependencies": {
+                        "ansi-regex": {
+                          "version": "2.0.0",
+                          "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/ansi-regex/-/ansi-regex-2.0.0.tgz",
+                          "integrity": "sha1-xQYbbg74qBd15Q9dZhUb9r83EQc=",
+                          "dev": true
+                        }
+                      }
+                    },
+                    "strip-ansi": {
+                      "version": "3.0.1",
+                      "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/strip-ansi/-/strip-ansi-3.0.1.tgz",
+                      "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+                      "dev": true,
+                      "requires": {
+                        "ansi-regex": "2.0.0"
+                      },
+                      "dependencies": {
+                        "ansi-regex": {
+                          "version": "2.0.0",
+                          "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/ansi-regex/-/ansi-regex-2.0.0.tgz",
+                          "integrity": "sha1-xQYbbg74qBd15Q9dZhUb9r83EQc=",
+                          "dev": true
+                        }
+                      }
+                    },
+                    "supports-color": {
+                      "version": "2.0.0",
+                      "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/supports-color/-/supports-color-2.0.0.tgz",
+                      "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+                      "dev": true
+                    }
+                  }
+                },
+                "commander": {
+                  "version": "2.9.0",
+                  "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
+                  "integrity": "sha1-nJkJQXbhIkDLItbFFGCYQA/g99Q=",
+                  "dev": true,
+                  "requires": {
+                    "graceful-readlink": "1.0.1"
+                  },
+                  "dependencies": {
+                    "graceful-readlink": {
+                      "version": "1.0.1",
+                      "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz",
+                      "integrity": "sha1-TK+tdrxi8C+gObL5Tpo906ORpyU=",
+                      "dev": true
+                    }
+                  }
+                },
+                "is-my-json-valid": {
+                  "version": "2.15.0",
+                  "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.15.0.tgz",
+                  "integrity": "sha1-k27do8o8IR/ZjzstPgjaQ/eykVs=",
+                  "dev": true,
+                  "requires": {
+                    "generate-function": "2.0.0",
+                    "generate-object-property": "1.2.0",
+                    "jsonpointer": "4.0.0",
+                    "xtend": "4.0.1"
+                  },
+                  "dependencies": {
+                    "generate-function": {
+                      "version": "2.0.0",
+                      "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz",
+                      "integrity": "sha1-aFj+fAlpt9TpCTM3ZHrHn2DfvnQ=",
+                      "dev": true
+                    },
+                    "generate-object-property": {
+                      "version": "1.2.0",
+                      "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
+                      "integrity": "sha1-nA4cQDCM6AT0eDYYuTf6iPmdUNA=",
+                      "dev": true,
+                      "requires": {
+                        "is-property": "1.0.2"
+                      },
+                      "dependencies": {
+                        "is-property": {
+                          "version": "1.0.2",
+                          "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
+                          "integrity": "sha1-V/4cTkhHTt1lsJkR8msc1Ald2oQ=",
+                          "dev": true
+                        }
+                      }
+                    },
+                    "jsonpointer": {
+                      "version": "4.0.0",
+                      "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-4.0.0.tgz",
+                      "integrity": "sha1-ZmHhYdL8RF8Z+YQwIxNDci4fy9U=",
+                      "dev": true
+                    },
+                    "xtend": {
+                      "version": "4.0.1",
+                      "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/xtend/-/xtend-4.0.1.tgz",
+                      "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68=",
+                      "dev": true
+                    }
+                  }
+                },
+                "pinkie-promise": {
+                  "version": "2.0.1",
+                  "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
+                  "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
+                  "dev": true,
+                  "requires": {
+                    "pinkie": "2.0.4"
+                  },
+                  "dependencies": {
+                    "pinkie": {
+                      "version": "2.0.4",
+                      "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/pinkie/-/pinkie-2.0.4.tgz",
+                      "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA=",
+                      "dev": true
+                    }
+                  }
+                }
+              }
+            },
+            "hawk": {
+              "version": "3.1.3",
+              "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/hawk/-/hawk-3.1.3.tgz",
+              "integrity": "sha1-B4REvXwWQLD+VA0sm3PVlnjo4cQ=",
+              "dev": true,
+              "requires": {
+                "boom": "2.10.1",
+                "cryptiles": "2.0.5",
+                "hoek": "2.16.3",
+                "sntp": "1.0.9"
+              },
+              "dependencies": {
+                "boom": {
+                  "version": "2.10.1",
+                  "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/boom/-/boom-2.10.1.tgz",
+                  "integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
+                  "dev": true,
+                  "requires": {
+                    "hoek": "2.16.3"
+                  }
+                },
+                "cryptiles": {
+                  "version": "2.0.5",
+                  "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/cryptiles/-/cryptiles-2.0.5.tgz",
+                  "integrity": "sha1-O9/s3GCBR8HGcgL6KR59ylnqo7g=",
+                  "dev": true,
+                  "requires": {
+                    "boom": "2.10.1"
+                  }
+                },
+                "hoek": {
+                  "version": "2.16.3",
+                  "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/hoek/-/hoek-2.16.3.tgz",
+                  "integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0=",
+                  "dev": true
+                },
+                "sntp": {
+                  "version": "1.0.9",
+                  "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
+                  "integrity": "sha1-ZUEYTMkK7qbG57NeJlkIJEPGYZg=",
+                  "dev": true,
+                  "requires": {
+                    "hoek": "2.16.3"
+                  }
+                }
+              }
+            },
+            "http-signature": {
+              "version": "1.1.1",
+              "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/http-signature/-/http-signature-1.1.1.tgz",
+              "integrity": "sha1-33LiZwZs0Kxn+3at+OE0qPvPkb8=",
+              "dev": true,
+              "requires": {
+                "assert-plus": "0.2.0",
+                "jsprim": "1.3.1",
+                "sshpk": "1.10.1"
+              },
+              "dependencies": {
+                "assert-plus": {
+                  "version": "0.2.0",
+                  "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/assert-plus/-/assert-plus-0.2.0.tgz",
+                  "integrity": "sha1-104bh+ev/A24qttwIfP+SBAasjQ=",
+                  "dev": true
+                },
+                "jsprim": {
+                  "version": "1.3.1",
+                  "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.3.1.tgz",
+                  "integrity": "sha1-KnJW9wQSop7jZwqspiWZTE3P8lI=",
+                  "dev": true,
+                  "requires": {
+                    "extsprintf": "1.0.2",
+                    "json-schema": "0.2.3",
+                    "verror": "1.3.6"
+                  },
+                  "dependencies": {
+                    "extsprintf": {
+                      "version": "1.0.2",
+                      "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/extsprintf/-/extsprintf-1.0.2.tgz",
+                      "integrity": "sha1-4QgOBljjALBilJkMxw4VAiNf1VA=",
+                      "dev": true
+                    },
+                    "json-schema": {
+                      "version": "0.2.3",
+                      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
+                      "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=",
+                      "dev": true
+                    },
+                    "verror": {
+                      "version": "1.3.6",
+                      "resolved": "https://registry.npmjs.org/verror/-/verror-1.3.6.tgz",
+                      "integrity": "sha1-z/XfEpRtKX0rqu+qJoniW+AcAFw=",
+                      "dev": true,
+                      "requires": {
+                        "extsprintf": "1.0.2"
+                      }
+                    }
+                  }
+                },
+                "sshpk": {
+                  "version": "1.10.1",
+                  "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.10.1.tgz",
+                  "integrity": "sha1-MOGl0ykkSXShr2FREznVla9mOLA=",
+                  "dev": true,
+                  "requires": {
+                    "asn1": "0.2.3",
+                    "assert-plus": "1.0.0",
+                    "bcrypt-pbkdf": "1.0.0",
+                    "dashdash": "1.14.0",
+                    "ecc-jsbn": "0.1.1",
+                    "getpass": "0.1.6",
+                    "jodid25519": "1.0.2",
+                    "jsbn": "0.1.0",
+                    "tweetnacl": "0.14.3"
+                  },
+                  "dependencies": {
+                    "asn1": {
+                      "version": "0.2.3",
+                      "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/asn1/-/asn1-0.2.3.tgz",
+                      "integrity": "sha1-2sh4dxPJlmhJ/IGAd36+nB3fO4Y=",
+                      "dev": true
+                    },
+                    "assert-plus": {
+                      "version": "1.0.0",
+                      "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/assert-plus/-/assert-plus-1.0.0.tgz",
+                      "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
+                      "dev": true
+                    },
+                    "bcrypt-pbkdf": {
+                      "version": "1.0.0",
+                      "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.0.tgz",
+                      "integrity": "sha1-PKdrhSQccXC/fZcD57mqdGMAQNQ=",
+                      "dev": true,
+                      "optional": true,
+                      "requires": {
+                        "tweetnacl": "0.14.3"
+                      }
+                    },
+                    "dashdash": {
+                      "version": "1.14.0",
+                      "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/dashdash/-/dashdash-1.14.0.tgz",
+                      "integrity": "sha1-KeSGxUGL8PNWA0qZPVFoajPoQUE=",
+                      "dev": true,
+                      "requires": {
+                        "assert-plus": "1.0.0"
+                      }
+                    },
+                    "ecc-jsbn": {
+                      "version": "0.1.1",
+                      "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
+                      "integrity": "sha1-D8c6ntXw1Tw4GTOYUj735UN3dQU=",
+                      "dev": true,
+                      "optional": true,
+                      "requires": {
+                        "jsbn": "0.1.0"
+                      }
+                    },
+                    "getpass": {
+                      "version": "0.1.6",
+                      "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/getpass/-/getpass-0.1.6.tgz",
+                      "integrity": "sha1-KD/9n8ElaECHUxHBtg6MQBhxEOY=",
+                      "dev": true,
+                      "requires": {
+                        "assert-plus": "1.0.0"
+                      }
+                    },
+                    "jodid25519": {
+                      "version": "1.0.2",
+                      "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/jodid25519/-/jodid25519-1.0.2.tgz",
+                      "integrity": "sha1-BtSRIlUJNBlHfUJWM2BuDpB4KWc=",
+                      "dev": true,
+                      "optional": true,
+                      "requires": {
+                        "jsbn": "0.1.0"
+                      }
+                    },
+                    "jsbn": {
+                      "version": "0.1.0",
+                      "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/jsbn/-/jsbn-0.1.0.tgz",
+                      "integrity": "sha1-ZQmH2g3XT06/WhE3eiqi0nPpff0=",
+                      "dev": true,
+                      "optional": true
+                    },
+                    "tweetnacl": {
+                      "version": "0.14.3",
+                      "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/tweetnacl/-/tweetnacl-0.14.3.tgz",
+                      "integrity": "sha1-PaOC9nDyXe1417PReSEZvKC3Ey0=",
+                      "dev": true,
+                      "optional": true
+                    }
+                  }
+                }
+              }
+            },
+            "is-typedarray": {
+              "version": "1.0.0",
+              "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/is-typedarray/-/is-typedarray-1.0.0.tgz",
+              "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
+              "dev": true
+            },
+            "isstream": {
+              "version": "0.1.2",
+              "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
+              "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
+              "dev": true
+            },
+            "json-stringify-safe": {
+              "version": "5.0.1",
+              "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+              "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
+              "dev": true
+            },
+            "mime-types": {
+              "version": "2.1.12",
+              "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.12.tgz",
+              "integrity": "sha1-FSuiVndwIN1GY/VMLnvCY4HnFyk=",
+              "dev": true,
+              "requires": {
+                "mime-db": "1.24.0"
+              },
+              "dependencies": {
+                "mime-db": {
+                  "version": "1.24.0",
+                  "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.24.0.tgz",
+                  "integrity": "sha1-4tE/k58AFsbk6a0lqGUvEmxGfww=",
+                  "dev": true
+                }
+              }
+            },
+            "oauth-sign": {
+              "version": "0.8.2",
+              "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/oauth-sign/-/oauth-sign-0.8.2.tgz",
+              "integrity": "sha1-Rqarfwrq2N6unsBWV4C31O/rnUM=",
+              "dev": true
+            },
+            "qs": {
+              "version": "6.2.1",
+              "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/qs/-/qs-6.2.1.tgz",
+              "integrity": "sha1-zgPF/wk1vB2daanxTL0Y5WjWdiU=",
+              "dev": true
+            },
+            "stringstream": {
+              "version": "0.0.5",
+              "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/stringstream/-/stringstream-0.0.5.tgz",
+              "integrity": "sha1-TkhM1N5aC7vuGORjB3EKioFiGHg=",
+              "dev": true
+            },
+            "tough-cookie": {
+              "version": "2.3.1",
+              "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/tough-cookie/-/tough-cookie-2.3.1.tgz",
+              "integrity": "sha1-mcd9+7fYBCSeiimdTLD9gf7wg/0=",
+              "dev": true
+            },
+            "tunnel-agent": {
+              "version": "0.4.3",
+              "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/tunnel-agent/-/tunnel-agent-0.4.3.tgz",
+              "integrity": "sha1-Y3PbdpCf5XDgjXNYM2Xtgop07us=",
+              "dev": true
+            }
+          }
+        }
+      }
+    },
+    "fs-extra": {
+      "version": "0.30.0",
+      "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/fs-extra/-/fs-extra-0.30.0.tgz",
+      "integrity": "sha1-8jP/zAjU2n1DLapEl3aYnbHfk/A=",
+      "requires": {
+        "graceful-fs": "4.1.9",
+        "jsonfile": "2.4.0",
+        "klaw": "1.3.0",
+        "path-is-absolute": "1.0.1",
+        "rimraf": "2.5.4"
+      },
+      "dependencies": {
+        "graceful-fs": {
+          "version": "4.1.9",
+          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.9.tgz",
+          "integrity": "sha1-uqy6N9GdEfnRRtNXi8mZWMN4fik="
+        },
+        "jsonfile": {
+          "version": "2.4.0",
+          "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-2.4.0.tgz",
+          "integrity": "sha1-NzaitCi4e72gzIO1P6PWM6NcKug=",
+          "requires": {
+            "graceful-fs": "4.1.9"
+          }
+        },
+        "klaw": {
+          "version": "1.3.0",
+          "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/klaw/-/klaw-1.3.0.tgz",
+          "integrity": "sha1-iFe/vB2CS63xPT0CQdi75G+xL3M="
+        },
+        "path-is-absolute": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+          "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
+        },
+        "rimraf": {
+          "version": "2.5.4",
+          "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/rimraf/-/rimraf-2.5.4.tgz",
+          "integrity": "sha1-loAAk8vxoMhr2VtGJUZ1NcKd+gQ=",
+          "requires": {
+            "glob": "7.1.0"
+          }
+        }
+      }
+    },
+    "glob": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.0.tgz",
+      "integrity": "sha1-Nq3YVtdG0NmeTMJ5e7oa4sZycv0=",
+      "requires": {
+        "fs.realpath": "1.0.0",
+        "inflight": "1.0.5",
+        "inherits": "2.0.3",
+        "minimatch": "3.0.3",
+        "once": "1.4.0",
+        "path-is-absolute": "1.0.1"
+      },
+      "dependencies": {
+        "fs.realpath": {
+          "version": "1.0.0",
+          "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/fs.realpath/-/fs.realpath-1.0.0.tgz",
+          "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
+        },
+        "inflight": {
+          "version": "1.0.5",
+          "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/inflight/-/inflight-1.0.5.tgz",
+          "integrity": "sha1-2zIEzVqd4ubNiQuFxuL2a89PYgo=",
+          "requires": {
+            "once": "1.4.0",
+            "wrappy": "1.0.2"
+          },
+          "dependencies": {
+            "wrappy": {
+              "version": "1.0.2",
+              "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/wrappy/-/wrappy-1.0.2.tgz",
+              "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+            }
+          }
+        },
+        "inherits": {
+          "version": "2.0.3",
+          "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/inherits/-/inherits-2.0.3.tgz",
+          "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
+        },
+        "minimatch": {
+          "version": "3.0.3",
+          "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/minimatch/-/minimatch-3.0.3.tgz",
+          "integrity": "sha1-Kk5AkLlrLbBqnX3wEFWmKnfJt3Q=",
+          "requires": {
+            "brace-expansion": "1.1.6"
+          },
+          "dependencies": {
+            "brace-expansion": {
+              "version": "1.1.6",
+              "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/brace-expansion/-/brace-expansion-1.1.6.tgz",
+              "integrity": "sha1-cZfX6qm4fmSDkOph/GbIRCdCDfk=",
+              "requires": {
+                "balanced-match": "0.4.2",
+                "concat-map": "0.0.1"
+              },
+              "dependencies": {
+                "balanced-match": {
+                  "version": "0.4.2",
+                  "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/balanced-match/-/balanced-match-0.4.2.tgz",
+                  "integrity": "sha1-yz8+PHMtwPAe5wtAPzAuYddwmDg="
+                },
+                "concat-map": {
+                  "version": "0.0.1",
+                  "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+                  "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+                }
+              }
+            }
+          }
+        },
+        "once": {
+          "version": "1.4.0",
+          "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/once/-/once-1.4.0.tgz",
+          "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+          "requires": {
+            "wrappy": "1.0.2"
+          },
+          "dependencies": {
+            "wrappy": {
+              "version": "1.0.2",
+              "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/wrappy/-/wrappy-1.0.2.tgz",
+              "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+            }
+          }
+        },
+        "path-is-absolute": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+          "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
+        }
+      }
+    },
+    "grunt": {
+      "version": "0.4.5",
+      "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/grunt/-/grunt-0.4.5.tgz",
+      "integrity": "sha1-VpN81RlDJK3/bSB2MYMqnWuk5/A=",
+      "dev": true,
+      "requires": {
+        "async": "0.1.22",
+        "coffee-script": "1.3.3",
+        "colors": "0.6.2",
+        "dateformat": "1.0.2-1.2.3",
+        "eventemitter2": "0.4.14",
+        "exit": "0.1.2",
+        "findup-sync": "0.1.3",
+        "getobject": "0.1.0",
+        "glob": "3.1.21",
+        "grunt-legacy-log": "0.1.3",
+        "grunt-legacy-util": "0.2.0",
+        "hooker": "0.2.3",
+        "iconv-lite": "0.2.11",
+        "js-yaml": "2.0.5",
+        "lodash": "0.9.2",
+        "minimatch": "0.2.14",
+        "nopt": "1.0.10",
+        "rimraf": "2.2.8",
+        "underscore.string": "2.2.1",
+        "which": "1.0.9"
+      },
+      "dependencies": {
+        "async": {
+          "version": "0.1.22",
+          "resolved": "https://registry.npmjs.org/async/-/async-0.1.22.tgz",
+          "integrity": "sha1-D8GqoIig4+8Ovi2IMbqw3PiEUGE=",
+          "dev": true
+        },
+        "coffee-script": {
+          "version": "1.3.3",
+          "resolved": "https://registry.npmjs.org/coffee-script/-/coffee-script-1.3.3.tgz",
+          "integrity": "sha1-FQ1rTLUiiUNp7+1qIQHCC8f0pPQ=",
+          "dev": true
+        },
+        "colors": {
+          "version": "0.6.2",
+          "resolved": "https://registry.npmjs.org/colors/-/colors-0.6.2.tgz",
+          "integrity": "sha1-JCP+ZnisDF2uiFLl0OW+CMmXq8w=",
+          "dev": true
+        },
+        "dateformat": {
+          "version": "1.0.2-1.2.3",
+          "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-1.0.2-1.2.3.tgz",
+          "integrity": "sha1-sCIMAt6YYXQztyhRz0fePfLNvuk=",
+          "dev": true
+        },
+        "eventemitter2": {
+          "version": "0.4.14",
+          "resolved": "https://registry.npmjs.org/eventemitter2/-/eventemitter2-0.4.14.tgz",
+          "integrity": "sha1-j2G3XN4BKy6esoTUVFWDtWQ7Yas=",
+          "dev": true
+        },
+        "exit": {
+          "version": "0.1.2",
+          "resolved": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz",
+          "integrity": "sha1-BjJjj42HfMghB9MKD/8aF8uhzQw=",
+          "dev": true
+        },
+        "findup-sync": {
+          "version": "0.1.3",
+          "resolved": "https://registry.npmjs.org/findup-sync/-/findup-sync-0.1.3.tgz",
+          "integrity": "sha1-fz56l7gjksZTvwZYm9hRkOk8NoM=",
+          "dev": true,
+          "requires": {
+            "glob": "3.2.11",
+            "lodash": "2.4.2"
+          },
+          "dependencies": {
+            "glob": {
+              "version": "3.2.11",
+              "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
+              "integrity": "sha1-Spc/Y1uRkPcV0QmH1cAP0oFevj0=",
+              "dev": true,
+              "requires": {
+                "inherits": "2.0.3",
+                "minimatch": "0.3.0"
+              },
+              "dependencies": {
+                "inherits": {
+                  "version": "2.0.3",
+                  "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/inherits/-/inherits-2.0.3.tgz",
+                  "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+                  "dev": true
+                },
+                "minimatch": {
+                  "version": "0.3.0",
+                  "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
+                  "integrity": "sha1-J12O2qxPG7MyZHIInnlJyDlGmd0=",
+                  "dev": true,
+                  "requires": {
+                    "lru-cache": "2.7.3",
+                    "sigmund": "1.0.1"
+                  },
+                  "dependencies": {
+                    "lru-cache": {
+                      "version": "2.7.3",
+                      "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/lru-cache/-/lru-cache-2.7.3.tgz",
+                      "integrity": "sha1-bUUk6LlV+V1PW1iFHOId1y+06VI=",
+                      "dev": true
+                    },
+                    "sigmund": {
+                      "version": "1.0.1",
+                      "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz",
+                      "integrity": "sha1-P/IfGYytIXX587eBhT/ZTQ0ZtZA=",
+                      "dev": true
+                    }
+                  }
+                }
+              }
+            },
+            "lodash": {
+              "version": "2.4.2",
+              "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz",
+              "integrity": "sha1-+t2DS5aDBz2hebPq5tnA0VBT9z4=",
+              "dev": true
+            }
+          }
+        },
+        "getobject": {
+          "version": "0.1.0",
+          "resolved": "https://registry.npmjs.org/getobject/-/getobject-0.1.0.tgz",
+          "integrity": "sha1-BHpEl4n6Fg0Bj1SG7ZEyC27HiFw=",
+          "dev": true
+        },
+        "glob": {
+          "version": "3.1.21",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-3.1.21.tgz",
+          "integrity": "sha1-0p4KBV3qUTj00H7UDomC6DwgZs0=",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "1.2.3",
+            "inherits": "1.0.2",
+            "minimatch": "0.2.14"
+          },
+          "dependencies": {
+            "graceful-fs": {
+              "version": "1.2.3",
+              "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-1.2.3.tgz",
+              "integrity": "sha1-FaSAaldUfLLS2/J/QuiajDRRs2Q=",
+              "dev": true
+            },
+            "inherits": {
+              "version": "1.0.2",
+              "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/inherits/-/inherits-1.0.2.tgz",
+              "integrity": "sha1-ykMJ2t7mtUzAuNJH6NfHoJdb3Js=",
+              "dev": true
+            }
+          }
+        },
+        "grunt-legacy-log": {
+          "version": "0.1.3",
+          "resolved": "https://registry.npmjs.org/grunt-legacy-log/-/grunt-legacy-log-0.1.3.tgz",
+          "integrity": "sha1-7ClCboAwIa9ZAp+H0vnNczWgVTE=",
+          "dev": true,
+          "requires": {
+            "colors": "0.6.2",
+            "grunt-legacy-log-utils": "0.1.1",
+            "hooker": "0.2.3",
+            "lodash": "2.4.2",
+            "underscore.string": "2.3.3"
+          },
+          "dependencies": {
+            "grunt-legacy-log-utils": {
+              "version": "0.1.1",
+              "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/grunt-legacy-log-utils/-/grunt-legacy-log-utils-0.1.1.tgz",
+              "integrity": "sha1-wHBrndkGThFvNvI/5OawSGcsD34=",
+              "dev": true,
+              "requires": {
+                "colors": "0.6.2",
+                "lodash": "2.4.2",
+                "underscore.string": "2.3.3"
+              }
+            },
+            "lodash": {
+              "version": "2.4.2",
+              "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz",
+              "integrity": "sha1-+t2DS5aDBz2hebPq5tnA0VBT9z4=",
+              "dev": true
+            },
+            "underscore.string": {
+              "version": "2.3.3",
+              "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/underscore.string/-/underscore.string-2.3.3.tgz",
+              "integrity": "sha1-ccCL9rQosRM/N+ePo6Icgvcymw0=",
+              "dev": true
+            }
+          }
+        },
+        "grunt-legacy-util": {
+          "version": "0.2.0",
+          "resolved": "https://registry.npmjs.org/grunt-legacy-util/-/grunt-legacy-util-0.2.0.tgz",
+          "integrity": "sha1-kzJIhNv343qf98Am3/RR2UqeVUs=",
+          "dev": true,
+          "requires": {
+            "async": "0.1.22",
+            "exit": "0.1.2",
+            "getobject": "0.1.0",
+            "hooker": "0.2.3",
+            "lodash": "0.9.2",
+            "underscore.string": "2.2.1",
+            "which": "1.0.9"
+          }
+        },
+        "hooker": {
+          "version": "0.2.3",
+          "resolved": "https://registry.npmjs.org/hooker/-/hooker-0.2.3.tgz",
+          "integrity": "sha1-uDT3I8xKJCqmWWNFnfbZhMXT2Vk=",
+          "dev": true
+        },
+        "iconv-lite": {
+          "version": "0.2.11",
+          "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.2.11.tgz",
+          "integrity": "sha1-HOYKOleGSiktEyH/RgnKS7llrcg=",
+          "dev": true
+        },
+        "js-yaml": {
+          "version": "2.0.5",
+          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-2.0.5.tgz",
+          "integrity": "sha1-olrmUJmZ6X3yeMZxnaEb0Gh3Q6g=",
+          "dev": true,
+          "requires": {
+            "argparse": "0.1.16",
+            "esprima": "1.0.4"
+          },
+          "dependencies": {
+            "argparse": {
+              "version": "0.1.16",
+              "resolved": "https://registry.npmjs.org/argparse/-/argparse-0.1.16.tgz",
+              "integrity": "sha1-z9AeD7uj1srtBJ+9dY1A9lGW9Xw=",
+              "dev": true,
+              "requires": {
+                "underscore": "1.7.0",
+                "underscore.string": "2.4.0"
+              },
+              "dependencies": {
+                "underscore": {
+                  "version": "1.7.0",
+                  "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.7.0.tgz",
+                  "integrity": "sha1-a7rwh3UA02vjTsqlhODbn+8DUgk=",
+                  "dev": true
+                },
+                "underscore.string": {
+                  "version": "2.4.0",
+                  "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.4.0.tgz",
+                  "integrity": "sha1-jN2PusTi0uoefi6Al8QvRCKA+Fs=",
+                  "dev": true
+                }
+              }
+            },
+            "esprima": {
+              "version": "1.0.4",
+              "resolved": "https://registry.npmjs.org/esprima/-/esprima-1.0.4.tgz",
+              "integrity": "sha1-n1V+CPw7TSbs6d00+Pv0drYlha0=",
+              "dev": true
+            }
+          }
+        },
+        "lodash": {
+          "version": "0.9.2",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-0.9.2.tgz",
+          "integrity": "sha1-jzSZxSRdNG1oLlsNO0B2fgnxqSw=",
+          "dev": true
+        },
+        "minimatch": {
+          "version": "0.2.14",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
+          "integrity": "sha1-x054BXT2PG+aCQ6Q775u9TpqdWo=",
+          "dev": true,
+          "requires": {
+            "lru-cache": "2.7.3",
+            "sigmund": "1.0.1"
+          },
+          "dependencies": {
+            "lru-cache": {
+              "version": "2.7.3",
+              "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/lru-cache/-/lru-cache-2.7.3.tgz",
+              "integrity": "sha1-bUUk6LlV+V1PW1iFHOId1y+06VI=",
+              "dev": true
+            },
+            "sigmund": {
+              "version": "1.0.1",
+              "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz",
+              "integrity": "sha1-P/IfGYytIXX587eBhT/ZTQ0ZtZA=",
+              "dev": true
+            }
+          }
+        },
+        "nopt": {
+          "version": "1.0.10",
+          "resolved": "https://registry.npmjs.org/nopt/-/nopt-1.0.10.tgz",
+          "integrity": "sha1-bd0hvSoxQXuScn3Vhfim83YI6+4=",
+          "dev": true,
+          "requires": {
+            "abbrev": "1.0.9"
+          },
+          "dependencies": {
+            "abbrev": {
+              "version": "1.0.9",
+              "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/abbrev/-/abbrev-1.0.9.tgz",
+              "integrity": "sha1-kbR5JYinc4wl813W9jdSovh3YTU=",
+              "dev": true
+            }
+          }
+        },
+        "rimraf": {
+          "version": "2.2.8",
+          "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/rimraf/-/rimraf-2.2.8.tgz",
+          "integrity": "sha1-5Dm+Kq7jJzIZUnMPmaiSnk/FBYI=",
+          "dev": true
+        },
+        "underscore.string": {
+          "version": "2.2.1",
+          "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.2.1.tgz",
+          "integrity": "sha1-18D6KvXVoaZ/QlPa7pgTLnM/Dxk=",
+          "dev": true
+        },
+        "which": {
+          "version": "1.0.9",
+          "resolved": "https://registry.npmjs.org/which/-/which-1.0.9.tgz",
+          "integrity": "sha1-RgwdoPgQED0DIam2M6+eV15kSG8=",
+          "dev": true
+        }
+      }
+    },
+    "grunt-release": {
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/grunt-release/-/grunt-release-0.13.1.tgz",
+      "integrity": "sha1-zu5xyZuMykxMnQVNj5MyJpXpoEc=",
+      "dev": true,
+      "requires": {
+        "q": "1.4.1",
+        "semver": "4.3.6",
+        "shelljs": "0.5.3",
+        "superagent": "1.8.4"
+      },
+      "dependencies": {
+        "q": {
+          "version": "1.4.1",
+          "resolved": "https://registry.npmjs.org/q/-/q-1.4.1.tgz",
+          "integrity": "sha1-VXBbzZPF82c1MMLCy8DCs63cKG4=",
+          "dev": true
+        },
+        "semver": {
+          "version": "4.3.6",
+          "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/semver/-/semver-4.3.6.tgz",
+          "integrity": "sha1-MAvG4OhjdPe6YQaLWx7NV/xlMto=",
+          "dev": true
+        },
+        "shelljs": {
+          "version": "0.5.3",
+          "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.5.3.tgz",
+          "integrity": "sha1-xUmCuZbHbvDB5rWfvcWCX1txMRM=",
+          "dev": true
+        },
+        "superagent": {
+          "version": "1.8.4",
+          "resolved": "https://registry.npmjs.org/superagent/-/superagent-1.8.4.tgz",
+          "integrity": "sha1-aLLIpADxdT3bOUEJBomeQvQg/To=",
+          "dev": true,
+          "requires": {
+            "component-emitter": "1.2.1",
+            "cookiejar": "2.0.6",
+            "debug": "2.2.0",
+            "extend": "3.0.0",
+            "form-data": "1.0.0-rc3",
+            "formidable": "1.0.17",
+            "methods": "1.1.2",
+            "mime": "1.3.4",
+            "qs": "2.3.3",
+            "readable-stream": "1.0.27-1",
+            "reduce-component": "1.0.1"
+          },
+          "dependencies": {
+            "component-emitter": {
+              "version": "1.2.1",
+              "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.2.1.tgz",
+              "integrity": "sha1-E3kY1teCg/ffemt8WmPhQOaUJeY=",
+              "dev": true
+            },
+            "cookiejar": {
+              "version": "2.0.6",
+              "resolved": "https://registry.npmjs.org/cookiejar/-/cookiejar-2.0.6.tgz",
+              "integrity": "sha1-Cr81atANHFohnYjURRgEbdAmrP4=",
+              "dev": true
+            },
+            "extend": {
+              "version": "3.0.0",
+              "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/extend/-/extend-3.0.0.tgz",
+              "integrity": "sha1-WkdDU7nzNT3dgXbf03uRyDpG8dQ=",
+              "dev": true
+            },
+            "form-data": {
+              "version": "1.0.0-rc3",
+              "resolved": "https://registry.npmjs.org/form-data/-/form-data-1.0.0-rc3.tgz",
+              "integrity": "sha1-01vGLn+8KTeuePlIqqDTjZBgdXc=",
+              "dev": true,
+              "requires": {
+                "async": "1.5.2",
+                "combined-stream": "1.0.5",
+                "mime-types": "2.1.12"
+              },
+              "dependencies": {
+                "async": {
+                  "version": "1.5.2",
+                  "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/async/-/async-1.5.2.tgz",
+                  "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=",
+                  "dev": true
+                },
+                "combined-stream": {
+                  "version": "1.0.5",
+                  "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/combined-stream/-/combined-stream-1.0.5.tgz",
+                  "integrity": "sha1-k4NwpXtKUd6ix3wV1cX9+JUWQAk=",
+                  "dev": true,
+                  "requires": {
+                    "delayed-stream": "1.0.0"
+                  },
+                  "dependencies": {
+                    "delayed-stream": {
+                      "version": "1.0.0",
+                      "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/delayed-stream/-/delayed-stream-1.0.0.tgz",
+                      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
+                      "dev": true
+                    }
+                  }
+                },
+                "mime-types": {
+                  "version": "2.1.12",
+                  "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.12.tgz",
+                  "integrity": "sha1-FSuiVndwIN1GY/VMLnvCY4HnFyk=",
+                  "dev": true,
+                  "requires": {
+                    "mime-db": "1.24.0"
+                  },
+                  "dependencies": {
+                    "mime-db": {
+                      "version": "1.24.0",
+                      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.24.0.tgz",
+                      "integrity": "sha1-4tE/k58AFsbk6a0lqGUvEmxGfww=",
+                      "dev": true
+                    }
+                  }
+                }
+              }
+            },
+            "formidable": {
+              "version": "1.0.17",
+              "resolved": "https://registry.npmjs.org/formidable/-/formidable-1.0.17.tgz",
+              "integrity": "sha1-71SRSQ+UM7cF+qdyScmQKa40hVk=",
+              "dev": true
+            },
+            "methods": {
+              "version": "1.1.2",
+              "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/methods/-/methods-1.1.2.tgz",
+              "integrity": "sha1-VSmk1nZUE07cxSZmVoNbD4Ua/O4=",
+              "dev": true
+            },
+            "mime": {
+              "version": "1.3.4",
+              "resolved": "https://registry.npmjs.org/mime/-/mime-1.3.4.tgz",
+              "integrity": "sha1-EV+eO2s9rylZmDyzjxSaLUDrXVM=",
+              "dev": true
+            },
+            "qs": {
+              "version": "2.3.3",
+              "resolved": "https://registry.npmjs.org/qs/-/qs-2.3.3.tgz",
+              "integrity": "sha1-6eha2+ddoLvkyOBHaghikPhjtAQ=",
+              "dev": true
+            },
+            "readable-stream": {
+              "version": "1.0.27-1",
+              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.27-1.tgz",
+              "integrity": "sha1-a2eYPCA1fO/QfwFlABoW1xDZEHg=",
+              "dev": true,
+              "requires": {
+                "core-util-is": "1.0.2",
+                "inherits": "2.0.3",
+                "isarray": "0.0.1",
+                "string_decoder": "0.10.31"
+              },
+              "dependencies": {
+                "core-util-is": {
+                  "version": "1.0.2",
+                  "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/core-util-is/-/core-util-is-1.0.2.tgz",
+                  "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
+                  "dev": true
+                },
+                "inherits": {
+                  "version": "2.0.3",
+                  "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/inherits/-/inherits-2.0.3.tgz",
+                  "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+                  "dev": true
+                },
+                "isarray": {
+                  "version": "0.0.1",
+                  "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+                  "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
+                  "dev": true
+                },
+                "string_decoder": {
+                  "version": "0.10.31",
+                  "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+                  "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
+                  "dev": true
+                }
+              }
+            },
+            "reduce-component": {
+              "version": "1.0.1",
+              "resolved": "https://registry.npmjs.org/reduce-component/-/reduce-component-1.0.1.tgz",
+              "integrity": "sha1-4Mk1QsV0UhvqE98PlIjtgqt3xdo=",
+              "dev": true
+            }
+          }
+        }
+      }
+    },
+    "gulp": {
+      "version": "3.9.1",
+      "resolved": "https://registry.npmjs.org/gulp/-/gulp-3.9.1.tgz",
+      "integrity": "sha1-VxzkWSjdQK9lFPxAEYZgFsE4RbQ=",
+      "dev": true,
+      "requires": {
+        "archy": "1.0.0",
+        "chalk": "1.1.3",
+        "deprecated": "0.0.1",
+        "gulp-util": "3.0.7",
+        "interpret": "1.0.1",
+        "liftoff": "2.3.0",
+        "minimist": "1.2.0",
+        "orchestrator": "0.3.7",
+        "pretty-hrtime": "1.0.2",
+        "semver": "4.3.6",
+        "tildify": "1.2.0",
+        "v8flags": "2.0.11",
+        "vinyl-fs": "0.3.14"
+      },
+      "dependencies": {
+        "chalk": {
+          "version": "1.1.3",
+          "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/chalk/-/chalk-1.1.3.tgz",
+          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "2.2.1",
+            "escape-string-regexp": "1.0.5",
+            "has-ansi": "2.0.0",
+            "strip-ansi": "3.0.1",
+            "supports-color": "2.0.0"
+          },
+          "dependencies": {
+            "ansi-styles": {
+              "version": "2.2.1",
+              "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/ansi-styles/-/ansi-styles-2.2.1.tgz",
+              "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+              "dev": true
+            },
+            "escape-string-regexp": {
+              "version": "1.0.5",
+              "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+              "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+              "dev": true
+            },
+            "has-ansi": {
+              "version": "2.0.0",
+              "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/has-ansi/-/has-ansi-2.0.0.tgz",
+              "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
+              "dev": true,
+              "requires": {
+                "ansi-regex": "2.0.0"
+              },
+              "dependencies": {
+                "ansi-regex": {
+                  "version": "2.0.0",
+                  "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/ansi-regex/-/ansi-regex-2.0.0.tgz",
+                  "integrity": "sha1-xQYbbg74qBd15Q9dZhUb9r83EQc=",
+                  "dev": true
+                }
+              }
+            },
+            "strip-ansi": {
+              "version": "3.0.1",
+              "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/strip-ansi/-/strip-ansi-3.0.1.tgz",
+              "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+              "dev": true,
+              "requires": {
+                "ansi-regex": "2.0.0"
+              },
+              "dependencies": {
+                "ansi-regex": {
+                  "version": "2.0.0",
+                  "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/ansi-regex/-/ansi-regex-2.0.0.tgz",
+                  "integrity": "sha1-xQYbbg74qBd15Q9dZhUb9r83EQc=",
+                  "dev": true
+                }
+              }
+            },
+            "supports-color": {
+              "version": "2.0.0",
+              "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/supports-color/-/supports-color-2.0.0.tgz",
+              "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+              "dev": true
+            }
+          }
+        },
+        "deprecated": {
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/deprecated/-/deprecated-0.0.1.tgz",
+          "integrity": "sha1-+cmvVGSvoeepcUWKi97yqpTVuxk=",
+          "dev": true
+        },
+        "gulp-util": {
+          "version": "3.0.7",
+          "resolved": "https://registry.npmjs.org/gulp-util/-/gulp-util-3.0.7.tgz",
+          "integrity": "sha1-eJJcS4+LSQBawBoBHFV+YhiUHLs=",
+          "dev": true,
+          "requires": {
+            "array-differ": "1.0.0",
+            "array-uniq": "1.0.3",
+            "beeper": "1.1.0",
+            "chalk": "1.1.3",
+            "dateformat": "1.0.12",
+            "fancy-log": "1.2.0",
+            "gulplog": "1.0.0",
+            "has-gulplog": "0.1.0",
+            "lodash._reescape": "3.0.0",
+            "lodash._reevaluate": "3.0.0",
+            "lodash._reinterpolate": "3.0.0",
+            "lodash.template": "3.6.2",
+            "minimist": "1.2.0",
+            "multipipe": "0.1.2",
+            "object-assign": "3.0.0",
+            "replace-ext": "0.0.1",
+            "through2": "2.0.1",
+            "vinyl": "0.5.3"
+          },
+          "dependencies": {
+            "array-differ": {
+              "version": "1.0.0",
+              "resolved": "https://registry.npmjs.org/array-differ/-/array-differ-1.0.0.tgz",
+              "integrity": "sha1-7/UuN1gknTO+QCuLuOVkuytdQDE=",
+              "dev": true
+            },
+            "array-uniq": {
+              "version": "1.0.3",
+              "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/array-uniq/-/array-uniq-1.0.3.tgz",
+              "integrity": "sha1-r2rId6Jcx/dOBYiUdThY39sk/bY=",
+              "dev": true
+            },
+            "beeper": {
+              "version": "1.1.0",
+              "resolved": "https://registry.npmjs.org/beeper/-/beeper-1.1.0.tgz",
+              "integrity": "sha1-nub8HOf1T+qs585zWIsFYDeGaiw=",
+              "dev": true
+            },
+            "dateformat": {
+              "version": "1.0.12",
+              "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-1.0.12.tgz",
+              "integrity": "sha1-nxJLZ1lMk3/3BpMuSmQsyo27/uk=",
+              "dev": true,
+              "requires": {
+                "get-stdin": "4.0.1",
+                "meow": "3.7.0"
+              },
+              "dependencies": {
+                "get-stdin": {
+                  "version": "4.0.1",
+                  "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz",
+                  "integrity": "sha1-uWjGsKBDhDJJAui/Gl3zJXmkUP4=",
+                  "dev": true
+                },
+                "meow": {
+                  "version": "3.7.0",
+                  "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/meow/-/meow-3.7.0.tgz",
+                  "integrity": "sha1-cstmi0JSKCkKu/qFaJJYcwioAfs=",
+                  "dev": true,
+                  "requires": {
+                    "camelcase-keys": "2.1.0",
+                    "decamelize": "1.2.0",
+                    "loud-rejection": "1.6.0",
+                    "map-obj": "1.0.1",
+                    "minimist": "1.2.0",
+                    "normalize-package-data": "2.3.5",
+                    "object-assign": "4.1.0",
+                    "read-pkg-up": "1.0.1",
+                    "redent": "1.0.0",
+                    "trim-newlines": "1.0.0"
+                  },
+                  "dependencies": {
+                    "camelcase-keys": {
+                      "version": "2.1.0",
+                      "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/camelcase-keys/-/camelcase-keys-2.1.0.tgz",
+                      "integrity": "sha1-MIvur/3ygRkFHvodkyITyRuPkuc=",
+                      "dev": true,
+                      "requires": {
+                        "camelcase": "2.1.1",
+                        "map-obj": "1.0.1"
+                      },
+                      "dependencies": {
+                        "camelcase": {
+                          "version": "2.1.1",
+                          "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/camelcase/-/camelcase-2.1.1.tgz",
+                          "integrity": "sha1-fB0W1nmhu+WcoCys7PsBHiAfWh8=",
+                          "dev": true
+                        }
+                      }
+                    },
+                    "decamelize": {
+                      "version": "1.2.0",
+                      "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/decamelize/-/decamelize-1.2.0.tgz",
+                      "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
+                      "dev": true
+                    },
+                    "loud-rejection": {
+                      "version": "1.6.0",
+                      "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/loud-rejection/-/loud-rejection-1.6.0.tgz",
+                      "integrity": "sha1-W0b4AUft7leIcPCG0Eghz5mOVR8=",
+                      "dev": true,
+                      "requires": {
+                        "currently-unhandled": "0.4.1",
+                        "signal-exit": "3.0.1"
+                      },
+                      "dependencies": {
+                        "currently-unhandled": {
+                          "version": "0.4.1",
+                          "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/currently-unhandled/-/currently-unhandled-0.4.1.tgz",
+                          "integrity": "sha1-mI3zP+qxke95mmE2nddsF635V+o=",
+                          "dev": true,
+                          "requires": {
+                            "array-find-index": "1.0.2"
+                          },
+                          "dependencies": {
+                            "array-find-index": {
+                              "version": "1.0.2",
+                              "resolved": "https://registry.npmjs.org/array-find-index/-/array-find-index-1.0.2.tgz",
+                              "integrity": "sha1-3wEKoSh+Fku9pvlyOwqWoexBh6E=",
+                              "dev": true
+                            }
+                          }
+                        },
+                        "signal-exit": {
+                          "version": "3.0.1",
+                          "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.1.tgz",
+                          "integrity": "sha1-WkyISZK2OnrNm623iUw+6c/MrYE=",
+                          "dev": true
+                        }
+                      }
+                    },
+                    "map-obj": {
+                      "version": "1.0.1",
+                      "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
+                      "integrity": "sha1-2TPOuSBdgr3PSIb2dCvcK03qFG0=",
+                      "dev": true
+                    },
+                    "normalize-package-data": {
+                      "version": "2.3.5",
+                      "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/normalize-package-data/-/normalize-package-data-2.3.5.tgz",
+                      "integrity": "sha1-jZJPFClg4Xd+f/4XBUNjHMfLAt8=",
+                      "dev": true,
+                      "requires": {
+                        "hosted-git-info": "2.1.5",
+                        "is-builtin-module": "1.0.0",
+                        "semver": "4.3.6",
+                        "validate-npm-package-license": "3.0.1"
+                      },
+                      "dependencies": {
+                        "hosted-git-info": {
+                          "version": "2.1.5",
+                          "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/hosted-git-info/-/hosted-git-info-2.1.5.tgz",
+                          "integrity": "sha1-C6gdkNouJas0ozLm7HeTbhWYEYs=",
+                          "dev": true
+                        },
+                        "is-builtin-module": {
+                          "version": "1.0.0",
+                          "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
+                          "integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
+                          "dev": true,
+                          "requires": {
+                            "builtin-modules": "1.1.1"
+                          },
+                          "dependencies": {
+                            "builtin-modules": {
+                              "version": "1.1.1",
+                              "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/builtin-modules/-/builtin-modules-1.1.1.tgz",
+                              "integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8=",
+                              "dev": true
+                            }
+                          }
+                        },
+                        "validate-npm-package-license": {
+                          "version": "3.0.1",
+                          "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/validate-npm-package-license/-/validate-npm-package-license-3.0.1.tgz",
+                          "integrity": "sha1-KAS6vnEq0zeUWaz74kdGqywwP7w=",
+                          "dev": true,
+                          "requires": {
+                            "spdx-correct": "1.0.2",
+                            "spdx-expression-parse": "1.0.4"
+                          },
+                          "dependencies": {
+                            "spdx-correct": {
+                              "version": "1.0.2",
+                              "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/spdx-correct/-/spdx-correct-1.0.2.tgz",
+                              "integrity": "sha1-SzBz2TP/UfORLwOsVRlJikFQ20A=",
+                              "dev": true,
+                              "requires": {
+                                "spdx-license-ids": "1.2.2"
+                              },
+                              "dependencies": {
+                                "spdx-license-ids": {
+                                  "version": "1.2.2",
+                                  "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/spdx-license-ids/-/spdx-license-ids-1.2.2.tgz",
+                                  "integrity": "sha1-yd96NCRZSt5r0RkA1ZZpbcBrrFc=",
+                                  "dev": true
+                                }
+                              }
+                            },
+                            "spdx-expression-parse": {
+                              "version": "1.0.4",
+                              "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-1.0.4.tgz",
+                              "integrity": "sha1-m98vIOH0DtRH++JzJmGR/O1RYmw=",
+                              "dev": true
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "object-assign": {
+                      "version": "4.1.0",
+                      "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/object-assign/-/object-assign-4.1.0.tgz",
+                      "integrity": "sha1-ejs9DpgGPUP0wD8uiubNUahog6A=",
+                      "dev": true
+                    },
+                    "read-pkg-up": {
+                      "version": "1.0.1",
+                      "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
+                      "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
+                      "dev": true,
+                      "requires": {
+                        "find-up": "1.1.2",
+                        "read-pkg": "1.1.0"
+                      },
+                      "dependencies": {
+                        "find-up": {
+                          "version": "1.1.2",
+                          "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/find-up/-/find-up-1.1.2.tgz",
+                          "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
+                          "dev": true,
+                          "requires": {
+                            "path-exists": "2.1.0",
+                            "pinkie-promise": "2.0.1"
+                          },
+                          "dependencies": {
+                            "path-exists": {
+                              "version": "2.1.0",
+                              "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/path-exists/-/path-exists-2.1.0.tgz",
+                              "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
+                              "dev": true,
+                              "requires": {
+                                "pinkie-promise": "2.0.1"
+                              }
+                            },
+                            "pinkie-promise": {
+                              "version": "2.0.1",
+                              "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
+                              "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
+                              "dev": true,
+                              "requires": {
+                                "pinkie": "2.0.4"
+                              },
+                              "dependencies": {
+                                "pinkie": {
+                                  "version": "2.0.4",
+                                  "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/pinkie/-/pinkie-2.0.4.tgz",
+                                  "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA=",
+                                  "dev": true
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "read-pkg": {
+                          "version": "1.1.0",
+                          "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/read-pkg/-/read-pkg-1.1.0.tgz",
+                          "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
+                          "dev": true,
+                          "requires": {
+                            "load-json-file": "1.1.0",
+                            "normalize-package-data": "2.3.5",
+                            "path-type": "1.1.0"
+                          },
+                          "dependencies": {
+                            "load-json-file": {
+                              "version": "1.1.0",
+                              "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/load-json-file/-/load-json-file-1.1.0.tgz",
+                              "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
+                              "dev": true,
+                              "requires": {
+                                "graceful-fs": "4.1.9",
+                                "parse-json": "2.2.0",
+                                "pify": "2.3.0",
+                                "pinkie-promise": "2.0.1",
+                                "strip-bom": "2.0.0"
+                              },
+                              "dependencies": {
+                                "graceful-fs": {
+                                  "version": "4.1.9",
+                                  "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.9.tgz",
+                                  "integrity": "sha1-uqy6N9GdEfnRRtNXi8mZWMN4fik=",
+                                  "dev": true
+                                },
+                                "parse-json": {
+                                  "version": "2.2.0",
+                                  "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/parse-json/-/parse-json-2.2.0.tgz",
+                                  "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
+                                  "dev": true,
+                                  "requires": {
+                                    "error-ex": "1.3.0"
+                                  },
+                                  "dependencies": {
+                                    "error-ex": {
+                                      "version": "1.3.0",
+                                      "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/error-ex/-/error-ex-1.3.0.tgz",
+                                      "integrity": "sha1-5ntD8+gsluo6WE/+4Ln8MyXYAtk=",
+                                      "dev": true,
+                                      "requires": {
+                                        "is-arrayish": "0.2.1"
+                                      },
+                                      "dependencies": {
+                                        "is-arrayish": {
+                                          "version": "0.2.1",
+                                          "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/is-arrayish/-/is-arrayish-0.2.1.tgz",
+                                          "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
+                                          "dev": true
+                                        }
+                                      }
+                                    }
+                                  }
+                                },
+                                "pify": {
+                                  "version": "2.3.0",
+                                  "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/pify/-/pify-2.3.0.tgz",
+                                  "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
+                                  "dev": true
+                                },
+                                "pinkie-promise": {
+                                  "version": "2.0.1",
+                                  "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
+                                  "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
+                                  "dev": true,
+                                  "requires": {
+                                    "pinkie": "2.0.4"
+                                  },
+                                  "dependencies": {
+                                    "pinkie": {
+                                      "version": "2.0.4",
+                                      "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/pinkie/-/pinkie-2.0.4.tgz",
+                                      "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA=",
+                                      "dev": true
+                                    }
+                                  }
+                                },
+                                "strip-bom": {
+                                  "version": "2.0.0",
+                                  "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/strip-bom/-/strip-bom-2.0.0.tgz",
+                                  "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
+                                  "dev": true,
+                                  "requires": {
+                                    "is-utf8": "0.2.1"
+                                  },
+                                  "dependencies": {
+                                    "is-utf8": {
+                                      "version": "0.2.1",
+                                      "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/is-utf8/-/is-utf8-0.2.1.tgz",
+                                      "integrity": "sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI=",
+                                      "dev": true
+                                    }
+                                  }
+                                }
+                              }
+                            },
+                            "path-type": {
+                              "version": "1.1.0",
+                              "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/path-type/-/path-type-1.1.0.tgz",
+                              "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
+                              "dev": true,
+                              "requires": {
+                                "graceful-fs": "4.1.9",
+                                "pify": "2.3.0",
+                                "pinkie-promise": "2.0.1"
+                              },
+                              "dependencies": {
+                                "graceful-fs": {
+                                  "version": "4.1.9",
+                                  "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.9.tgz",
+                                  "integrity": "sha1-uqy6N9GdEfnRRtNXi8mZWMN4fik=",
+                                  "dev": true
+                                },
+                                "pify": {
+                                  "version": "2.3.0",
+                                  "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/pify/-/pify-2.3.0.tgz",
+                                  "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
+                                  "dev": true
+                                },
+                                "pinkie-promise": {
+                                  "version": "2.0.1",
+                                  "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
+                                  "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
+                                  "dev": true,
+                                  "requires": {
+                                    "pinkie": "2.0.4"
+                                  },
+                                  "dependencies": {
+                                    "pinkie": {
+                                      "version": "2.0.4",
+                                      "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/pinkie/-/pinkie-2.0.4.tgz",
+                                      "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA=",
+                                      "dev": true
+                                    }
+                                  }
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "redent": {
+                      "version": "1.0.0",
+                      "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/redent/-/redent-1.0.0.tgz",
+                      "integrity": "sha1-z5Fqsf1fHxbfsggi3W7H9zDCr94=",
+                      "dev": true,
+                      "requires": {
+                        "indent-string": "2.1.0",
+                        "strip-indent": "1.0.1"
+                      },
+                      "dependencies": {
+                        "indent-string": {
+                          "version": "2.1.0",
+                          "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/indent-string/-/indent-string-2.1.0.tgz",
+                          "integrity": "sha1-ji1INIdCEhtKghi3oTfppSBJ3IA=",
+                          "dev": true,
+                          "requires": {
+                            "repeating": "2.0.1"
+                          },
+                          "dependencies": {
+                            "repeating": {
+                              "version": "2.0.1",
+                              "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/repeating/-/repeating-2.0.1.tgz",
+                              "integrity": "sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo=",
+                              "dev": true,
+                              "requires": {
+                                "is-finite": "1.0.2"
+                              },
+                              "dependencies": {
+                                "is-finite": {
+                                  "version": "1.0.2",
+                                  "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.2.tgz",
+                                  "integrity": "sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko=",
+                                  "dev": true,
+                                  "requires": {
+                                    "number-is-nan": "1.0.1"
+                                  },
+                                  "dependencies": {
+                                    "number-is-nan": {
+                                      "version": "1.0.1",
+                                      "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
+                                      "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
+                                      "dev": true
+                                    }
+                                  }
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "strip-indent": {
+                          "version": "1.0.1",
+                          "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/strip-indent/-/strip-indent-1.0.1.tgz",
+                          "integrity": "sha1-DHlipq3vp7vUrDZkYKY4VSrhoKI=",
+                          "dev": true,
+                          "requires": {
+                            "get-stdin": "4.0.1"
+                          }
+                        }
+                      }
+                    },
+                    "trim-newlines": {
+                      "version": "1.0.0",
+                      "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/trim-newlines/-/trim-newlines-1.0.0.tgz",
+                      "integrity": "sha1-WIeWa7WCpFA6QetST301ARgVphM=",
+                      "dev": true
+                    }
+                  }
+                }
+              }
+            },
+            "fancy-log": {
+              "version": "1.2.0",
+              "resolved": "https://registry.npmjs.org/fancy-log/-/fancy-log-1.2.0.tgz",
+              "integrity": "sha1-1aUbU+mrIsoH1VjytnrlX9tfy9g=",
+              "dev": true,
+              "requires": {
+                "chalk": "1.1.3",
+                "time-stamp": "1.0.1"
+              },
+              "dependencies": {
+                "time-stamp": {
+                  "version": "1.0.1",
+                  "resolved": "https://registry.npmjs.org/time-stamp/-/time-stamp-1.0.1.tgz",
+                  "integrity": "sha1-n0vSNVnJNllm8zAtu6KwfGuZsVE=",
+                  "dev": true
+                }
+              }
+            },
+            "gulplog": {
+              "version": "1.0.0",
+              "resolved": "https://registry.npmjs.org/gulplog/-/gulplog-1.0.0.tgz",
+              "integrity": "sha1-4oxNRdBey77YGDY86PnFkmIp/+U=",
+              "dev": true,
+              "requires": {
+                "glogg": "1.0.0"
+              },
+              "dependencies": {
+                "glogg": {
+                  "version": "1.0.0",
+                  "resolved": "https://registry.npmjs.org/glogg/-/glogg-1.0.0.tgz",
+                  "integrity": "sha1-f+DxmfV6yQbPUS/urY+Q7kooT8U=",
+                  "dev": true,
+                  "requires": {
+                    "sparkles": "1.0.0"
+                  },
+                  "dependencies": {
+                    "sparkles": {
+                      "version": "1.0.0",
+                      "resolved": "https://registry.npmjs.org/sparkles/-/sparkles-1.0.0.tgz",
+                      "integrity": "sha1-Gsu/tZJDbRC76PeFt8xvgoFQEsM=",
+                      "dev": true
+                    }
+                  }
+                }
+              }
+            },
+            "has-gulplog": {
+              "version": "0.1.0",
+              "resolved": "https://registry.npmjs.org/has-gulplog/-/has-gulplog-0.1.0.tgz",
+              "integrity": "sha1-ZBTIKRNpfaUVkDl9r7EvIpZ4Ec4=",
+              "dev": true,
+              "requires": {
+                "sparkles": "1.0.0"
+              },
+              "dependencies": {
+                "sparkles": {
+                  "version": "1.0.0",
+                  "resolved": "https://registry.npmjs.org/sparkles/-/sparkles-1.0.0.tgz",
+                  "integrity": "sha1-Gsu/tZJDbRC76PeFt8xvgoFQEsM=",
+                  "dev": true
+                }
+              }
+            },
+            "lodash._reescape": {
+              "version": "3.0.0",
+              "resolved": "https://registry.npmjs.org/lodash._reescape/-/lodash._reescape-3.0.0.tgz",
+              "integrity": "sha1-Kx1vXf4HyKNVdT5fJ/rH8c3hYWo=",
+              "dev": true
+            },
+            "lodash._reevaluate": {
+              "version": "3.0.0",
+              "resolved": "https://registry.npmjs.org/lodash._reevaluate/-/lodash._reevaluate-3.0.0.tgz",
+              "integrity": "sha1-WLx0xAZklTrgsSTYBpltrKQx4u0=",
+              "dev": true
+            },
+            "lodash._reinterpolate": {
+              "version": "3.0.0",
+              "resolved": "https://registry.npmjs.org/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz",
+              "integrity": "sha1-DM8tiRZq8Ds2Y8eWU4t1rG4RTZ0=",
+              "dev": true
+            },
+            "lodash.template": {
+              "version": "3.6.2",
+              "resolved": "https://registry.npmjs.org/lodash.template/-/lodash.template-3.6.2.tgz",
+              "integrity": "sha1-+M3sxhaaJVvpCYrosMU9N4kx0U8=",
+              "dev": true,
+              "requires": {
+                "lodash._basecopy": "3.0.1",
+                "lodash._basetostring": "3.0.1",
+                "lodash._basevalues": "3.0.0",
+                "lodash._isiterateecall": "3.0.9",
+                "lodash._reinterpolate": "3.0.0",
+                "lodash.escape": "3.2.0",
+                "lodash.keys": "3.1.2",
+                "lodash.restparam": "3.6.1",
+                "lodash.templatesettings": "3.1.1"
+              },
+              "dependencies": {
+                "lodash._basecopy": {
+                  "version": "3.0.1",
+                  "resolved": "https://registry.npmjs.org/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz",
+                  "integrity": "sha1-jaDmqHbPNEwK2KVIghEd08XHyjY=",
+                  "dev": true
+                },
+                "lodash._basetostring": {
+                  "version": "3.0.1",
+                  "resolved": "https://registry.npmjs.org/lodash._basetostring/-/lodash._basetostring-3.0.1.tgz",
+                  "integrity": "sha1-0YYdh3+CSlL2aYMtyvPuFVZqB9U=",
+                  "dev": true
+                },
+                "lodash._basevalues": {
+                  "version": "3.0.0",
+                  "resolved": "https://registry.npmjs.org/lodash._basevalues/-/lodash._basevalues-3.0.0.tgz",
+                  "integrity": "sha1-W3dXYoAr3j0yl1A+JjAIIP32Ybc=",
+                  "dev": true
+                },
+                "lodash._isiterateecall": {
+                  "version": "3.0.9",
+                  "resolved": "https://registry.npmjs.org/lodash._isiterateecall/-/lodash._isiterateecall-3.0.9.tgz",
+                  "integrity": "sha1-UgOte6Ql+uhCRg5pbbnPPmqsBXw=",
+                  "dev": true
+                },
+                "lodash.escape": {
+                  "version": "3.2.0",
+                  "resolved": "https://registry.npmjs.org/lodash.escape/-/lodash.escape-3.2.0.tgz",
+                  "integrity": "sha1-mV7g3BjBtIzJLv+ucaEKq1tIdpg=",
+                  "dev": true,
+                  "requires": {
+                    "lodash._root": "3.0.1"
+                  },
+                  "dependencies": {
+                    "lodash._root": {
+                      "version": "3.0.1",
+                      "resolved": "https://registry.npmjs.org/lodash._root/-/lodash._root-3.0.1.tgz",
+                      "integrity": "sha1-+6HEUkwZ7ppfgTa0YJ8BfPTe1pI=",
+                      "dev": true
+                    }
+                  }
+                },
+                "lodash.keys": {
+                  "version": "3.1.2",
+                  "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/lodash.keys/-/lodash.keys-3.1.2.tgz",
+                  "integrity": "sha1-TbwEcrFWvlCgsoaFXRvQsMZWCYo=",
+                  "dev": true,
+                  "requires": {
+                    "lodash._getnative": "3.9.1",
+                    "lodash.isarguments": "3.1.0",
+                    "lodash.isarray": "3.0.4"
+                  },
+                  "dependencies": {
+                    "lodash._getnative": {
+                      "version": "3.9.1",
+                      "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/lodash._getnative/-/lodash._getnative-3.9.1.tgz",
+                      "integrity": "sha1-VwvH3t5G1hzc3mh9ZdPuy6o6r/U=",
+                      "dev": true
+                    },
+                    "lodash.isarguments": {
+                      "version": "3.1.0",
+                      "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
+                      "integrity": "sha1-L1c9hcaiQon/AGY7SRwdM4/zRYo=",
+                      "dev": true
+                    },
+                    "lodash.isarray": {
+                      "version": "3.0.4",
+                      "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/lodash.isarray/-/lodash.isarray-3.0.4.tgz",
+                      "integrity": "sha1-eeTriMNqgSKvhvhEqpvNhRtfu1U=",
+                      "dev": true
+                    }
+                  }
+                },
+                "lodash.restparam": {
+                  "version": "3.6.1",
+                  "resolved": "https://registry.npmjs.org/lodash.restparam/-/lodash.restparam-3.6.1.tgz",
+                  "integrity": "sha1-k2pOMJ7zMKdkXtQUWYbIWuWyCAU=",
+                  "dev": true
+                },
+                "lodash.templatesettings": {
+                  "version": "3.1.1",
+                  "resolved": "https://registry.npmjs.org/lodash.templatesettings/-/lodash.templatesettings-3.1.1.tgz",
+                  "integrity": "sha1-+zB4RHU7Zrnxr6VOJix0UwfbqOU=",
+                  "dev": true,
+                  "requires": {
+                    "lodash._reinterpolate": "3.0.0",
+                    "lodash.escape": "3.2.0"
+                  }
+                }
+              }
+            },
+            "multipipe": {
+              "version": "0.1.2",
+              "resolved": "https://registry.npmjs.org/multipipe/-/multipipe-0.1.2.tgz",
+              "integrity": "sha1-Ko8t33Du1WTf8tV/HhoTfZ8FB4s=",
+              "dev": true,
+              "requires": {
+                "duplexer2": "0.0.2"
+              },
+              "dependencies": {
+                "duplexer2": {
+                  "version": "0.0.2",
+                  "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.0.2.tgz",
+                  "integrity": "sha1-xhTc9n4vsUmVqRcR5aYX6KYKMds=",
+                  "dev": true,
+                  "requires": {
+                    "readable-stream": "1.1.14"
+                  },
+                  "dependencies": {
+                    "readable-stream": {
+                      "version": "1.1.14",
+                      "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/readable-stream/-/readable-stream-1.1.14.tgz",
+                      "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
+                      "dev": true,
+                      "requires": {
+                        "core-util-is": "1.0.2",
+                        "inherits": "2.0.3",
+                        "isarray": "0.0.1",
+                        "string_decoder": "0.10.31"
+                      },
+                      "dependencies": {
+                        "core-util-is": {
+                          "version": "1.0.2",
+                          "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/core-util-is/-/core-util-is-1.0.2.tgz",
+                          "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
+                          "dev": true
+                        },
+                        "inherits": {
+                          "version": "2.0.3",
+                          "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/inherits/-/inherits-2.0.3.tgz",
+                          "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+                          "dev": true
+                        },
+                        "isarray": {
+                          "version": "0.0.1",
+                          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+                          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
+                          "dev": true
+                        },
+                        "string_decoder": {
+                          "version": "0.10.31",
+                          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+                          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
+                          "dev": true
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "object-assign": {
+              "version": "3.0.0",
+              "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/object-assign/-/object-assign-3.0.0.tgz",
+              "integrity": "sha1-m+3VygiXlJvKR+f/QIBi1Un1h/I=",
+              "dev": true
+            },
+            "replace-ext": {
+              "version": "0.0.1",
+              "resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-0.0.1.tgz",
+              "integrity": "sha1-KbvZIHinOfC8zitO5B6DeVNSKSQ=",
+              "dev": true
+            },
+            "through2": {
+              "version": "2.0.1",
+              "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/through2/-/through2-2.0.1.tgz",
+              "integrity": "sha1-OE51MU1J8y3hLuu4E2uOtrXVnak=",
+              "dev": true,
+              "requires": {
+                "readable-stream": "2.0.6",
+                "xtend": "4.0.1"
+              },
+              "dependencies": {
+                "readable-stream": {
+                  "version": "2.0.6",
+                  "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/readable-stream/-/readable-stream-2.0.6.tgz",
+                  "integrity": "sha1-j5A0HmilPMySh4jaz80Rs265t44=",
+                  "dev": true,
+                  "requires": {
+                    "core-util-is": "1.0.2",
+                    "inherits": "2.0.3",
+                    "isarray": "1.0.0",
+                    "process-nextick-args": "1.0.7",
+                    "string_decoder": "0.10.31",
+                    "util-deprecate": "1.0.2"
+                  },
+                  "dependencies": {
+                    "core-util-is": {
+                      "version": "1.0.2",
+                      "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/core-util-is/-/core-util-is-1.0.2.tgz",
+                      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
+                      "dev": true
+                    },
+                    "inherits": {
+                      "version": "2.0.3",
+                      "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/inherits/-/inherits-2.0.3.tgz",
+                      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+                      "dev": true
+                    },
+                    "isarray": {
+                      "version": "1.0.0",
+                      "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/isarray/-/isarray-1.0.0.tgz",
+                      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+                      "dev": true
+                    },
+                    "process-nextick-args": {
+                      "version": "1.0.7",
+                      "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
+                      "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M=",
+                      "dev": true
+                    },
+                    "string_decoder": {
+                      "version": "0.10.31",
+                      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+                      "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
+                      "dev": true
+                    },
+                    "util-deprecate": {
+                      "version": "1.0.2",
+                      "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/util-deprecate/-/util-deprecate-1.0.2.tgz",
+                      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
+                      "dev": true
+                    }
+                  }
+                },
+                "xtend": {
+                  "version": "4.0.1",
+                  "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/xtend/-/xtend-4.0.1.tgz",
+                  "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68=",
+                  "dev": true
+                }
+              }
+            },
+            "vinyl": {
+              "version": "0.5.3",
+              "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-0.5.3.tgz",
+              "integrity": "sha1-sEVbOPxeDPMNQyUTLkYZcMIJHN4=",
+              "dev": true,
+              "requires": {
+                "clone": "1.0.2",
+                "clone-stats": "0.0.1",
+                "replace-ext": "0.0.1"
+              },
+              "dependencies": {
+                "clone": {
+                  "version": "1.0.2",
+                  "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/clone/-/clone-1.0.2.tgz",
+                  "integrity": "sha1-Jgt6meux7f4kdTgXX3gyQ8sZ0Uk=",
+                  "dev": true
+                },
+                "clone-stats": {
+                  "version": "0.0.1",
+                  "resolved": "https://registry.npmjs.org/clone-stats/-/clone-stats-0.0.1.tgz",
+                  "integrity": "sha1-uI+UqCzzi4eR1YBG6kAprYjKmdE=",
+                  "dev": true
+                }
+              }
+            }
+          }
+        },
+        "interpret": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.0.1.tgz",
+          "integrity": "sha1-1Xn7f2k7hYAElHrzn6DbSfeVYCw=",
+          "dev": true
+        },
+        "liftoff": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/liftoff/-/liftoff-2.3.0.tgz",
+          "integrity": "sha1-qY8v9nGD2Lp8+soQVIvX/wVQs4U=",
+          "dev": true,
+          "requires": {
+            "extend": "3.0.0",
+            "findup-sync": "0.4.2",
+            "fined": "1.0.2",
+            "flagged-respawn": "0.3.2",
+            "lodash.isplainobject": "4.0.6",
+            "lodash.isstring": "4.0.1",
+            "lodash.mapvalues": "4.6.0",
+            "rechoir": "0.6.2",
+            "resolve": "1.1.7"
+          },
+          "dependencies": {
+            "extend": {
+              "version": "3.0.0",
+              "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/extend/-/extend-3.0.0.tgz",
+              "integrity": "sha1-WkdDU7nzNT3dgXbf03uRyDpG8dQ=",
+              "dev": true
+            },
+            "findup-sync": {
+              "version": "0.4.2",
+              "resolved": "https://registry.npmjs.org/findup-sync/-/findup-sync-0.4.2.tgz",
+              "integrity": "sha1-qBF9D3MST1pFRoOVef5S1xKfteU=",
+              "dev": true,
+              "requires": {
+                "detect-file": "0.1.0",
+                "is-glob": "2.0.1",
+                "micromatch": "2.3.11",
+                "resolve-dir": "0.1.1"
+              },
+              "dependencies": {
+                "detect-file": {
+                  "version": "0.1.0",
+                  "resolved": "https://registry.npmjs.org/detect-file/-/detect-file-0.1.0.tgz",
+                  "integrity": "sha1-STXe39lIhkjgBrASlWbpOGcR6mM=",
+                  "dev": true,
+                  "requires": {
+                    "fs-exists-sync": "0.1.0"
+                  },
+                  "dependencies": {
+                    "fs-exists-sync": {
+                      "version": "0.1.0",
+                      "resolved": "https://registry.npmjs.org/fs-exists-sync/-/fs-exists-sync-0.1.0.tgz",
+                      "integrity": "sha1-mC1ok6+RjnLQjeyehnP/K1qNat0=",
+                      "dev": true
+                    }
+                  }
+                },
+                "is-glob": {
+                  "version": "2.0.1",
+                  "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/is-glob/-/is-glob-2.0.1.tgz",
+                  "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
+                  "dev": true,
+                  "requires": {
+                    "is-extglob": "1.0.0"
+                  },
+                  "dependencies": {
+                    "is-extglob": {
+                      "version": "1.0.0",
+                      "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/is-extglob/-/is-extglob-1.0.0.tgz",
+                      "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
+                      "dev": true
+                    }
+                  }
+                },
+                "micromatch": {
+                  "version": "2.3.11",
+                  "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/micromatch/-/micromatch-2.3.11.tgz",
+                  "integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
+                  "dev": true,
+                  "requires": {
+                    "arr-diff": "2.0.0",
+                    "array-unique": "0.2.1",
+                    "braces": "1.8.5",
+                    "expand-brackets": "0.1.5",
+                    "extglob": "0.3.2",
+                    "filename-regex": "2.0.0",
+                    "is-extglob": "1.0.0",
+                    "is-glob": "2.0.1",
+                    "kind-of": "3.0.4",
+                    "normalize-path": "2.0.1",
+                    "object.omit": "2.0.0",
+                    "parse-glob": "3.0.4",
+                    "regex-cache": "0.4.3"
+                  },
+                  "dependencies": {
+                    "arr-diff": {
+                      "version": "2.0.0",
+                      "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/arr-diff/-/arr-diff-2.0.0.tgz",
+                      "integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
+                      "dev": true,
+                      "requires": {
+                        "arr-flatten": "1.0.1"
+                      },
+                      "dependencies": {
+                        "arr-flatten": {
+                          "version": "1.0.1",
+                          "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/arr-flatten/-/arr-flatten-1.0.1.tgz",
+                          "integrity": "sha1-5f/lTUXhnzLyFukeuZyM6JK7YEs=",
+                          "dev": true
+                        }
+                      }
+                    },
+                    "array-unique": {
+                      "version": "0.2.1",
+                      "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/array-unique/-/array-unique-0.2.1.tgz",
+                      "integrity": "sha1-odl8yvy8JiXMcPrc6zalDFiwGlM=",
+                      "dev": true
+                    },
+                    "braces": {
+                      "version": "1.8.5",
+                      "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/braces/-/braces-1.8.5.tgz",
+                      "integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
+                      "dev": true,
+                      "requires": {
+                        "expand-range": "1.8.2",
+                        "preserve": "0.2.0",
+                        "repeat-element": "1.1.2"
+                      },
+                      "dependencies": {
+                        "expand-range": {
+                          "version": "1.8.2",
+                          "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/expand-range/-/expand-range-1.8.2.tgz",
+                          "integrity": "sha1-opnv/TNf4nIeuujiV+x5ZE/IUzc=",
+                          "dev": true,
+                          "requires": {
+                            "fill-range": "2.2.3"
+                          },
+                          "dependencies": {
+                            "fill-range": {
+                              "version": "2.2.3",
+                              "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/fill-range/-/fill-range-2.2.3.tgz",
+                              "integrity": "sha1-ULd9/X5Gm8dJJHCWNpn+eoSFpyM=",
+                              "dev": true,
+                              "requires": {
+                                "is-number": "2.1.0",
+                                "isobject": "2.1.0",
+                                "randomatic": "1.1.5",
+                                "repeat-element": "1.1.2",
+                                "repeat-string": "1.5.4"
+                              },
+                              "dependencies": {
+                                "is-number": {
+                                  "version": "2.1.0",
+                                  "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/is-number/-/is-number-2.1.0.tgz",
+                                  "integrity": "sha1-Afy7s5NGOlSPL0ZszhbezknbkI8=",
+                                  "dev": true,
+                                  "requires": {
+                                    "kind-of": "3.0.4"
+                                  }
+                                },
+                                "isobject": {
+                                  "version": "2.1.0",
+                                  "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/isobject/-/isobject-2.1.0.tgz",
+                                  "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
+                                  "dev": true,
+                                  "requires": {
+                                    "isarray": "1.0.0"
+                                  },
+                                  "dependencies": {
+                                    "isarray": {
+                                      "version": "1.0.0",
+                                      "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/isarray/-/isarray-1.0.0.tgz",
+                                      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+                                      "dev": true
+                                    }
+                                  }
+                                },
+                                "randomatic": {
+                                  "version": "1.1.5",
+                                  "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/randomatic/-/randomatic-1.1.5.tgz",
+                                  "integrity": "sha1-Xp718tVzxnvSuBJK6QtRVuRXhAs=",
+                                  "dev": true,
+                                  "requires": {
+                                    "is-number": "2.1.0",
+                                    "kind-of": "3.0.4"
+                                  }
+                                },
+                                "repeat-string": {
+                                  "version": "1.5.4",
+                                  "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.5.4.tgz",
+                                  "integrity": "sha1-ZOwMkeD0tHX5DVtkNlHj5uW2wtU=",
+                                  "dev": true
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "preserve": {
+                          "version": "0.2.0",
+                          "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/preserve/-/preserve-0.2.0.tgz",
+                          "integrity": "sha1-gV7R9uvGWSb4ZbMQwHE7yzMVzks=",
+                          "dev": true
+                        },
+                        "repeat-element": {
+                          "version": "1.1.2",
+                          "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/repeat-element/-/repeat-element-1.1.2.tgz",
+                          "integrity": "sha1-7wiaF40Ug7quTZPrmLT55OEdmQo=",
+                          "dev": true
+                        }
+                      }
+                    },
+                    "expand-brackets": {
+                      "version": "0.1.5",
+                      "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/expand-brackets/-/expand-brackets-0.1.5.tgz",
+                      "integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
+                      "dev": true,
+                      "requires": {
+                        "is-posix-bracket": "0.1.1"
+                      },
+                      "dependencies": {
+                        "is-posix-bracket": {
+                          "version": "0.1.1",
+                          "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/is-posix-bracket/-/is-posix-bracket-0.1.1.tgz",
+                          "integrity": "sha1-MzTceXdDaOkvAW5vvAqI9c1ua8Q=",
+                          "dev": true
+                        }
+                      }
+                    },
+                    "extglob": {
+                      "version": "0.3.2",
+                      "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/extglob/-/extglob-0.3.2.tgz",
+                      "integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
+                      "dev": true,
+                      "requires": {
+                        "is-extglob": "1.0.0"
+                      }
+                    },
+                    "filename-regex": {
+                      "version": "2.0.0",
+                      "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/filename-regex/-/filename-regex-2.0.0.tgz",
+                      "integrity": "sha1-mW4+gEebmLmJfxWopYs9CE6SZ3U=",
+                      "dev": true
+                    },
+                    "is-extglob": {
+                      "version": "1.0.0",
+                      "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/is-extglob/-/is-extglob-1.0.0.tgz",
+                      "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
+                      "dev": true
+                    },
+                    "kind-of": {
+                      "version": "3.0.4",
+                      "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/kind-of/-/kind-of-3.0.4.tgz",
+                      "integrity": "sha1-e47PGKThf4Jp1ztQHJ8jLJaIenQ=",
+                      "dev": true,
+                      "requires": {
+                        "is-buffer": "1.1.4"
+                      },
+                      "dependencies": {
+                        "is-buffer": {
+                          "version": "1.1.4",
+                          "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/is-buffer/-/is-buffer-1.1.4.tgz",
+                          "integrity": "sha1-z8hszV3FpS+oBIkRHGkgxFfi2Ys=",
+                          "dev": true
+                        }
+                      }
+                    },
+                    "normalize-path": {
+                      "version": "2.0.1",
+                      "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/normalize-path/-/normalize-path-2.0.1.tgz",
+                      "integrity": "sha1-R4hqwWYnYNQmG32XnSQXCdPOP3o=",
+                      "dev": true
+                    },
+                    "object.omit": {
+                      "version": "2.0.0",
+                      "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/object.omit/-/object.omit-2.0.0.tgz",
+                      "integrity": "sha1-hoWXMz1U5gZilAu0WGBd1q4S/pQ=",
+                      "dev": true,
+                      "requires": {
+                        "for-own": "0.1.4",
+                        "is-extendable": "0.1.1"
+                      },
+                      "dependencies": {
+                        "for-own": {
+                          "version": "0.1.4",
+                          "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/for-own/-/for-own-0.1.4.tgz",
+                          "integrity": "sha1-AUm0GjkIjHUV9R6+HBOG1F+TUHI=",
+                          "dev": true,
+                          "requires": {
+                            "for-in": "0.1.6"
+                          },
+                          "dependencies": {
+                            "for-in": {
+                              "version": "0.1.6",
+                              "resolved": "https://registry.npmjs.org/for-in/-/for-in-0.1.6.tgz",
+                              "integrity": "sha1-yfluib+tGKVFr17D7TUqHZ5bTcg=",
+                              "dev": true
+                            }
+                          }
+                        },
+                        "is-extendable": {
+                          "version": "0.1.1",
+                          "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/is-extendable/-/is-extendable-0.1.1.tgz",
+                          "integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik=",
+                          "dev": true
+                        }
+                      }
+                    },
+                    "parse-glob": {
+                      "version": "3.0.4",
+                      "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/parse-glob/-/parse-glob-3.0.4.tgz",
+                      "integrity": "sha1-ssN2z7EfNVE7rdFz7wu246OIORw=",
+                      "dev": true,
+                      "requires": {
+                        "glob-base": "0.3.0",
+                        "is-dotfile": "1.0.2",
+                        "is-extglob": "1.0.0",
+                        "is-glob": "2.0.1"
+                      },
+                      "dependencies": {
+                        "glob-base": {
+                          "version": "0.3.0",
+                          "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/glob-base/-/glob-base-0.3.0.tgz",
+                          "integrity": "sha1-27Fk9iIbHAscz4Kuoyi0l98Oo8Q=",
+                          "dev": true,
+                          "requires": {
+                            "glob-parent": "2.0.0",
+                            "is-glob": "2.0.1"
+                          },
+                          "dependencies": {
+                            "glob-parent": {
+                              "version": "2.0.0",
+                              "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/glob-parent/-/glob-parent-2.0.0.tgz",
+                              "integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
+                              "dev": true,
+                              "requires": {
+                                "is-glob": "2.0.1"
+                              }
+                            }
+                          }
+                        },
+                        "is-dotfile": {
+                          "version": "1.0.2",
+                          "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/is-dotfile/-/is-dotfile-1.0.2.tgz",
+                          "integrity": "sha1-LBMjg/ORmfjtwmjKAbmwB9IFzE0=",
+                          "dev": true
+                        }
+                      }
+                    },
+                    "regex-cache": {
+                      "version": "0.4.3",
+                      "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/regex-cache/-/regex-cache-0.4.3.tgz",
+                      "integrity": "sha1-mxpsNdTQ3871cRrmUejp09cRQUU=",
+                      "dev": true,
+                      "requires": {
+                        "is-equal-shallow": "0.1.3",
+                        "is-primitive": "2.0.0"
+                      },
+                      "dependencies": {
+                        "is-equal-shallow": {
+                          "version": "0.1.3",
+                          "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz",
+                          "integrity": "sha1-IjgJj8Ih3gvPpdnqxMRdY4qhxTQ=",
+                          "dev": true,
+                          "requires": {
+                            "is-primitive": "2.0.0"
+                          }
+                        },
+                        "is-primitive": {
+                          "version": "2.0.0",
+                          "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/is-primitive/-/is-primitive-2.0.0.tgz",
+                          "integrity": "sha1-IHurkWOEmcB7Kt8kCkGochADRXU=",
+                          "dev": true
+                        }
+                      }
+                    }
+                  }
+                },
+                "resolve-dir": {
+                  "version": "0.1.1",
+                  "resolved": "https://registry.npmjs.org/resolve-dir/-/resolve-dir-0.1.1.tgz",
+                  "integrity": "sha1-shklmlYC+sXFxJatiUpujMQwJh4=",
+                  "dev": true,
+                  "requires": {
+                    "expand-tilde": "1.2.2",
+                    "global-modules": "0.2.3"
+                  },
+                  "dependencies": {
+                    "expand-tilde": {
+                      "version": "1.2.2",
+                      "resolved": "https://registry.npmjs.org/expand-tilde/-/expand-tilde-1.2.2.tgz",
+                      "integrity": "sha1-C4HrqJflo9MdHD0QL48BRB5VlEk=",
+                      "dev": true,
+                      "requires": {
+                        "os-homedir": "1.0.2"
+                      },
+                      "dependencies": {
+                        "os-homedir": {
+                          "version": "1.0.2",
+                          "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
+                          "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
+                          "dev": true
+                        }
+                      }
+                    },
+                    "global-modules": {
+                      "version": "0.2.3",
+                      "resolved": "https://registry.npmjs.org/global-modules/-/global-modules-0.2.3.tgz",
+                      "integrity": "sha1-6lo77ULG1s6ZWk+KEmm12uIjgo0=",
+                      "dev": true,
+                      "requires": {
+                        "global-prefix": "0.1.4",
+                        "is-windows": "0.2.0"
+                      },
+                      "dependencies": {
+                        "global-prefix": {
+                          "version": "0.1.4",
+                          "resolved": "https://registry.npmjs.org/global-prefix/-/global-prefix-0.1.4.tgz",
+                          "integrity": "sha1-BRWNsc3i3UkbRV4pDrOri/xFxuE=",
+                          "dev": true,
+                          "requires": {
+                            "ini": "1.3.4",
+                            "is-windows": "0.2.0",
+                            "osenv": "0.1.3",
+                            "which": "1.2.11"
+                          },
+                          "dependencies": {
+                            "ini": {
+                              "version": "1.3.4",
+                              "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz",
+                              "integrity": "sha1-BTfLedr1m1mhpRff9wbIbsA5Fi4=",
+                              "dev": true
+                            },
+                            "osenv": {
+                              "version": "0.1.3",
+                              "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/osenv/-/osenv-0.1.3.tgz",
+                              "integrity": "sha1-g88FxtZFj8TVrGNi6jJdkvJ1Qhc=",
+                              "dev": true,
+                              "requires": {
+                                "os-homedir": "1.0.2",
+                                "os-tmpdir": "1.0.2"
+                              },
+                              "dependencies": {
+                                "os-homedir": {
+                                  "version": "1.0.2",
+                                  "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
+                                  "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
+                                  "dev": true
+                                },
+                                "os-tmpdir": {
+                                  "version": "1.0.2",
+                                  "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+                                  "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
+                                  "dev": true
+                                }
+                              }
+                            },
+                            "which": {
+                              "version": "1.2.11",
+                              "resolved": "https://registry.npmjs.org/which/-/which-1.2.11.tgz",
+                              "integrity": "sha1-yLLu6muMFln6fB3U/aq+lTPcXos=",
+                              "dev": true,
+                              "requires": {
+                                "isexe": "1.1.2"
+                              },
+                              "dependencies": {
+                                "isexe": {
+                                  "version": "1.1.2",
+                                  "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/isexe/-/isexe-1.1.2.tgz",
+                                  "integrity": "sha1-NvPiLmB1CSD15yQaR2qMakInWtA=",
+                                  "dev": true
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "is-windows": {
+                          "version": "0.2.0",
+                          "resolved": "https://registry.npmjs.org/is-windows/-/is-windows-0.2.0.tgz",
+                          "integrity": "sha1-3hqm1j6indJIc3tp8f+LgALSEIw=",
+                          "dev": true
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "fined": {
+              "version": "1.0.2",
+              "resolved": "https://registry.npmjs.org/fined/-/fined-1.0.2.tgz",
+              "integrity": "sha1-WyhCS3YNdZiWC374SA3/itNmDpc=",
+              "dev": true,
+              "requires": {
+                "expand-tilde": "1.2.2",
+                "lodash.assignwith": "4.2.0",
+                "lodash.isempty": "4.4.0",
+                "lodash.isplainobject": "4.0.6",
+                "lodash.isstring": "4.0.1",
+                "lodash.pick": "4.4.0",
+                "parse-filepath": "1.0.1"
+              },
+              "dependencies": {
+                "expand-tilde": {
+                  "version": "1.2.2",
+                  "resolved": "https://registry.npmjs.org/expand-tilde/-/expand-tilde-1.2.2.tgz",
+                  "integrity": "sha1-C4HrqJflo9MdHD0QL48BRB5VlEk=",
+                  "dev": true,
+                  "requires": {
+                    "os-homedir": "1.0.2"
+                  },
+                  "dependencies": {
+                    "os-homedir": {
+                      "version": "1.0.2",
+                      "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
+                      "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
+                      "dev": true
+                    }
+                  }
+                },
+                "lodash.assignwith": {
+                  "version": "4.2.0",
+                  "resolved": "https://registry.npmjs.org/lodash.assignwith/-/lodash.assignwith-4.2.0.tgz",
+                  "integrity": "sha1-EnqX8CrcQXUalU0ksN4X4QDgOOs=",
+                  "dev": true
+                },
+                "lodash.isempty": {
+                  "version": "4.4.0",
+                  "resolved": "https://registry.npmjs.org/lodash.isempty/-/lodash.isempty-4.4.0.tgz",
+                  "integrity": "sha1-b4bL7di+TsmHvpqvM8loTbGzHn4=",
+                  "dev": true
+                },
+                "lodash.pick": {
+                  "version": "4.4.0",
+                  "resolved": "https://registry.npmjs.org/lodash.pick/-/lodash.pick-4.4.0.tgz",
+                  "integrity": "sha1-UvBWEP/53tQiYRRB7R/BI6AwAbM=",
+                  "dev": true
+                },
+                "parse-filepath": {
+                  "version": "1.0.1",
+                  "resolved": "https://registry.npmjs.org/parse-filepath/-/parse-filepath-1.0.1.tgz",
+                  "integrity": "sha1-FZ1hVdQ5BNFsEO9piRHaHpGWm3M=",
+                  "dev": true,
+                  "requires": {
+                    "is-absolute": "0.2.5",
+                    "map-cache": "0.2.2",
+                    "path-root": "0.1.1"
+                  },
+                  "dependencies": {
+                    "is-absolute": {
+                      "version": "0.2.5",
+                      "resolved": "https://registry.npmjs.org/is-absolute/-/is-absolute-0.2.5.tgz",
+                      "integrity": "sha1-mUFCufRo0nwU+/DNMP5325NMp20=",
+                      "dev": true,
+                      "requires": {
+                        "is-relative": "0.2.1",
+                        "is-windows": "0.1.1"
+                      },
+                      "dependencies": {
+                        "is-relative": {
+                          "version": "0.2.1",
+                          "resolved": "https://registry.npmjs.org/is-relative/-/is-relative-0.2.1.tgz",
+                          "integrity": "sha1-0n9MfVFtF1+2ENuEu+7yPDvJeqU=",
+                          "dev": true,
+                          "requires": {
+                            "is-unc-path": "0.1.1"
+                          },
+                          "dependencies": {
+                            "is-unc-path": {
+                              "version": "0.1.1",
+                              "resolved": "https://registry.npmjs.org/is-unc-path/-/is-unc-path-0.1.1.tgz",
+                              "integrity": "sha1-qyUz13rXM1YRJMPcD1zYuQBUyGs=",
+                              "dev": true,
+                              "requires": {
+                                "unc-path-regex": "0.1.2"
+                              },
+                              "dependencies": {
+                                "unc-path-regex": {
+                                  "version": "0.1.2",
+                                  "resolved": "https://registry.npmjs.org/unc-path-regex/-/unc-path-regex-0.1.2.tgz",
+                                  "integrity": "sha1-5z3T17DXxe2G+6xrCufYxqadUPo=",
+                                  "dev": true
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "is-windows": {
+                          "version": "0.1.1",
+                          "resolved": "https://registry.npmjs.org/is-windows/-/is-windows-0.1.1.tgz",
+                          "integrity": "sha1-vjEHFUMc+rzMVKs5USEPoLbQGr4=",
+                          "dev": true
+                        }
+                      }
+                    },
+                    "map-cache": {
+                      "version": "0.2.2",
+                      "resolved": "https://registry.npmjs.org/map-cache/-/map-cache-0.2.2.tgz",
+                      "integrity": "sha1-wyq9C9ZSXZsFFkW7TyasXcmKDb8=",
+                      "dev": true
+                    },
+                    "path-root": {
+                      "version": "0.1.1",
+                      "resolved": "https://registry.npmjs.org/path-root/-/path-root-0.1.1.tgz",
+                      "integrity": "sha1-mkpoFMrBwM1zNgqV8yCDyOpHRbc=",
+                      "dev": true,
+                      "requires": {
+                        "path-root-regex": "0.1.2"
+                      },
+                      "dependencies": {
+                        "path-root-regex": {
+                          "version": "0.1.2",
+                          "resolved": "https://registry.npmjs.org/path-root-regex/-/path-root-regex-0.1.2.tgz",
+                          "integrity": "sha1-v8zcjfWxLcUsi0PsONGNcsBLqW0=",
+                          "dev": true
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "flagged-respawn": {
+              "version": "0.3.2",
+              "resolved": "https://registry.npmjs.org/flagged-respawn/-/flagged-respawn-0.3.2.tgz",
+              "integrity": "sha1-/xke3c1wiKZ1smEP/8l2vpuAdLU=",
+              "dev": true
+            },
+            "lodash.isplainobject": {
+              "version": "4.0.6",
+              "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+              "integrity": "sha1-fFJqUtibRcRcxpC4gWO+BJf1UMs=",
+              "dev": true
+            },
+            "lodash.isstring": {
+              "version": "4.0.1",
+              "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
+              "integrity": "sha1-1SfftUVuynzJu5XV2ur4i6VKVFE=",
+              "dev": true
+            },
+            "lodash.mapvalues": {
+              "version": "4.6.0",
+              "resolved": "https://registry.npmjs.org/lodash.mapvalues/-/lodash.mapvalues-4.6.0.tgz",
+              "integrity": "sha1-G6+lAF3p3W9PJmaMMMo3IwzJaJw=",
+              "dev": true
+            },
+            "rechoir": {
+              "version": "0.6.2",
+              "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz",
+              "integrity": "sha1-hSBLVNuoLVdC4oyWdW70OvUOM4Q=",
+              "dev": true,
+              "requires": {
+                "resolve": "1.1.7"
+              }
+            },
+            "resolve": {
+              "version": "1.1.7",
+              "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/resolve/-/resolve-1.1.7.tgz",
+              "integrity": "sha1-IDEU2CrSxe2ejgQRs5ModeiJ6Xs=",
+              "dev": true
+            }
+          }
+        },
+        "minimist": {
+          "version": "1.2.0",
+          "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/minimist/-/minimist-1.2.0.tgz",
+          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+          "dev": true
+        },
+        "orchestrator": {
+          "version": "0.3.7",
+          "resolved": "https://registry.npmjs.org/orchestrator/-/orchestrator-0.3.7.tgz",
+          "integrity": "sha1-xFBk4ixaKnuZc09AmpX/7cfTw98=",
+          "dev": true,
+          "requires": {
+            "end-of-stream": "0.1.5",
+            "sequencify": "0.0.7",
+            "stream-consume": "0.1.0"
+          },
+          "dependencies": {
+            "end-of-stream": {
+              "version": "0.1.5",
+              "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-0.1.5.tgz",
+              "integrity": "sha1-jhdyBsPICDfYVjLouTWd/osvbq8=",
+              "dev": true,
+              "requires": {
+                "once": "1.3.3"
+              },
+              "dependencies": {
+                "once": {
+                  "version": "1.3.3",
+                  "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/once/-/once-1.3.3.tgz",
+                  "integrity": "sha1-suJhVXzkwxTsgwTz+oJmPkKXyiA=",
+                  "dev": true,
+                  "requires": {
+                    "wrappy": "1.0.2"
+                  },
+                  "dependencies": {
+                    "wrappy": {
+                      "version": "1.0.2",
+                      "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/wrappy/-/wrappy-1.0.2.tgz",
+                      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+                      "dev": true
+                    }
+                  }
+                }
+              }
+            },
+            "sequencify": {
+              "version": "0.0.7",
+              "resolved": "https://registry.npmjs.org/sequencify/-/sequencify-0.0.7.tgz",
+              "integrity": "sha1-kM/xnQLgcCf9dn9erT57ldHnOAw=",
+              "dev": true
+            },
+            "stream-consume": {
+              "version": "0.1.0",
+              "resolved": "https://registry.npmjs.org/stream-consume/-/stream-consume-0.1.0.tgz",
+              "integrity": "sha1-pB6tGm1ggc63n2WwYZAbbY89HQ8=",
+              "dev": true
+            }
+          }
+        },
+        "pretty-hrtime": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/pretty-hrtime/-/pretty-hrtime-1.0.2.tgz",
+          "integrity": "sha1-cMqW9NBiikQ7kYdY95QWqae8n6g=",
+          "dev": true
+        },
+        "semver": {
+          "version": "4.3.6",
+          "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/semver/-/semver-4.3.6.tgz",
+          "integrity": "sha1-MAvG4OhjdPe6YQaLWx7NV/xlMto=",
+          "dev": true
+        },
+        "tildify": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/tildify/-/tildify-1.2.0.tgz",
+          "integrity": "sha1-3OwD9V3Km3qj5bBPIYF+tW5jWIo=",
+          "dev": true,
+          "requires": {
+            "os-homedir": "1.0.2"
+          },
+          "dependencies": {
+            "os-homedir": {
+              "version": "1.0.2",
+              "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
+              "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
+              "dev": true
+            }
+          }
+        },
+        "v8flags": {
+          "version": "2.0.11",
+          "resolved": "https://registry.npmjs.org/v8flags/-/v8flags-2.0.11.tgz",
+          "integrity": "sha1-vKjzDw1tYGEswsAGQeaWLUKuaIE=",
+          "dev": true,
+          "requires": {
+            "user-home": "1.1.1"
+          },
+          "dependencies": {
+            "user-home": {
+              "version": "1.1.1",
+              "resolved": "https://registry.npmjs.org/user-home/-/user-home-1.1.1.tgz",
+              "integrity": "sha1-K1viOjK2Onyd640PKNSFcko98ZA=",
+              "dev": true
+            }
+          }
+        },
+        "vinyl-fs": {
+          "version": "0.3.14",
+          "resolved": "https://registry.npmjs.org/vinyl-fs/-/vinyl-fs-0.3.14.tgz",
+          "integrity": "sha1-mmhRzhysHBzqX+hsCTHWIMLPqeY=",
+          "dev": true,
+          "requires": {
+            "defaults": "1.0.3",
+            "glob-stream": "3.1.18",
+            "glob-watcher": "0.0.6",
+            "graceful-fs": "3.0.11",
+            "mkdirp": "0.5.1",
+            "strip-bom": "1.0.0",
+            "through2": "0.6.5",
+            "vinyl": "0.4.6"
+          },
+          "dependencies": {
+            "defaults": {
+              "version": "1.0.3",
+              "resolved": "https://registry.npmjs.org/defaults/-/defaults-1.0.3.tgz",
+              "integrity": "sha1-xlYFHpgX2f8I7YgUd/P+QBnz730=",
+              "dev": true,
+              "requires": {
+                "clone": "1.0.2"
+              },
+              "dependencies": {
+                "clone": {
+                  "version": "1.0.2",
+                  "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/clone/-/clone-1.0.2.tgz",
+                  "integrity": "sha1-Jgt6meux7f4kdTgXX3gyQ8sZ0Uk=",
+                  "dev": true
+                }
+              }
+            },
+            "glob-stream": {
+              "version": "3.1.18",
+              "resolved": "https://registry.npmjs.org/glob-stream/-/glob-stream-3.1.18.tgz",
+              "integrity": "sha1-kXCl8St5Awb9/lmPMT+PeVT9FDs=",
+              "dev": true,
+              "requires": {
+                "glob": "4.5.3",
+                "glob2base": "0.0.12",
+                "minimatch": "2.0.10",
+                "ordered-read-streams": "0.1.0",
+                "through2": "0.6.5",
+                "unique-stream": "1.0.0"
+              },
+              "dependencies": {
+                "glob": {
+                  "version": "4.5.3",
+                  "resolved": "https://registry.npmjs.org/glob/-/glob-4.5.3.tgz",
+                  "integrity": "sha1-xstz0yJsHv7wTePFbQEvAzd+4V8=",
+                  "dev": true,
+                  "requires": {
+                    "inflight": "1.0.5",
+                    "inherits": "2.0.3",
+                    "minimatch": "2.0.10",
+                    "once": "1.4.0"
+                  },
+                  "dependencies": {
+                    "inflight": {
+                      "version": "1.0.5",
+                      "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/inflight/-/inflight-1.0.5.tgz",
+                      "integrity": "sha1-2zIEzVqd4ubNiQuFxuL2a89PYgo=",
+                      "dev": true,
+                      "requires": {
+                        "once": "1.4.0",
+                        "wrappy": "1.0.2"
+                      },
+                      "dependencies": {
+                        "wrappy": {
+                          "version": "1.0.2",
+                          "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/wrappy/-/wrappy-1.0.2.tgz",
+                          "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+                          "dev": true
+                        }
+                      }
+                    },
+                    "inherits": {
+                      "version": "2.0.3",
+                      "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/inherits/-/inherits-2.0.3.tgz",
+                      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+                      "dev": true
+                    },
+                    "once": {
+                      "version": "1.4.0",
+                      "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/once/-/once-1.4.0.tgz",
+                      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+                      "dev": true,
+                      "requires": {
+                        "wrappy": "1.0.2"
+                      },
+                      "dependencies": {
+                        "wrappy": {
+                          "version": "1.0.2",
+                          "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/wrappy/-/wrappy-1.0.2.tgz",
+                          "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+                          "dev": true
+                        }
+                      }
+                    }
+                  }
+                },
+                "glob2base": {
+                  "version": "0.0.12",
+                  "resolved": "https://registry.npmjs.org/glob2base/-/glob2base-0.0.12.tgz",
+                  "integrity": "sha1-nUGbPijxLoOjYhZKJ3BVkiycDVY=",
+                  "dev": true,
+                  "requires": {
+                    "find-index": "0.1.1"
+                  },
+                  "dependencies": {
+                    "find-index": {
+                      "version": "0.1.1",
+                      "resolved": "https://registry.npmjs.org/find-index/-/find-index-0.1.1.tgz",
+                      "integrity": "sha1-Z101iyyjiS15Whq0cjL4tuLg3eQ=",
+                      "dev": true
+                    }
+                  }
+                },
+                "minimatch": {
+                  "version": "2.0.10",
+                  "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/minimatch/-/minimatch-2.0.10.tgz",
+                  "integrity": "sha1-jQh8OcazjAAbl/ynzm0OHoCvusc=",
+                  "dev": true,
+                  "requires": {
+                    "brace-expansion": "1.1.6"
+                  },
+                  "dependencies": {
+                    "brace-expansion": {
+                      "version": "1.1.6",
+                      "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/brace-expansion/-/brace-expansion-1.1.6.tgz",
+                      "integrity": "sha1-cZfX6qm4fmSDkOph/GbIRCdCDfk=",
+                      "dev": true,
+                      "requires": {
+                        "balanced-match": "0.4.2",
+                        "concat-map": "0.0.1"
+                      },
+                      "dependencies": {
+                        "balanced-match": {
+                          "version": "0.4.2",
+                          "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/balanced-match/-/balanced-match-0.4.2.tgz",
+                          "integrity": "sha1-yz8+PHMtwPAe5wtAPzAuYddwmDg=",
+                          "dev": true
+                        },
+                        "concat-map": {
+                          "version": "0.0.1",
+                          "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+                          "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+                          "dev": true
+                        }
+                      }
+                    }
+                  }
+                },
+                "ordered-read-streams": {
+                  "version": "0.1.0",
+                  "resolved": "https://registry.npmjs.org/ordered-read-streams/-/ordered-read-streams-0.1.0.tgz",
+                  "integrity": "sha1-/VZamvjrRHO6abbtijQ1LLVS8SY=",
+                  "dev": true
+                },
+                "unique-stream": {
+                  "version": "1.0.0",
+                  "resolved": "https://registry.npmjs.org/unique-stream/-/unique-stream-1.0.0.tgz",
+                  "integrity": "sha1-1ZpKdUJ0R9mqbJHnAmP40mpLEEs=",
+                  "dev": true
+                }
+              }
+            },
+            "glob-watcher": {
+              "version": "0.0.6",
+              "resolved": "https://registry.npmjs.org/glob-watcher/-/glob-watcher-0.0.6.tgz",
+              "integrity": "sha1-uVtKjfdLOcgymLDAXJeLTZo7cQs=",
+              "dev": true,
+              "requires": {
+                "gaze": "0.5.2"
+              },
+              "dependencies": {
+                "gaze": {
+                  "version": "0.5.2",
+                  "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/gaze/-/gaze-0.5.2.tgz",
+                  "integrity": "sha1-QLcJU30k0dRXZ9takIaJ3+aaxE8=",
+                  "dev": true,
+                  "requires": {
+                    "globule": "0.1.0"
+                  },
+                  "dependencies": {
+                    "globule": {
+                      "version": "0.1.0",
+                      "resolved": "https://registry.npmjs.org/globule/-/globule-0.1.0.tgz",
+                      "integrity": "sha1-2cjt3h2nnRJaFRt5UzuXhnY0auU=",
+                      "dev": true,
+                      "requires": {
+                        "glob": "3.1.21",
+                        "lodash": "1.0.2",
+                        "minimatch": "0.2.14"
+                      },
+                      "dependencies": {
+                        "glob": {
+                          "version": "3.1.21",
+                          "resolved": "https://registry.npmjs.org/glob/-/glob-3.1.21.tgz",
+                          "integrity": "sha1-0p4KBV3qUTj00H7UDomC6DwgZs0=",
+                          "dev": true,
+                          "requires": {
+                            "graceful-fs": "1.2.3",
+                            "inherits": "1.0.2",
+                            "minimatch": "0.2.14"
+                          },
+                          "dependencies": {
+                            "graceful-fs": {
+                              "version": "1.2.3",
+                              "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-1.2.3.tgz",
+                              "integrity": "sha1-FaSAaldUfLLS2/J/QuiajDRRs2Q=",
+                              "dev": true
+                            },
+                            "inherits": {
+                              "version": "1.0.2",
+                              "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/inherits/-/inherits-1.0.2.tgz",
+                              "integrity": "sha1-ykMJ2t7mtUzAuNJH6NfHoJdb3Js=",
+                              "dev": true
+                            }
+                          }
+                        },
+                        "lodash": {
+                          "version": "1.0.2",
+                          "resolved": "https://registry.npmjs.org/lodash/-/lodash-1.0.2.tgz",
+                          "integrity": "sha1-j1dWDIO1n8JwvT1WG2kAQ0MOJVE=",
+                          "dev": true
+                        },
+                        "minimatch": {
+                          "version": "0.2.14",
+                          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
+                          "integrity": "sha1-x054BXT2PG+aCQ6Q775u9TpqdWo=",
+                          "dev": true,
+                          "requires": {
+                            "lru-cache": "2.7.3",
+                            "sigmund": "1.0.1"
+                          },
+                          "dependencies": {
+                            "lru-cache": {
+                              "version": "2.7.3",
+                              "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/lru-cache/-/lru-cache-2.7.3.tgz",
+                              "integrity": "sha1-bUUk6LlV+V1PW1iFHOId1y+06VI=",
+                              "dev": true
+                            },
+                            "sigmund": {
+                              "version": "1.0.1",
+                              "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz",
+                              "integrity": "sha1-P/IfGYytIXX587eBhT/ZTQ0ZtZA=",
+                              "dev": true
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "graceful-fs": {
+              "version": "3.0.11",
+              "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.11.tgz",
+              "integrity": "sha1-dhPHeKGv6mLyXGMKCG1/Osu92Bg=",
+              "dev": true,
+              "requires": {
+                "natives": "1.1.0"
+              },
+              "dependencies": {
+                "natives": {
+                  "version": "1.1.0",
+                  "resolved": "https://registry.npmjs.org/natives/-/natives-1.1.0.tgz",
+                  "integrity": "sha1-6f+EFBimsux6SV6TmYT3jxY+bjE=",
+                  "dev": true
+                }
+              }
+            },
+            "mkdirp": {
+              "version": "0.5.1",
+              "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+              "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+              "dev": true,
+              "requires": {
+                "minimist": "0.0.8"
+              },
+              "dependencies": {
+                "minimist": {
+                  "version": "0.0.8",
+                  "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+                  "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+                  "dev": true
+                }
+              }
+            },
+            "strip-bom": {
+              "version": "1.0.0",
+              "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-1.0.0.tgz",
+              "integrity": "sha1-hbiGLzhEtabV7IRnqTWYFzo295Q=",
+              "dev": true,
+              "requires": {
+                "first-chunk-stream": "1.0.0",
+                "is-utf8": "0.2.1"
+              },
+              "dependencies": {
+                "first-chunk-stream": {
+                  "version": "1.0.0",
+                  "resolved": "https://registry.npmjs.org/first-chunk-stream/-/first-chunk-stream-1.0.0.tgz",
+                  "integrity": "sha1-Wb+1DNkF9g18OUzT2ayqtOatk04=",
+                  "dev": true
+                },
+                "is-utf8": {
+                  "version": "0.2.1",
+                  "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/is-utf8/-/is-utf8-0.2.1.tgz",
+                  "integrity": "sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI=",
+                  "dev": true
+                }
+              }
+            },
+            "through2": {
+              "version": "0.6.5",
+              "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
+              "integrity": "sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=",
+              "dev": true,
+              "requires": {
+                "readable-stream": "1.0.34",
+                "xtend": "4.0.1"
+              },
+              "dependencies": {
+                "readable-stream": {
+                  "version": "1.0.34",
+                  "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/readable-stream/-/readable-stream-1.0.34.tgz",
+                  "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
+                  "dev": true,
+                  "requires": {
+                    "core-util-is": "1.0.2",
+                    "inherits": "2.0.3",
+                    "isarray": "0.0.1",
+                    "string_decoder": "0.10.31"
+                  },
+                  "dependencies": {
+                    "core-util-is": {
+                      "version": "1.0.2",
+                      "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/core-util-is/-/core-util-is-1.0.2.tgz",
+                      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
+                      "dev": true
+                    },
+                    "inherits": {
+                      "version": "2.0.3",
+                      "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/inherits/-/inherits-2.0.3.tgz",
+                      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+                      "dev": true
+                    },
+                    "isarray": {
+                      "version": "0.0.1",
+                      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+                      "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
+                      "dev": true
+                    },
+                    "string_decoder": {
+                      "version": "0.10.31",
+                      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+                      "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
+                      "dev": true
+                    }
+                  }
+                },
+                "xtend": {
+                  "version": "4.0.1",
+                  "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/xtend/-/xtend-4.0.1.tgz",
+                  "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68=",
+                  "dev": true
+                }
+              }
+            },
+            "vinyl": {
+              "version": "0.4.6",
+              "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-0.4.6.tgz",
+              "integrity": "sha1-LzVsh6VQolVGHza76ypbqL94SEc=",
+              "dev": true,
+              "requires": {
+                "clone": "0.2.0",
+                "clone-stats": "0.0.1"
+              },
+              "dependencies": {
+                "clone": {
+                  "version": "0.2.0",
+                  "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/clone/-/clone-0.2.0.tgz",
+                  "integrity": "sha1-xhJqkK1Pctv1rNskPMN3JP6T/B8=",
+                  "dev": true
+                },
+                "clone-stats": {
+                  "version": "0.0.1",
+                  "resolved": "https://registry.npmjs.org/clone-stats/-/clone-stats-0.0.1.tgz",
+                  "integrity": "sha1-uI+UqCzzi4eR1YBG6kAprYjKmdE=",
+                  "dev": true
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "gulp-eslint": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/gulp-eslint/-/gulp-eslint-1.1.1.tgz",
+      "integrity": "sha1-nxY4D1MxchUrN/O1woFkmt+PRmQ=",
+      "dev": true,
+      "requires": {
+        "bufferstreams": "1.1.1",
+        "eslint": "1.10.3",
+        "gulp-util": "3.0.7",
+        "object-assign": "4.1.0"
+      },
+      "dependencies": {
+        "bufferstreams": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/bufferstreams/-/bufferstreams-1.1.1.tgz",
+          "integrity": "sha1-AWE3MGCsWYjv+ZBYcxEU9uGV1R4=",
+          "dev": true,
+          "requires": {
+            "readable-stream": "2.1.5"
+          },
+          "dependencies": {
+            "readable-stream": {
+              "version": "2.1.5",
+              "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/readable-stream/-/readable-stream-2.1.5.tgz",
+              "integrity": "sha1-ZvqLcg4UOLNkaB8q0aY8YYRIydA=",
+              "dev": true,
+              "requires": {
+                "buffer-shims": "1.0.0",
+                "core-util-is": "1.0.2",
+                "inherits": "2.0.3",
+                "isarray": "1.0.0",
+                "process-nextick-args": "1.0.7",
+                "string_decoder": "0.10.31",
+                "util-deprecate": "1.0.2"
+              },
+              "dependencies": {
+                "buffer-shims": {
+                  "version": "1.0.0",
+                  "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/buffer-shims/-/buffer-shims-1.0.0.tgz",
+                  "integrity": "sha1-mXjOMXOIxkmth5MCjDR37wRKi1E=",
+                  "dev": true
+                },
+                "core-util-is": {
+                  "version": "1.0.2",
+                  "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/core-util-is/-/core-util-is-1.0.2.tgz",
+                  "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
+                  "dev": true
+                },
+                "inherits": {
+                  "version": "2.0.3",
+                  "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/inherits/-/inherits-2.0.3.tgz",
+                  "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+                  "dev": true
+                },
+                "isarray": {
+                  "version": "1.0.0",
+                  "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/isarray/-/isarray-1.0.0.tgz",
+                  "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+                  "dev": true
+                },
+                "process-nextick-args": {
+                  "version": "1.0.7",
+                  "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
+                  "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M=",
+                  "dev": true
+                },
+                "string_decoder": {
+                  "version": "0.10.31",
+                  "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+                  "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
+                  "dev": true
+                },
+                "util-deprecate": {
+                  "version": "1.0.2",
+                  "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/util-deprecate/-/util-deprecate-1.0.2.tgz",
+                  "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
+                  "dev": true
+                }
+              }
+            }
+          }
+        },
+        "gulp-util": {
+          "version": "3.0.7",
+          "resolved": "https://registry.npmjs.org/gulp-util/-/gulp-util-3.0.7.tgz",
+          "integrity": "sha1-eJJcS4+LSQBawBoBHFV+YhiUHLs=",
+          "dev": true,
+          "requires": {
+            "array-differ": "1.0.0",
+            "array-uniq": "1.0.3",
+            "beeper": "1.1.0",
+            "chalk": "1.1.3",
+            "dateformat": "1.0.12",
+            "fancy-log": "1.2.0",
+            "gulplog": "1.0.0",
+            "has-gulplog": "0.1.0",
+            "lodash._reescape": "3.0.0",
+            "lodash._reevaluate": "3.0.0",
+            "lodash._reinterpolate": "3.0.0",
+            "lodash.template": "3.6.2",
+            "minimist": "1.2.0",
+            "multipipe": "0.1.2",
+            "object-assign": "3.0.0",
+            "replace-ext": "0.0.1",
+            "through2": "2.0.1",
+            "vinyl": "0.5.3"
+          },
+          "dependencies": {
+            "array-differ": {
+              "version": "1.0.0",
+              "resolved": "https://registry.npmjs.org/array-differ/-/array-differ-1.0.0.tgz",
+              "integrity": "sha1-7/UuN1gknTO+QCuLuOVkuytdQDE=",
+              "dev": true
+            },
+            "array-uniq": {
+              "version": "1.0.3",
+              "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/array-uniq/-/array-uniq-1.0.3.tgz",
+              "integrity": "sha1-r2rId6Jcx/dOBYiUdThY39sk/bY=",
+              "dev": true
+            },
+            "beeper": {
+              "version": "1.1.0",
+              "resolved": "https://registry.npmjs.org/beeper/-/beeper-1.1.0.tgz",
+              "integrity": "sha1-nub8HOf1T+qs585zWIsFYDeGaiw=",
+              "dev": true
+            },
+            "chalk": {
+              "version": "1.1.3",
+              "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/chalk/-/chalk-1.1.3.tgz",
+              "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+              "dev": true,
+              "requires": {
+                "ansi-styles": "2.2.1",
+                "escape-string-regexp": "1.0.5",
+                "has-ansi": "2.0.0",
+                "strip-ansi": "3.0.1",
+                "supports-color": "2.0.0"
+              },
+              "dependencies": {
+                "ansi-styles": {
+                  "version": "2.2.1",
+                  "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/ansi-styles/-/ansi-styles-2.2.1.tgz",
+                  "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+                  "dev": true
+                },
+                "escape-string-regexp": {
+                  "version": "1.0.5",
+                  "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+                  "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+                  "dev": true
+                },
+                "has-ansi": {
+                  "version": "2.0.0",
+                  "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/has-ansi/-/has-ansi-2.0.0.tgz",
+                  "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
+                  "dev": true,
+                  "requires": {
+                    "ansi-regex": "2.0.0"
+                  },
+                  "dependencies": {
+                    "ansi-regex": {
+                      "version": "2.0.0",
+                      "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/ansi-regex/-/ansi-regex-2.0.0.tgz",
+                      "integrity": "sha1-xQYbbg74qBd15Q9dZhUb9r83EQc=",
+                      "dev": true
+                    }
+                  }
+                },
+                "strip-ansi": {
+                  "version": "3.0.1",
+                  "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/strip-ansi/-/strip-ansi-3.0.1.tgz",
+                  "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+                  "dev": true,
+                  "requires": {
+                    "ansi-regex": "2.0.0"
+                  },
+                  "dependencies": {
+                    "ansi-regex": {
+                      "version": "2.0.0",
+                      "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/ansi-regex/-/ansi-regex-2.0.0.tgz",
+                      "integrity": "sha1-xQYbbg74qBd15Q9dZhUb9r83EQc=",
+                      "dev": true
+                    }
+                  }
+                },
+                "supports-color": {
+                  "version": "2.0.0",
+                  "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/supports-color/-/supports-color-2.0.0.tgz",
+                  "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+                  "dev": true
+                }
+              }
+            },
+            "dateformat": {
+              "version": "1.0.12",
+              "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-1.0.12.tgz",
+              "integrity": "sha1-nxJLZ1lMk3/3BpMuSmQsyo27/uk=",
+              "dev": true,
+              "requires": {
+                "get-stdin": "4.0.1",
+                "meow": "3.7.0"
+              },
+              "dependencies": {
+                "get-stdin": {
+                  "version": "4.0.1",
+                  "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz",
+                  "integrity": "sha1-uWjGsKBDhDJJAui/Gl3zJXmkUP4=",
+                  "dev": true
+                },
+                "meow": {
+                  "version": "3.7.0",
+                  "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/meow/-/meow-3.7.0.tgz",
+                  "integrity": "sha1-cstmi0JSKCkKu/qFaJJYcwioAfs=",
+                  "dev": true,
+                  "requires": {
+                    "camelcase-keys": "2.1.0",
+                    "decamelize": "1.2.0",
+                    "loud-rejection": "1.6.0",
+                    "map-obj": "1.0.1",
+                    "minimist": "1.2.0",
+                    "normalize-package-data": "2.3.5",
+                    "object-assign": "4.1.0",
+                    "read-pkg-up": "1.0.1",
+                    "redent": "1.0.0",
+                    "trim-newlines": "1.0.0"
+                  },
+                  "dependencies": {
+                    "camelcase-keys": {
+                      "version": "2.1.0",
+                      "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/camelcase-keys/-/camelcase-keys-2.1.0.tgz",
+                      "integrity": "sha1-MIvur/3ygRkFHvodkyITyRuPkuc=",
+                      "dev": true,
+                      "requires": {
+                        "camelcase": "2.1.1",
+                        "map-obj": "1.0.1"
+                      },
+                      "dependencies": {
+                        "camelcase": {
+                          "version": "2.1.1",
+                          "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/camelcase/-/camelcase-2.1.1.tgz",
+                          "integrity": "sha1-fB0W1nmhu+WcoCys7PsBHiAfWh8=",
+                          "dev": true
+                        }
+                      }
+                    },
+                    "decamelize": {
+                      "version": "1.2.0",
+                      "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/decamelize/-/decamelize-1.2.0.tgz",
+                      "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
+                      "dev": true
+                    },
+                    "loud-rejection": {
+                      "version": "1.6.0",
+                      "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/loud-rejection/-/loud-rejection-1.6.0.tgz",
+                      "integrity": "sha1-W0b4AUft7leIcPCG0Eghz5mOVR8=",
+                      "dev": true,
+                      "requires": {
+                        "currently-unhandled": "0.4.1",
+                        "signal-exit": "3.0.1"
+                      },
+                      "dependencies": {
+                        "currently-unhandled": {
+                          "version": "0.4.1",
+                          "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/currently-unhandled/-/currently-unhandled-0.4.1.tgz",
+                          "integrity": "sha1-mI3zP+qxke95mmE2nddsF635V+o=",
+                          "dev": true,
+                          "requires": {
+                            "array-find-index": "1.0.2"
+                          },
+                          "dependencies": {
+                            "array-find-index": {
+                              "version": "1.0.2",
+                              "resolved": "https://registry.npmjs.org/array-find-index/-/array-find-index-1.0.2.tgz",
+                              "integrity": "sha1-3wEKoSh+Fku9pvlyOwqWoexBh6E=",
+                              "dev": true
+                            }
+                          }
+                        },
+                        "signal-exit": {
+                          "version": "3.0.1",
+                          "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.1.tgz",
+                          "integrity": "sha1-WkyISZK2OnrNm623iUw+6c/MrYE=",
+                          "dev": true
+                        }
+                      }
+                    },
+                    "map-obj": {
+                      "version": "1.0.1",
+                      "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
+                      "integrity": "sha1-2TPOuSBdgr3PSIb2dCvcK03qFG0=",
+                      "dev": true
+                    },
+                    "normalize-package-data": {
+                      "version": "2.3.5",
+                      "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/normalize-package-data/-/normalize-package-data-2.3.5.tgz",
+                      "integrity": "sha1-jZJPFClg4Xd+f/4XBUNjHMfLAt8=",
+                      "dev": true,
+                      "requires": {
+                        "hosted-git-info": "2.1.5",
+                        "is-builtin-module": "1.0.0",
+                        "semver": "5.3.0",
+                        "validate-npm-package-license": "3.0.1"
+                      },
+                      "dependencies": {
+                        "hosted-git-info": {
+                          "version": "2.1.5",
+                          "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/hosted-git-info/-/hosted-git-info-2.1.5.tgz",
+                          "integrity": "sha1-C6gdkNouJas0ozLm7HeTbhWYEYs=",
+                          "dev": true
+                        },
+                        "is-builtin-module": {
+                          "version": "1.0.0",
+                          "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
+                          "integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
+                          "dev": true,
+                          "requires": {
+                            "builtin-modules": "1.1.1"
+                          },
+                          "dependencies": {
+                            "builtin-modules": {
+                              "version": "1.1.1",
+                              "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/builtin-modules/-/builtin-modules-1.1.1.tgz",
+                              "integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8=",
+                              "dev": true
+                            }
+                          }
+                        },
+                        "validate-npm-package-license": {
+                          "version": "3.0.1",
+                          "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/validate-npm-package-license/-/validate-npm-package-license-3.0.1.tgz",
+                          "integrity": "sha1-KAS6vnEq0zeUWaz74kdGqywwP7w=",
+                          "dev": true,
+                          "requires": {
+                            "spdx-correct": "1.0.2",
+                            "spdx-expression-parse": "1.0.4"
+                          },
+                          "dependencies": {
+                            "spdx-correct": {
+                              "version": "1.0.2",
+                              "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/spdx-correct/-/spdx-correct-1.0.2.tgz",
+                              "integrity": "sha1-SzBz2TP/UfORLwOsVRlJikFQ20A=",
+                              "dev": true,
+                              "requires": {
+                                "spdx-license-ids": "1.2.2"
+                              },
+                              "dependencies": {
+                                "spdx-license-ids": {
+                                  "version": "1.2.2",
+                                  "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/spdx-license-ids/-/spdx-license-ids-1.2.2.tgz",
+                                  "integrity": "sha1-yd96NCRZSt5r0RkA1ZZpbcBrrFc=",
+                                  "dev": true
+                                }
+                              }
+                            },
+                            "spdx-expression-parse": {
+                              "version": "1.0.4",
+                              "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-1.0.4.tgz",
+                              "integrity": "sha1-m98vIOH0DtRH++JzJmGR/O1RYmw=",
+                              "dev": true
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "object-assign": {
+                      "version": "4.1.0",
+                      "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/object-assign/-/object-assign-4.1.0.tgz",
+                      "integrity": "sha1-ejs9DpgGPUP0wD8uiubNUahog6A=",
+                      "dev": true
+                    },
+                    "read-pkg-up": {
+                      "version": "1.0.1",
+                      "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
+                      "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
+                      "dev": true,
+                      "requires": {
+                        "find-up": "1.1.2",
+                        "read-pkg": "1.1.0"
+                      },
+                      "dependencies": {
+                        "find-up": {
+                          "version": "1.1.2",
+                          "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/find-up/-/find-up-1.1.2.tgz",
+                          "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
+                          "dev": true,
+                          "requires": {
+                            "path-exists": "2.1.0",
+                            "pinkie-promise": "2.0.1"
+                          },
+                          "dependencies": {
+                            "path-exists": {
+                              "version": "2.1.0",
+                              "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/path-exists/-/path-exists-2.1.0.tgz",
+                              "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
+                              "dev": true,
+                              "requires": {
+                                "pinkie-promise": "2.0.1"
+                              }
+                            },
+                            "pinkie-promise": {
+                              "version": "2.0.1",
+                              "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
+                              "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
+                              "dev": true,
+                              "requires": {
+                                "pinkie": "2.0.4"
+                              },
+                              "dependencies": {
+                                "pinkie": {
+                                  "version": "2.0.4",
+                                  "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/pinkie/-/pinkie-2.0.4.tgz",
+                                  "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA=",
+                                  "dev": true
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "read-pkg": {
+                          "version": "1.1.0",
+                          "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/read-pkg/-/read-pkg-1.1.0.tgz",
+                          "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
+                          "dev": true,
+                          "requires": {
+                            "load-json-file": "1.1.0",
+                            "normalize-package-data": "2.3.5",
+                            "path-type": "1.1.0"
+                          },
+                          "dependencies": {
+                            "load-json-file": {
+                              "version": "1.1.0",
+                              "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/load-json-file/-/load-json-file-1.1.0.tgz",
+                              "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
+                              "dev": true,
+                              "requires": {
+                                "graceful-fs": "4.1.9",
+                                "parse-json": "2.2.0",
+                                "pify": "2.3.0",
+                                "pinkie-promise": "2.0.1",
+                                "strip-bom": "2.0.0"
+                              },
+                              "dependencies": {
+                                "graceful-fs": {
+                                  "version": "4.1.9",
+                                  "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.9.tgz",
+                                  "integrity": "sha1-uqy6N9GdEfnRRtNXi8mZWMN4fik=",
+                                  "dev": true
+                                },
+                                "parse-json": {
+                                  "version": "2.2.0",
+                                  "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/parse-json/-/parse-json-2.2.0.tgz",
+                                  "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
+                                  "dev": true,
+                                  "requires": {
+                                    "error-ex": "1.3.0"
+                                  },
+                                  "dependencies": {
+                                    "error-ex": {
+                                      "version": "1.3.0",
+                                      "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/error-ex/-/error-ex-1.3.0.tgz",
+                                      "integrity": "sha1-5ntD8+gsluo6WE/+4Ln8MyXYAtk=",
+                                      "dev": true,
+                                      "requires": {
+                                        "is-arrayish": "0.2.1"
+                                      },
+                                      "dependencies": {
+                                        "is-arrayish": {
+                                          "version": "0.2.1",
+                                          "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/is-arrayish/-/is-arrayish-0.2.1.tgz",
+                                          "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
+                                          "dev": true
+                                        }
+                                      }
+                                    }
+                                  }
+                                },
+                                "pify": {
+                                  "version": "2.3.0",
+                                  "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/pify/-/pify-2.3.0.tgz",
+                                  "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
+                                  "dev": true
+                                },
+                                "pinkie-promise": {
+                                  "version": "2.0.1",
+                                  "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
+                                  "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
+                                  "dev": true,
+                                  "requires": {
+                                    "pinkie": "2.0.4"
+                                  },
+                                  "dependencies": {
+                                    "pinkie": {
+                                      "version": "2.0.4",
+                                      "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/pinkie/-/pinkie-2.0.4.tgz",
+                                      "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA=",
+                                      "dev": true
+                                    }
+                                  }
+                                },
+                                "strip-bom": {
+                                  "version": "2.0.0",
+                                  "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/strip-bom/-/strip-bom-2.0.0.tgz",
+                                  "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
+                                  "dev": true,
+                                  "requires": {
+                                    "is-utf8": "0.2.1"
+                                  },
+                                  "dependencies": {
+                                    "is-utf8": {
+                                      "version": "0.2.1",
+                                      "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/is-utf8/-/is-utf8-0.2.1.tgz",
+                                      "integrity": "sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI=",
+                                      "dev": true
+                                    }
+                                  }
+                                }
+                              }
+                            },
+                            "path-type": {
+                              "version": "1.1.0",
+                              "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/path-type/-/path-type-1.1.0.tgz",
+                              "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
+                              "dev": true,
+                              "requires": {
+                                "graceful-fs": "4.1.9",
+                                "pify": "2.3.0",
+                                "pinkie-promise": "2.0.1"
+                              },
+                              "dependencies": {
+                                "graceful-fs": {
+                                  "version": "4.1.9",
+                                  "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.9.tgz",
+                                  "integrity": "sha1-uqy6N9GdEfnRRtNXi8mZWMN4fik=",
+                                  "dev": true
+                                },
+                                "pify": {
+                                  "version": "2.3.0",
+                                  "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/pify/-/pify-2.3.0.tgz",
+                                  "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
+                                  "dev": true
+                                },
+                                "pinkie-promise": {
+                                  "version": "2.0.1",
+                                  "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
+                                  "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
+                                  "dev": true,
+                                  "requires": {
+                                    "pinkie": "2.0.4"
+                                  },
+                                  "dependencies": {
+                                    "pinkie": {
+                                      "version": "2.0.4",
+                                      "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/pinkie/-/pinkie-2.0.4.tgz",
+                                      "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA=",
+                                      "dev": true
+                                    }
+                                  }
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "redent": {
+                      "version": "1.0.0",
+                      "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/redent/-/redent-1.0.0.tgz",
+                      "integrity": "sha1-z5Fqsf1fHxbfsggi3W7H9zDCr94=",
+                      "dev": true,
+                      "requires": {
+                        "indent-string": "2.1.0",
+                        "strip-indent": "1.0.1"
+                      },
+                      "dependencies": {
+                        "indent-string": {
+                          "version": "2.1.0",
+                          "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/indent-string/-/indent-string-2.1.0.tgz",
+                          "integrity": "sha1-ji1INIdCEhtKghi3oTfppSBJ3IA=",
+                          "dev": true,
+                          "requires": {
+                            "repeating": "2.0.1"
+                          },
+                          "dependencies": {
+                            "repeating": {
+                              "version": "2.0.1",
+                              "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/repeating/-/repeating-2.0.1.tgz",
+                              "integrity": "sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo=",
+                              "dev": true,
+                              "requires": {
+                                "is-finite": "1.0.2"
+                              },
+                              "dependencies": {
+                                "is-finite": {
+                                  "version": "1.0.2",
+                                  "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.2.tgz",
+                                  "integrity": "sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko=",
+                                  "dev": true,
+                                  "requires": {
+                                    "number-is-nan": "1.0.1"
+                                  },
+                                  "dependencies": {
+                                    "number-is-nan": {
+                                      "version": "1.0.1",
+                                      "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
+                                      "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
+                                      "dev": true
+                                    }
+                                  }
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "strip-indent": {
+                          "version": "1.0.1",
+                          "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/strip-indent/-/strip-indent-1.0.1.tgz",
+                          "integrity": "sha1-DHlipq3vp7vUrDZkYKY4VSrhoKI=",
+                          "dev": true,
+                          "requires": {
+                            "get-stdin": "4.0.1"
+                          }
+                        }
+                      }
+                    },
+                    "trim-newlines": {
+                      "version": "1.0.0",
+                      "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/trim-newlines/-/trim-newlines-1.0.0.tgz",
+                      "integrity": "sha1-WIeWa7WCpFA6QetST301ARgVphM=",
+                      "dev": true
+                    }
+                  }
+                }
+              }
+            },
+            "fancy-log": {
+              "version": "1.2.0",
+              "resolved": "https://registry.npmjs.org/fancy-log/-/fancy-log-1.2.0.tgz",
+              "integrity": "sha1-1aUbU+mrIsoH1VjytnrlX9tfy9g=",
+              "dev": true,
+              "requires": {
+                "chalk": "1.1.3",
+                "time-stamp": "1.0.1"
+              },
+              "dependencies": {
+                "time-stamp": {
+                  "version": "1.0.1",
+                  "resolved": "https://registry.npmjs.org/time-stamp/-/time-stamp-1.0.1.tgz",
+                  "integrity": "sha1-n0vSNVnJNllm8zAtu6KwfGuZsVE=",
+                  "dev": true
+                }
+              }
+            },
+            "gulplog": {
+              "version": "1.0.0",
+              "resolved": "https://registry.npmjs.org/gulplog/-/gulplog-1.0.0.tgz",
+              "integrity": "sha1-4oxNRdBey77YGDY86PnFkmIp/+U=",
+              "dev": true,
+              "requires": {
+                "glogg": "1.0.0"
+              },
+              "dependencies": {
+                "glogg": {
+                  "version": "1.0.0",
+                  "resolved": "https://registry.npmjs.org/glogg/-/glogg-1.0.0.tgz",
+                  "integrity": "sha1-f+DxmfV6yQbPUS/urY+Q7kooT8U=",
+                  "dev": true,
+                  "requires": {
+                    "sparkles": "1.0.0"
+                  },
+                  "dependencies": {
+                    "sparkles": {
+                      "version": "1.0.0",
+                      "resolved": "https://registry.npmjs.org/sparkles/-/sparkles-1.0.0.tgz",
+                      "integrity": "sha1-Gsu/tZJDbRC76PeFt8xvgoFQEsM=",
+                      "dev": true
+                    }
+                  }
+                }
+              }
+            },
+            "has-gulplog": {
+              "version": "0.1.0",
+              "resolved": "https://registry.npmjs.org/has-gulplog/-/has-gulplog-0.1.0.tgz",
+              "integrity": "sha1-ZBTIKRNpfaUVkDl9r7EvIpZ4Ec4=",
+              "dev": true,
+              "requires": {
+                "sparkles": "1.0.0"
+              },
+              "dependencies": {
+                "sparkles": {
+                  "version": "1.0.0",
+                  "resolved": "https://registry.npmjs.org/sparkles/-/sparkles-1.0.0.tgz",
+                  "integrity": "sha1-Gsu/tZJDbRC76PeFt8xvgoFQEsM=",
+                  "dev": true
+                }
+              }
+            },
+            "lodash._reescape": {
+              "version": "3.0.0",
+              "resolved": "https://registry.npmjs.org/lodash._reescape/-/lodash._reescape-3.0.0.tgz",
+              "integrity": "sha1-Kx1vXf4HyKNVdT5fJ/rH8c3hYWo=",
+              "dev": true
+            },
+            "lodash._reevaluate": {
+              "version": "3.0.0",
+              "resolved": "https://registry.npmjs.org/lodash._reevaluate/-/lodash._reevaluate-3.0.0.tgz",
+              "integrity": "sha1-WLx0xAZklTrgsSTYBpltrKQx4u0=",
+              "dev": true
+            },
+            "lodash._reinterpolate": {
+              "version": "3.0.0",
+              "resolved": "https://registry.npmjs.org/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz",
+              "integrity": "sha1-DM8tiRZq8Ds2Y8eWU4t1rG4RTZ0=",
+              "dev": true
+            },
+            "lodash.template": {
+              "version": "3.6.2",
+              "resolved": "https://registry.npmjs.org/lodash.template/-/lodash.template-3.6.2.tgz",
+              "integrity": "sha1-+M3sxhaaJVvpCYrosMU9N4kx0U8=",
+              "dev": true,
+              "requires": {
+                "lodash._basecopy": "3.0.1",
+                "lodash._basetostring": "3.0.1",
+                "lodash._basevalues": "3.0.0",
+                "lodash._isiterateecall": "3.0.9",
+                "lodash._reinterpolate": "3.0.0",
+                "lodash.escape": "3.2.0",
+                "lodash.keys": "3.1.2",
+                "lodash.restparam": "3.6.1",
+                "lodash.templatesettings": "3.1.1"
+              },
+              "dependencies": {
+                "lodash._basecopy": {
+                  "version": "3.0.1",
+                  "resolved": "https://registry.npmjs.org/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz",
+                  "integrity": "sha1-jaDmqHbPNEwK2KVIghEd08XHyjY=",
+                  "dev": true
+                },
+                "lodash._basetostring": {
+                  "version": "3.0.1",
+                  "resolved": "https://registry.npmjs.org/lodash._basetostring/-/lodash._basetostring-3.0.1.tgz",
+                  "integrity": "sha1-0YYdh3+CSlL2aYMtyvPuFVZqB9U=",
+                  "dev": true
+                },
+                "lodash._basevalues": {
+                  "version": "3.0.0",
+                  "resolved": "https://registry.npmjs.org/lodash._basevalues/-/lodash._basevalues-3.0.0.tgz",
+                  "integrity": "sha1-W3dXYoAr3j0yl1A+JjAIIP32Ybc=",
+                  "dev": true
+                },
+                "lodash._isiterateecall": {
+                  "version": "3.0.9",
+                  "resolved": "https://registry.npmjs.org/lodash._isiterateecall/-/lodash._isiterateecall-3.0.9.tgz",
+                  "integrity": "sha1-UgOte6Ql+uhCRg5pbbnPPmqsBXw=",
+                  "dev": true
+                },
+                "lodash.escape": {
+                  "version": "3.2.0",
+                  "resolved": "https://registry.npmjs.org/lodash.escape/-/lodash.escape-3.2.0.tgz",
+                  "integrity": "sha1-mV7g3BjBtIzJLv+ucaEKq1tIdpg=",
+                  "dev": true,
+                  "requires": {
+                    "lodash._root": "3.0.1"
+                  },
+                  "dependencies": {
+                    "lodash._root": {
+                      "version": "3.0.1",
+                      "resolved": "https://registry.npmjs.org/lodash._root/-/lodash._root-3.0.1.tgz",
+                      "integrity": "sha1-+6HEUkwZ7ppfgTa0YJ8BfPTe1pI=",
+                      "dev": true
+                    }
+                  }
+                },
+                "lodash.keys": {
+                  "version": "3.1.2",
+                  "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/lodash.keys/-/lodash.keys-3.1.2.tgz",
+                  "integrity": "sha1-TbwEcrFWvlCgsoaFXRvQsMZWCYo=",
+                  "dev": true,
+                  "requires": {
+                    "lodash._getnative": "3.9.1",
+                    "lodash.isarguments": "3.1.0",
+                    "lodash.isarray": "3.0.4"
+                  },
+                  "dependencies": {
+                    "lodash._getnative": {
+                      "version": "3.9.1",
+                      "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/lodash._getnative/-/lodash._getnative-3.9.1.tgz",
+                      "integrity": "sha1-VwvH3t5G1hzc3mh9ZdPuy6o6r/U=",
+                      "dev": true
+                    },
+                    "lodash.isarguments": {
+                      "version": "3.1.0",
+                      "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
+                      "integrity": "sha1-L1c9hcaiQon/AGY7SRwdM4/zRYo=",
+                      "dev": true
+                    },
+                    "lodash.isarray": {
+                      "version": "3.0.4",
+                      "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/lodash.isarray/-/lodash.isarray-3.0.4.tgz",
+                      "integrity": "sha1-eeTriMNqgSKvhvhEqpvNhRtfu1U=",
+                      "dev": true
+                    }
+                  }
+                },
+                "lodash.restparam": {
+                  "version": "3.6.1",
+                  "resolved": "https://registry.npmjs.org/lodash.restparam/-/lodash.restparam-3.6.1.tgz",
+                  "integrity": "sha1-k2pOMJ7zMKdkXtQUWYbIWuWyCAU=",
+                  "dev": true
+                },
+                "lodash.templatesettings": {
+                  "version": "3.1.1",
+                  "resolved": "https://registry.npmjs.org/lodash.templatesettings/-/lodash.templatesettings-3.1.1.tgz",
+                  "integrity": "sha1-+zB4RHU7Zrnxr6VOJix0UwfbqOU=",
+                  "dev": true,
+                  "requires": {
+                    "lodash._reinterpolate": "3.0.0",
+                    "lodash.escape": "3.2.0"
+                  }
+                }
+              }
+            },
+            "minimist": {
+              "version": "1.2.0",
+              "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/minimist/-/minimist-1.2.0.tgz",
+              "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+              "dev": true
+            },
+            "multipipe": {
+              "version": "0.1.2",
+              "resolved": "https://registry.npmjs.org/multipipe/-/multipipe-0.1.2.tgz",
+              "integrity": "sha1-Ko8t33Du1WTf8tV/HhoTfZ8FB4s=",
+              "dev": true,
+              "requires": {
+                "duplexer2": "0.0.2"
+              },
+              "dependencies": {
+                "duplexer2": {
+                  "version": "0.0.2",
+                  "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.0.2.tgz",
+                  "integrity": "sha1-xhTc9n4vsUmVqRcR5aYX6KYKMds=",
+                  "dev": true,
+                  "requires": {
+                    "readable-stream": "1.1.14"
+                  },
+                  "dependencies": {
+                    "readable-stream": {
+                      "version": "1.1.14",
+                      "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/readable-stream/-/readable-stream-1.1.14.tgz",
+                      "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
+                      "dev": true,
+                      "requires": {
+                        "core-util-is": "1.0.2",
+                        "inherits": "2.0.3",
+                        "isarray": "0.0.1",
+                        "string_decoder": "0.10.31"
+                      },
+                      "dependencies": {
+                        "core-util-is": {
+                          "version": "1.0.2",
+                          "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/core-util-is/-/core-util-is-1.0.2.tgz",
+                          "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
+                          "dev": true
+                        },
+                        "inherits": {
+                          "version": "2.0.3",
+                          "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/inherits/-/inherits-2.0.3.tgz",
+                          "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+                          "dev": true
+                        },
+                        "isarray": {
+                          "version": "0.0.1",
+                          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+                          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
+                          "dev": true
+                        },
+                        "string_decoder": {
+                          "version": "0.10.31",
+                          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+                          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
+                          "dev": true
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "object-assign": {
+              "version": "3.0.0",
+              "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/object-assign/-/object-assign-3.0.0.tgz",
+              "integrity": "sha1-m+3VygiXlJvKR+f/QIBi1Un1h/I=",
+              "dev": true
+            },
+            "replace-ext": {
+              "version": "0.0.1",
+              "resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-0.0.1.tgz",
+              "integrity": "sha1-KbvZIHinOfC8zitO5B6DeVNSKSQ=",
+              "dev": true
+            },
+            "through2": {
+              "version": "2.0.1",
+              "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/through2/-/through2-2.0.1.tgz",
+              "integrity": "sha1-OE51MU1J8y3hLuu4E2uOtrXVnak=",
+              "dev": true,
+              "requires": {
+                "readable-stream": "2.0.6",
+                "xtend": "4.0.1"
+              },
+              "dependencies": {
+                "readable-stream": {
+                  "version": "2.0.6",
+                  "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/readable-stream/-/readable-stream-2.0.6.tgz",
+                  "integrity": "sha1-j5A0HmilPMySh4jaz80Rs265t44=",
+                  "dev": true,
+                  "requires": {
+                    "core-util-is": "1.0.2",
+                    "inherits": "2.0.3",
+                    "isarray": "1.0.0",
+                    "process-nextick-args": "1.0.7",
+                    "string_decoder": "0.10.31",
+                    "util-deprecate": "1.0.2"
+                  },
+                  "dependencies": {
+                    "core-util-is": {
+                      "version": "1.0.2",
+                      "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/core-util-is/-/core-util-is-1.0.2.tgz",
+                      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
+                      "dev": true
+                    },
+                    "inherits": {
+                      "version": "2.0.3",
+                      "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/inherits/-/inherits-2.0.3.tgz",
+                      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+                      "dev": true
+                    },
+                    "isarray": {
+                      "version": "1.0.0",
+                      "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/isarray/-/isarray-1.0.0.tgz",
+                      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+                      "dev": true
+                    },
+                    "process-nextick-args": {
+                      "version": "1.0.7",
+                      "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
+                      "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M=",
+                      "dev": true
+                    },
+                    "string_decoder": {
+                      "version": "0.10.31",
+                      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+                      "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
+                      "dev": true
+                    },
+                    "util-deprecate": {
+                      "version": "1.0.2",
+                      "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/util-deprecate/-/util-deprecate-1.0.2.tgz",
+                      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
+                      "dev": true
+                    }
+                  }
+                },
+                "xtend": {
+                  "version": "4.0.1",
+                  "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/xtend/-/xtend-4.0.1.tgz",
+                  "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68=",
+                  "dev": true
+                }
+              }
+            },
+            "vinyl": {
+              "version": "0.5.3",
+              "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-0.5.3.tgz",
+              "integrity": "sha1-sEVbOPxeDPMNQyUTLkYZcMIJHN4=",
+              "dev": true,
+              "requires": {
+                "clone": "1.0.2",
+                "clone-stats": "0.0.1",
+                "replace-ext": "0.0.1"
+              },
+              "dependencies": {
+                "clone": {
+                  "version": "1.0.2",
+                  "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/clone/-/clone-1.0.2.tgz",
+                  "integrity": "sha1-Jgt6meux7f4kdTgXX3gyQ8sZ0Uk=",
+                  "dev": true
+                },
+                "clone-stats": {
+                  "version": "0.0.1",
+                  "resolved": "https://registry.npmjs.org/clone-stats/-/clone-stats-0.0.1.tgz",
+                  "integrity": "sha1-uI+UqCzzi4eR1YBG6kAprYjKmdE=",
+                  "dev": true
+                }
+              }
+            }
+          }
+        },
+        "object-assign": {
+          "version": "4.1.0",
+          "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/object-assign/-/object-assign-4.1.0.tgz",
+          "integrity": "sha1-ejs9DpgGPUP0wD8uiubNUahog6A=",
+          "dev": true
+        }
+      }
+    },
+    "gulp-gh-pages": {
+      "version": "0.5.4",
+      "resolved": "https://registry.npmjs.org/gulp-gh-pages/-/gulp-gh-pages-0.5.4.tgz",
+      "integrity": "sha1-pnMspHWrm1pTJTwcJHNMQMIbZUY=",
+      "dev": true,
+      "requires": {
+        "gift": "0.6.1",
+        "gulp-util": "3.0.7",
+        "readable-stream": "2.1.5",
+        "rimraf": "2.5.4",
+        "vinyl-fs": "2.4.3",
+        "wrap-promise": "1.0.1"
+      },
+      "dependencies": {
+        "gift": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/gift/-/gift-0.6.1.tgz",
+          "integrity": "sha1-wWmOa2iHFk7ZeKAQlUI8/2W4558=",
+          "dev": true,
+          "requires": {
+            "underscore": "1.8.3"
+          },
+          "dependencies": {
+            "underscore": {
+              "version": "1.8.3",
+              "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.8.3.tgz",
+              "integrity": "sha1-Tz+1OxBuYJf8+ctBCfKl6b36UCI=",
+              "dev": true
+            }
+          }
+        },
+        "gulp-util": {
+          "version": "3.0.7",
+          "resolved": "https://registry.npmjs.org/gulp-util/-/gulp-util-3.0.7.tgz",
+          "integrity": "sha1-eJJcS4+LSQBawBoBHFV+YhiUHLs=",
+          "dev": true,
+          "requires": {
+            "array-differ": "1.0.0",
+            "array-uniq": "1.0.3",
+            "beeper": "1.1.0",
+            "chalk": "1.1.3",
+            "dateformat": "1.0.12",
+            "fancy-log": "1.2.0",
+            "gulplog": "1.0.0",
+            "has-gulplog": "0.1.0",
+            "lodash._reescape": "3.0.0",
+            "lodash._reevaluate": "3.0.0",
+            "lodash._reinterpolate": "3.0.0",
+            "lodash.template": "3.6.2",
+            "minimist": "1.2.0",
+            "multipipe": "0.1.2",
+            "object-assign": "3.0.0",
+            "replace-ext": "0.0.1",
+            "through2": "2.0.1",
+            "vinyl": "0.5.3"
+          },
+          "dependencies": {
+            "array-differ": {
+              "version": "1.0.0",
+              "resolved": "https://registry.npmjs.org/array-differ/-/array-differ-1.0.0.tgz",
+              "integrity": "sha1-7/UuN1gknTO+QCuLuOVkuytdQDE=",
+              "dev": true
+            },
+            "array-uniq": {
+              "version": "1.0.3",
+              "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/array-uniq/-/array-uniq-1.0.3.tgz",
+              "integrity": "sha1-r2rId6Jcx/dOBYiUdThY39sk/bY=",
+              "dev": true
+            },
+            "beeper": {
+              "version": "1.1.0",
+              "resolved": "https://registry.npmjs.org/beeper/-/beeper-1.1.0.tgz",
+              "integrity": "sha1-nub8HOf1T+qs585zWIsFYDeGaiw=",
+              "dev": true
+            },
+            "chalk": {
+              "version": "1.1.3",
+              "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/chalk/-/chalk-1.1.3.tgz",
+              "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+              "dev": true,
+              "requires": {
+                "ansi-styles": "2.2.1",
+                "escape-string-regexp": "1.0.5",
+                "has-ansi": "2.0.0",
+                "strip-ansi": "3.0.1",
+                "supports-color": "2.0.0"
+              },
+              "dependencies": {
+                "ansi-styles": {
+                  "version": "2.2.1",
+                  "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/ansi-styles/-/ansi-styles-2.2.1.tgz",
+                  "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+                  "dev": true
+                },
+                "escape-string-regexp": {
+                  "version": "1.0.5",
+                  "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+                  "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+                  "dev": true
+                },
+                "has-ansi": {
+                  "version": "2.0.0",
+                  "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/has-ansi/-/has-ansi-2.0.0.tgz",
+                  "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
+                  "dev": true,
+                  "requires": {
+                    "ansi-regex": "2.0.0"
+                  },
+                  "dependencies": {
+                    "ansi-regex": {
+                      "version": "2.0.0",
+                      "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/ansi-regex/-/ansi-regex-2.0.0.tgz",
+                      "integrity": "sha1-xQYbbg74qBd15Q9dZhUb9r83EQc=",
+                      "dev": true
+                    }
+                  }
+                },
+                "strip-ansi": {
+                  "version": "3.0.1",
+                  "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/strip-ansi/-/strip-ansi-3.0.1.tgz",
+                  "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+                  "dev": true,
+                  "requires": {
+                    "ansi-regex": "2.0.0"
+                  },
+                  "dependencies": {
+                    "ansi-regex": {
+                      "version": "2.0.0",
+                      "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/ansi-regex/-/ansi-regex-2.0.0.tgz",
+                      "integrity": "sha1-xQYbbg74qBd15Q9dZhUb9r83EQc=",
+                      "dev": true
+                    }
+                  }
+                },
+                "supports-color": {
+                  "version": "2.0.0",
+                  "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/supports-color/-/supports-color-2.0.0.tgz",
+                  "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+                  "dev": true
+                }
+              }
+            },
+            "dateformat": {
+              "version": "1.0.12",
+              "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-1.0.12.tgz",
+              "integrity": "sha1-nxJLZ1lMk3/3BpMuSmQsyo27/uk=",
+              "dev": true,
+              "requires": {
+                "get-stdin": "4.0.1",
+                "meow": "3.7.0"
+              },
+              "dependencies": {
+                "get-stdin": {
+                  "version": "4.0.1",
+                  "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz",
+                  "integrity": "sha1-uWjGsKBDhDJJAui/Gl3zJXmkUP4=",
+                  "dev": true
+                },
+                "meow": {
+                  "version": "3.7.0",
+                  "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/meow/-/meow-3.7.0.tgz",
+                  "integrity": "sha1-cstmi0JSKCkKu/qFaJJYcwioAfs=",
+                  "dev": true,
+                  "requires": {
+                    "camelcase-keys": "2.1.0",
+                    "decamelize": "1.2.0",
+                    "loud-rejection": "1.6.0",
+                    "map-obj": "1.0.1",
+                    "minimist": "1.2.0",
+                    "normalize-package-data": "2.3.5",
+                    "object-assign": "4.1.0",
+                    "read-pkg-up": "1.0.1",
+                    "redent": "1.0.0",
+                    "trim-newlines": "1.0.0"
+                  },
+                  "dependencies": {
+                    "camelcase-keys": {
+                      "version": "2.1.0",
+                      "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/camelcase-keys/-/camelcase-keys-2.1.0.tgz",
+                      "integrity": "sha1-MIvur/3ygRkFHvodkyITyRuPkuc=",
+                      "dev": true,
+                      "requires": {
+                        "camelcase": "2.1.1",
+                        "map-obj": "1.0.1"
+                      },
+                      "dependencies": {
+                        "camelcase": {
+                          "version": "2.1.1",
+                          "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/camelcase/-/camelcase-2.1.1.tgz",
+                          "integrity": "sha1-fB0W1nmhu+WcoCys7PsBHiAfWh8=",
+                          "dev": true
+                        }
+                      }
+                    },
+                    "decamelize": {
+                      "version": "1.2.0",
+                      "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/decamelize/-/decamelize-1.2.0.tgz",
+                      "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
+                      "dev": true
+                    },
+                    "loud-rejection": {
+                      "version": "1.6.0",
+                      "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/loud-rejection/-/loud-rejection-1.6.0.tgz",
+                      "integrity": "sha1-W0b4AUft7leIcPCG0Eghz5mOVR8=",
+                      "dev": true,
+                      "requires": {
+                        "currently-unhandled": "0.4.1",
+                        "signal-exit": "3.0.1"
+                      },
+                      "dependencies": {
+                        "currently-unhandled": {
+                          "version": "0.4.1",
+                          "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/currently-unhandled/-/currently-unhandled-0.4.1.tgz",
+                          "integrity": "sha1-mI3zP+qxke95mmE2nddsF635V+o=",
+                          "dev": true,
+                          "requires": {
+                            "array-find-index": "1.0.2"
+                          },
+                          "dependencies": {
+                            "array-find-index": {
+                              "version": "1.0.2",
+                              "resolved": "https://registry.npmjs.org/array-find-index/-/array-find-index-1.0.2.tgz",
+                              "integrity": "sha1-3wEKoSh+Fku9pvlyOwqWoexBh6E=",
+                              "dev": true
+                            }
+                          }
+                        },
+                        "signal-exit": {
+                          "version": "3.0.1",
+                          "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.1.tgz",
+                          "integrity": "sha1-WkyISZK2OnrNm623iUw+6c/MrYE=",
+                          "dev": true
+                        }
+                      }
+                    },
+                    "map-obj": {
+                      "version": "1.0.1",
+                      "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
+                      "integrity": "sha1-2TPOuSBdgr3PSIb2dCvcK03qFG0=",
+                      "dev": true
+                    },
+                    "normalize-package-data": {
+                      "version": "2.3.5",
+                      "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/normalize-package-data/-/normalize-package-data-2.3.5.tgz",
+                      "integrity": "sha1-jZJPFClg4Xd+f/4XBUNjHMfLAt8=",
+                      "dev": true,
+                      "requires": {
+                        "hosted-git-info": "2.1.5",
+                        "is-builtin-module": "1.0.0",
+                        "semver": "5.3.0",
+                        "validate-npm-package-license": "3.0.1"
+                      },
+                      "dependencies": {
+                        "hosted-git-info": {
+                          "version": "2.1.5",
+                          "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/hosted-git-info/-/hosted-git-info-2.1.5.tgz",
+                          "integrity": "sha1-C6gdkNouJas0ozLm7HeTbhWYEYs=",
+                          "dev": true
+                        },
+                        "is-builtin-module": {
+                          "version": "1.0.0",
+                          "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
+                          "integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
+                          "dev": true,
+                          "requires": {
+                            "builtin-modules": "1.1.1"
+                          },
+                          "dependencies": {
+                            "builtin-modules": {
+                              "version": "1.1.1",
+                              "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/builtin-modules/-/builtin-modules-1.1.1.tgz",
+                              "integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8=",
+                              "dev": true
+                            }
+                          }
+                        },
+                        "validate-npm-package-license": {
+                          "version": "3.0.1",
+                          "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/validate-npm-package-license/-/validate-npm-package-license-3.0.1.tgz",
+                          "integrity": "sha1-KAS6vnEq0zeUWaz74kdGqywwP7w=",
+                          "dev": true,
+                          "requires": {
+                            "spdx-correct": "1.0.2",
+                            "spdx-expression-parse": "1.0.4"
+                          },
+                          "dependencies": {
+                            "spdx-correct": {
+                              "version": "1.0.2",
+                              "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/spdx-correct/-/spdx-correct-1.0.2.tgz",
+                              "integrity": "sha1-SzBz2TP/UfORLwOsVRlJikFQ20A=",
+                              "dev": true,
+                              "requires": {
+                                "spdx-license-ids": "1.2.2"
+                              },
+                              "dependencies": {
+                                "spdx-license-ids": {
+                                  "version": "1.2.2",
+                                  "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/spdx-license-ids/-/spdx-license-ids-1.2.2.tgz",
+                                  "integrity": "sha1-yd96NCRZSt5r0RkA1ZZpbcBrrFc=",
+                                  "dev": true
+                                }
+                              }
+                            },
+                            "spdx-expression-parse": {
+                              "version": "1.0.4",
+                              "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-1.0.4.tgz",
+                              "integrity": "sha1-m98vIOH0DtRH++JzJmGR/O1RYmw=",
+                              "dev": true
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "object-assign": {
+                      "version": "4.1.0",
+                      "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/object-assign/-/object-assign-4.1.0.tgz",
+                      "integrity": "sha1-ejs9DpgGPUP0wD8uiubNUahog6A=",
+                      "dev": true
+                    },
+                    "read-pkg-up": {
+                      "version": "1.0.1",
+                      "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
+                      "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
+                      "dev": true,
+                      "requires": {
+                        "find-up": "1.1.2",
+                        "read-pkg": "1.1.0"
+                      },
+                      "dependencies": {
+                        "find-up": {
+                          "version": "1.1.2",
+                          "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/find-up/-/find-up-1.1.2.tgz",
+                          "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
+                          "dev": true,
+                          "requires": {
+                            "path-exists": "2.1.0",
+                            "pinkie-promise": "2.0.1"
+                          },
+                          "dependencies": {
+                            "path-exists": {
+                              "version": "2.1.0",
+                              "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/path-exists/-/path-exists-2.1.0.tgz",
+                              "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
+                              "dev": true,
+                              "requires": {
+                                "pinkie-promise": "2.0.1"
+                              }
+                            },
+                            "pinkie-promise": {
+                              "version": "2.0.1",
+                              "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
+                              "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
+                              "dev": true,
+                              "requires": {
+                                "pinkie": "2.0.4"
+                              },
+                              "dependencies": {
+                                "pinkie": {
+                                  "version": "2.0.4",
+                                  "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/pinkie/-/pinkie-2.0.4.tgz",
+                                  "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA=",
+                                  "dev": true
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "read-pkg": {
+                          "version": "1.1.0",
+                          "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/read-pkg/-/read-pkg-1.1.0.tgz",
+                          "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
+                          "dev": true,
+                          "requires": {
+                            "load-json-file": "1.1.0",
+                            "normalize-package-data": "2.3.5",
+                            "path-type": "1.1.0"
+                          },
+                          "dependencies": {
+                            "load-json-file": {
+                              "version": "1.1.0",
+                              "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/load-json-file/-/load-json-file-1.1.0.tgz",
+                              "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
+                              "dev": true,
+                              "requires": {
+                                "graceful-fs": "4.1.9",
+                                "parse-json": "2.2.0",
+                                "pify": "2.3.0",
+                                "pinkie-promise": "2.0.1",
+                                "strip-bom": "2.0.0"
+                              },
+                              "dependencies": {
+                                "graceful-fs": {
+                                  "version": "4.1.9",
+                                  "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.9.tgz",
+                                  "integrity": "sha1-uqy6N9GdEfnRRtNXi8mZWMN4fik=",
+                                  "dev": true
+                                },
+                                "parse-json": {
+                                  "version": "2.2.0",
+                                  "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/parse-json/-/parse-json-2.2.0.tgz",
+                                  "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
+                                  "dev": true,
+                                  "requires": {
+                                    "error-ex": "1.3.0"
+                                  },
+                                  "dependencies": {
+                                    "error-ex": {
+                                      "version": "1.3.0",
+                                      "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/error-ex/-/error-ex-1.3.0.tgz",
+                                      "integrity": "sha1-5ntD8+gsluo6WE/+4Ln8MyXYAtk=",
+                                      "dev": true,
+                                      "requires": {
+                                        "is-arrayish": "0.2.1"
+                                      },
+                                      "dependencies": {
+                                        "is-arrayish": {
+                                          "version": "0.2.1",
+                                          "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/is-arrayish/-/is-arrayish-0.2.1.tgz",
+                                          "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
+                                          "dev": true
+                                        }
+                                      }
+                                    }
+                                  }
+                                },
+                                "pify": {
+                                  "version": "2.3.0",
+                                  "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/pify/-/pify-2.3.0.tgz",
+                                  "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
+                                  "dev": true
+                                },
+                                "pinkie-promise": {
+                                  "version": "2.0.1",
+                                  "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
+                                  "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
+                                  "dev": true,
+                                  "requires": {
+                                    "pinkie": "2.0.4"
+                                  },
+                                  "dependencies": {
+                                    "pinkie": {
+                                      "version": "2.0.4",
+                                      "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/pinkie/-/pinkie-2.0.4.tgz",
+                                      "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA=",
+                                      "dev": true
+                                    }
+                                  }
+                                },
+                                "strip-bom": {
+                                  "version": "2.0.0",
+                                  "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/strip-bom/-/strip-bom-2.0.0.tgz",
+                                  "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
+                                  "dev": true,
+                                  "requires": {
+                                    "is-utf8": "0.2.1"
+                                  },
+                                  "dependencies": {
+                                    "is-utf8": {
+                                      "version": "0.2.1",
+                                      "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/is-utf8/-/is-utf8-0.2.1.tgz",
+                                      "integrity": "sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI=",
+                                      "dev": true
+                                    }
+                                  }
+                                }
+                              }
+                            },
+                            "path-type": {
+                              "version": "1.1.0",
+                              "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/path-type/-/path-type-1.1.0.tgz",
+                              "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
+                              "dev": true,
+                              "requires": {
+                                "graceful-fs": "4.1.9",
+                                "pify": "2.3.0",
+                                "pinkie-promise": "2.0.1"
+                              },
+                              "dependencies": {
+                                "graceful-fs": {
+                                  "version": "4.1.9",
+                                  "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.9.tgz",
+                                  "integrity": "sha1-uqy6N9GdEfnRRtNXi8mZWMN4fik=",
+                                  "dev": true
+                                },
+                                "pify": {
+                                  "version": "2.3.0",
+                                  "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/pify/-/pify-2.3.0.tgz",
+                                  "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
+                                  "dev": true
+                                },
+                                "pinkie-promise": {
+                                  "version": "2.0.1",
+                                  "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
+                                  "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
+                                  "dev": true,
+                                  "requires": {
+                                    "pinkie": "2.0.4"
+                                  },
+                                  "dependencies": {
+                                    "pinkie": {
+                                      "version": "2.0.4",
+                                      "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/pinkie/-/pinkie-2.0.4.tgz",
+                                      "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA=",
+                                      "dev": true
+                                    }
+                                  }
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "redent": {
+                      "version": "1.0.0",
+                      "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/redent/-/redent-1.0.0.tgz",
+                      "integrity": "sha1-z5Fqsf1fHxbfsggi3W7H9zDCr94=",
+                      "dev": true,
+                      "requires": {
+                        "indent-string": "2.1.0",
+                        "strip-indent": "1.0.1"
+                      },
+                      "dependencies": {
+                        "indent-string": {
+                          "version": "2.1.0",
+                          "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/indent-string/-/indent-string-2.1.0.tgz",
+                          "integrity": "sha1-ji1INIdCEhtKghi3oTfppSBJ3IA=",
+                          "dev": true,
+                          "requires": {
+                            "repeating": "2.0.1"
+                          },
+                          "dependencies": {
+                            "repeating": {
+                              "version": "2.0.1",
+                              "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/repeating/-/repeating-2.0.1.tgz",
+                              "integrity": "sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo=",
+                              "dev": true,
+                              "requires": {
+                                "is-finite": "1.0.2"
+                              },
+                              "dependencies": {
+                                "is-finite": {
+                                  "version": "1.0.2",
+                                  "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.2.tgz",
+                                  "integrity": "sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko=",
+                                  "dev": true,
+                                  "requires": {
+                                    "number-is-nan": "1.0.1"
+                                  },
+                                  "dependencies": {
+                                    "number-is-nan": {
+                                      "version": "1.0.1",
+                                      "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
+                                      "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
+                                      "dev": true
+                                    }
+                                  }
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "strip-indent": {
+                          "version": "1.0.1",
+                          "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/strip-indent/-/strip-indent-1.0.1.tgz",
+                          "integrity": "sha1-DHlipq3vp7vUrDZkYKY4VSrhoKI=",
+                          "dev": true,
+                          "requires": {
+                            "get-stdin": "4.0.1"
+                          }
+                        }
+                      }
+                    },
+                    "trim-newlines": {
+                      "version": "1.0.0",
+                      "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/trim-newlines/-/trim-newlines-1.0.0.tgz",
+                      "integrity": "sha1-WIeWa7WCpFA6QetST301ARgVphM=",
+                      "dev": true
+                    }
+                  }
+                }
+              }
+            },
+            "fancy-log": {
+              "version": "1.2.0",
+              "resolved": "https://registry.npmjs.org/fancy-log/-/fancy-log-1.2.0.tgz",
+              "integrity": "sha1-1aUbU+mrIsoH1VjytnrlX9tfy9g=",
+              "dev": true,
+              "requires": {
+                "chalk": "1.1.3",
+                "time-stamp": "1.0.1"
+              },
+              "dependencies": {
+                "time-stamp": {
+                  "version": "1.0.1",
+                  "resolved": "https://registry.npmjs.org/time-stamp/-/time-stamp-1.0.1.tgz",
+                  "integrity": "sha1-n0vSNVnJNllm8zAtu6KwfGuZsVE=",
+                  "dev": true
+                }
+              }
+            },
+            "gulplog": {
+              "version": "1.0.0",
+              "resolved": "https://registry.npmjs.org/gulplog/-/gulplog-1.0.0.tgz",
+              "integrity": "sha1-4oxNRdBey77YGDY86PnFkmIp/+U=",
+              "dev": true,
+              "requires": {
+                "glogg": "1.0.0"
+              },
+              "dependencies": {
+                "glogg": {
+                  "version": "1.0.0",
+                  "resolved": "https://registry.npmjs.org/glogg/-/glogg-1.0.0.tgz",
+                  "integrity": "sha1-f+DxmfV6yQbPUS/urY+Q7kooT8U=",
+                  "dev": true,
+                  "requires": {
+                    "sparkles": "1.0.0"
+                  },
+                  "dependencies": {
+                    "sparkles": {
+                      "version": "1.0.0",
+                      "resolved": "https://registry.npmjs.org/sparkles/-/sparkles-1.0.0.tgz",
+                      "integrity": "sha1-Gsu/tZJDbRC76PeFt8xvgoFQEsM=",
+                      "dev": true
+                    }
+                  }
+                }
+              }
+            },
+            "has-gulplog": {
+              "version": "0.1.0",
+              "resolved": "https://registry.npmjs.org/has-gulplog/-/has-gulplog-0.1.0.tgz",
+              "integrity": "sha1-ZBTIKRNpfaUVkDl9r7EvIpZ4Ec4=",
+              "dev": true,
+              "requires": {
+                "sparkles": "1.0.0"
+              },
+              "dependencies": {
+                "sparkles": {
+                  "version": "1.0.0",
+                  "resolved": "https://registry.npmjs.org/sparkles/-/sparkles-1.0.0.tgz",
+                  "integrity": "sha1-Gsu/tZJDbRC76PeFt8xvgoFQEsM=",
+                  "dev": true
+                }
+              }
+            },
+            "lodash._reescape": {
+              "version": "3.0.0",
+              "resolved": "https://registry.npmjs.org/lodash._reescape/-/lodash._reescape-3.0.0.tgz",
+              "integrity": "sha1-Kx1vXf4HyKNVdT5fJ/rH8c3hYWo=",
+              "dev": true
+            },
+            "lodash._reevaluate": {
+              "version": "3.0.0",
+              "resolved": "https://registry.npmjs.org/lodash._reevaluate/-/lodash._reevaluate-3.0.0.tgz",
+              "integrity": "sha1-WLx0xAZklTrgsSTYBpltrKQx4u0=",
+              "dev": true
+            },
+            "lodash._reinterpolate": {
+              "version": "3.0.0",
+              "resolved": "https://registry.npmjs.org/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz",
+              "integrity": "sha1-DM8tiRZq8Ds2Y8eWU4t1rG4RTZ0=",
+              "dev": true
+            },
+            "lodash.template": {
+              "version": "3.6.2",
+              "resolved": "https://registry.npmjs.org/lodash.template/-/lodash.template-3.6.2.tgz",
+              "integrity": "sha1-+M3sxhaaJVvpCYrosMU9N4kx0U8=",
+              "dev": true,
+              "requires": {
+                "lodash._basecopy": "3.0.1",
+                "lodash._basetostring": "3.0.1",
+                "lodash._basevalues": "3.0.0",
+                "lodash._isiterateecall": "3.0.9",
+                "lodash._reinterpolate": "3.0.0",
+                "lodash.escape": "3.2.0",
+                "lodash.keys": "3.1.2",
+                "lodash.restparam": "3.6.1",
+                "lodash.templatesettings": "3.1.1"
+              },
+              "dependencies": {
+                "lodash._basecopy": {
+                  "version": "3.0.1",
+                  "resolved": "https://registry.npmjs.org/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz",
+                  "integrity": "sha1-jaDmqHbPNEwK2KVIghEd08XHyjY=",
+                  "dev": true
+                },
+                "lodash._basetostring": {
+                  "version": "3.0.1",
+                  "resolved": "https://registry.npmjs.org/lodash._basetostring/-/lodash._basetostring-3.0.1.tgz",
+                  "integrity": "sha1-0YYdh3+CSlL2aYMtyvPuFVZqB9U=",
+                  "dev": true
+                },
+                "lodash._basevalues": {
+                  "version": "3.0.0",
+                  "resolved": "https://registry.npmjs.org/lodash._basevalues/-/lodash._basevalues-3.0.0.tgz",
+                  "integrity": "sha1-W3dXYoAr3j0yl1A+JjAIIP32Ybc=",
+                  "dev": true
+                },
+                "lodash._isiterateecall": {
+                  "version": "3.0.9",
+                  "resolved": "https://registry.npmjs.org/lodash._isiterateecall/-/lodash._isiterateecall-3.0.9.tgz",
+                  "integrity": "sha1-UgOte6Ql+uhCRg5pbbnPPmqsBXw=",
+                  "dev": true
+                },
+                "lodash.escape": {
+                  "version": "3.2.0",
+                  "resolved": "https://registry.npmjs.org/lodash.escape/-/lodash.escape-3.2.0.tgz",
+                  "integrity": "sha1-mV7g3BjBtIzJLv+ucaEKq1tIdpg=",
+                  "dev": true,
+                  "requires": {
+                    "lodash._root": "3.0.1"
+                  },
+                  "dependencies": {
+                    "lodash._root": {
+                      "version": "3.0.1",
+                      "resolved": "https://registry.npmjs.org/lodash._root/-/lodash._root-3.0.1.tgz",
+                      "integrity": "sha1-+6HEUkwZ7ppfgTa0YJ8BfPTe1pI=",
+                      "dev": true
+                    }
+                  }
+                },
+                "lodash.keys": {
+                  "version": "3.1.2",
+                  "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/lodash.keys/-/lodash.keys-3.1.2.tgz",
+                  "integrity": "sha1-TbwEcrFWvlCgsoaFXRvQsMZWCYo=",
+                  "dev": true,
+                  "requires": {
+                    "lodash._getnative": "3.9.1",
+                    "lodash.isarguments": "3.1.0",
+                    "lodash.isarray": "3.0.4"
+                  },
+                  "dependencies": {
+                    "lodash._getnative": {
+                      "version": "3.9.1",
+                      "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/lodash._getnative/-/lodash._getnative-3.9.1.tgz",
+                      "integrity": "sha1-VwvH3t5G1hzc3mh9ZdPuy6o6r/U=",
+                      "dev": true
+                    },
+                    "lodash.isarguments": {
+                      "version": "3.1.0",
+                      "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
+                      "integrity": "sha1-L1c9hcaiQon/AGY7SRwdM4/zRYo=",
+                      "dev": true
+                    },
+                    "lodash.isarray": {
+                      "version": "3.0.4",
+                      "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/lodash.isarray/-/lodash.isarray-3.0.4.tgz",
+                      "integrity": "sha1-eeTriMNqgSKvhvhEqpvNhRtfu1U=",
+                      "dev": true
+                    }
+                  }
+                },
+                "lodash.restparam": {
+                  "version": "3.6.1",
+                  "resolved": "https://registry.npmjs.org/lodash.restparam/-/lodash.restparam-3.6.1.tgz",
+                  "integrity": "sha1-k2pOMJ7zMKdkXtQUWYbIWuWyCAU=",
+                  "dev": true
+                },
+                "lodash.templatesettings": {
+                  "version": "3.1.1",
+                  "resolved": "https://registry.npmjs.org/lodash.templatesettings/-/lodash.templatesettings-3.1.1.tgz",
+                  "integrity": "sha1-+zB4RHU7Zrnxr6VOJix0UwfbqOU=",
+                  "dev": true,
+                  "requires": {
+                    "lodash._reinterpolate": "3.0.0",
+                    "lodash.escape": "3.2.0"
+                  }
+                }
+              }
+            },
+            "minimist": {
+              "version": "1.2.0",
+              "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/minimist/-/minimist-1.2.0.tgz",
+              "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+              "dev": true
+            },
+            "multipipe": {
+              "version": "0.1.2",
+              "resolved": "https://registry.npmjs.org/multipipe/-/multipipe-0.1.2.tgz",
+              "integrity": "sha1-Ko8t33Du1WTf8tV/HhoTfZ8FB4s=",
+              "dev": true,
+              "requires": {
+                "duplexer2": "0.0.2"
+              },
+              "dependencies": {
+                "duplexer2": {
+                  "version": "0.0.2",
+                  "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.0.2.tgz",
+                  "integrity": "sha1-xhTc9n4vsUmVqRcR5aYX6KYKMds=",
+                  "dev": true,
+                  "requires": {
+                    "readable-stream": "1.1.14"
+                  },
+                  "dependencies": {
+                    "readable-stream": {
+                      "version": "1.1.14",
+                      "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/readable-stream/-/readable-stream-1.1.14.tgz",
+                      "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
+                      "dev": true,
+                      "requires": {
+                        "core-util-is": "1.0.2",
+                        "inherits": "2.0.3",
+                        "isarray": "0.0.1",
+                        "string_decoder": "0.10.31"
+                      },
+                      "dependencies": {
+                        "core-util-is": {
+                          "version": "1.0.2",
+                          "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/core-util-is/-/core-util-is-1.0.2.tgz",
+                          "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
+                          "dev": true
+                        },
+                        "inherits": {
+                          "version": "2.0.3",
+                          "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/inherits/-/inherits-2.0.3.tgz",
+                          "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+                          "dev": true
+                        },
+                        "isarray": {
+                          "version": "0.0.1",
+                          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+                          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
+                          "dev": true
+                        },
+                        "string_decoder": {
+                          "version": "0.10.31",
+                          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+                          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
+                          "dev": true
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "object-assign": {
+              "version": "3.0.0",
+              "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/object-assign/-/object-assign-3.0.0.tgz",
+              "integrity": "sha1-m+3VygiXlJvKR+f/QIBi1Un1h/I=",
+              "dev": true
+            },
+            "replace-ext": {
+              "version": "0.0.1",
+              "resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-0.0.1.tgz",
+              "integrity": "sha1-KbvZIHinOfC8zitO5B6DeVNSKSQ=",
+              "dev": true
+            },
+            "through2": {
+              "version": "2.0.1",
+              "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/through2/-/through2-2.0.1.tgz",
+              "integrity": "sha1-OE51MU1J8y3hLuu4E2uOtrXVnak=",
+              "dev": true,
+              "requires": {
+                "readable-stream": "2.0.6",
+                "xtend": "4.0.1"
+              },
+              "dependencies": {
+                "readable-stream": {
+                  "version": "2.0.6",
+                  "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/readable-stream/-/readable-stream-2.0.6.tgz",
+                  "integrity": "sha1-j5A0HmilPMySh4jaz80Rs265t44=",
+                  "dev": true,
+                  "requires": {
+                    "core-util-is": "1.0.2",
+                    "inherits": "2.0.3",
+                    "isarray": "1.0.0",
+                    "process-nextick-args": "1.0.7",
+                    "string_decoder": "0.10.31",
+                    "util-deprecate": "1.0.2"
+                  },
+                  "dependencies": {
+                    "core-util-is": {
+                      "version": "1.0.2",
+                      "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/core-util-is/-/core-util-is-1.0.2.tgz",
+                      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
+                      "dev": true
+                    },
+                    "inherits": {
+                      "version": "2.0.3",
+                      "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/inherits/-/inherits-2.0.3.tgz",
+                      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+                      "dev": true
+                    },
+                    "isarray": {
+                      "version": "1.0.0",
+                      "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/isarray/-/isarray-1.0.0.tgz",
+                      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+                      "dev": true
+                    },
+                    "process-nextick-args": {
+                      "version": "1.0.7",
+                      "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
+                      "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M=",
+                      "dev": true
+                    },
+                    "string_decoder": {
+                      "version": "0.10.31",
+                      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+                      "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
+                      "dev": true
+                    },
+                    "util-deprecate": {
+                      "version": "1.0.2",
+                      "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/util-deprecate/-/util-deprecate-1.0.2.tgz",
+                      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
+                      "dev": true
+                    }
+                  }
+                },
+                "xtend": {
+                  "version": "4.0.1",
+                  "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/xtend/-/xtend-4.0.1.tgz",
+                  "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68=",
+                  "dev": true
+                }
+              }
+            },
+            "vinyl": {
+              "version": "0.5.3",
+              "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-0.5.3.tgz",
+              "integrity": "sha1-sEVbOPxeDPMNQyUTLkYZcMIJHN4=",
+              "dev": true,
+              "requires": {
+                "clone": "1.0.2",
+                "clone-stats": "0.0.1",
+                "replace-ext": "0.0.1"
+              },
+              "dependencies": {
+                "clone": {
+                  "version": "1.0.2",
+                  "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/clone/-/clone-1.0.2.tgz",
+                  "integrity": "sha1-Jgt6meux7f4kdTgXX3gyQ8sZ0Uk=",
+                  "dev": true
+                },
+                "clone-stats": {
+                  "version": "0.0.1",
+                  "resolved": "https://registry.npmjs.org/clone-stats/-/clone-stats-0.0.1.tgz",
+                  "integrity": "sha1-uI+UqCzzi4eR1YBG6kAprYjKmdE=",
+                  "dev": true
+                }
+              }
+            }
+          }
+        },
+        "readable-stream": {
+          "version": "2.1.5",
+          "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/readable-stream/-/readable-stream-2.1.5.tgz",
+          "integrity": "sha1-ZvqLcg4UOLNkaB8q0aY8YYRIydA=",
+          "dev": true,
+          "requires": {
+            "buffer-shims": "1.0.0",
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
+            "isarray": "1.0.0",
+            "process-nextick-args": "1.0.7",
+            "string_decoder": "0.10.31",
+            "util-deprecate": "1.0.2"
+          },
+          "dependencies": {
+            "buffer-shims": {
+              "version": "1.0.0",
+              "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/buffer-shims/-/buffer-shims-1.0.0.tgz",
+              "integrity": "sha1-mXjOMXOIxkmth5MCjDR37wRKi1E=",
+              "dev": true
+            },
+            "core-util-is": {
+              "version": "1.0.2",
+              "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/core-util-is/-/core-util-is-1.0.2.tgz",
+              "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
+              "dev": true
+            },
+            "inherits": {
+              "version": "2.0.3",
+              "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/inherits/-/inherits-2.0.3.tgz",
+              "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+              "dev": true
+            },
+            "isarray": {
+              "version": "1.0.0",
+              "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/isarray/-/isarray-1.0.0.tgz",
+              "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+              "dev": true
+            },
+            "process-nextick-args": {
+              "version": "1.0.7",
+              "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
+              "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M=",
+              "dev": true
+            },
+            "string_decoder": {
+              "version": "0.10.31",
+              "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+              "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
+              "dev": true
+            },
+            "util-deprecate": {
+              "version": "1.0.2",
+              "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/util-deprecate/-/util-deprecate-1.0.2.tgz",
+              "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
+              "dev": true
+            }
+          }
+        },
+        "rimraf": {
+          "version": "2.5.4",
+          "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/rimraf/-/rimraf-2.5.4.tgz",
+          "integrity": "sha1-loAAk8vxoMhr2VtGJUZ1NcKd+gQ=",
+          "dev": true,
+          "requires": {
+            "glob": "7.1.0"
+          }
+        },
+        "vinyl-fs": {
+          "version": "2.4.3",
+          "resolved": "https://registry.npmjs.org/vinyl-fs/-/vinyl-fs-2.4.3.tgz",
+          "integrity": "sha1-PZflYuv91LZpId6nBia4S96dLQc=",
+          "dev": true,
+          "requires": {
+            "duplexify": "3.4.5",
+            "glob-stream": "5.3.5",
+            "graceful-fs": "4.1.9",
+            "gulp-sourcemaps": "1.6.0",
+            "is-valid-glob": "0.3.0",
+            "lazystream": "1.0.0",
+            "lodash.isequal": "4.4.0",
+            "merge-stream": "1.0.0",
+            "mkdirp": "0.5.1",
+            "object-assign": "4.1.0",
+            "readable-stream": "2.1.5",
+            "strip-bom": "2.0.0",
+            "strip-bom-stream": "1.0.0",
+            "through2": "2.0.1",
+            "through2-filter": "2.0.0",
+            "vali-date": "1.0.0",
+            "vinyl": "1.2.0"
+          },
+          "dependencies": {
+            "duplexify": {
+              "version": "3.4.5",
+              "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.4.5.tgz",
+              "integrity": "sha1-Dn4oenda91O/V+bnt/IfGD9sOlM=",
+              "dev": true,
+              "requires": {
+                "end-of-stream": "1.0.0",
+                "inherits": "2.0.3",
+                "readable-stream": "2.1.5",
+                "stream-shift": "1.0.0"
+              },
+              "dependencies": {
+                "end-of-stream": {
+                  "version": "1.0.0",
+                  "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.0.0.tgz",
+                  "integrity": "sha1-1FlucCc0qT5A6a+GQxnqvZn/Lw4=",
+                  "dev": true,
+                  "requires": {
+                    "once": "1.3.3"
+                  },
+                  "dependencies": {
+                    "once": {
+                      "version": "1.3.3",
+                      "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/once/-/once-1.3.3.tgz",
+                      "integrity": "sha1-suJhVXzkwxTsgwTz+oJmPkKXyiA=",
+                      "dev": true,
+                      "requires": {
+                        "wrappy": "1.0.2"
+                      },
+                      "dependencies": {
+                        "wrappy": {
+                          "version": "1.0.2",
+                          "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/wrappy/-/wrappy-1.0.2.tgz",
+                          "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+                          "dev": true
+                        }
+                      }
+                    }
+                  }
+                },
+                "inherits": {
+                  "version": "2.0.3",
+                  "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/inherits/-/inherits-2.0.3.tgz",
+                  "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+                  "dev": true
+                },
+                "stream-shift": {
+                  "version": "1.0.0",
+                  "resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.0.tgz",
+                  "integrity": "sha1-1cdSgl5TZ+eG944Y5EXqIjoVWVI=",
+                  "dev": true
+                }
+              }
+            },
+            "glob-stream": {
+              "version": "5.3.5",
+              "resolved": "https://registry.npmjs.org/glob-stream/-/glob-stream-5.3.5.tgz",
+              "integrity": "sha1-pVZlqajM3EGRWofHAeMtTgFvrSI=",
+              "dev": true,
+              "requires": {
+                "extend": "3.0.0",
+                "glob": "5.0.15",
+                "glob-parent": "3.0.0",
+                "micromatch": "2.3.11",
+                "ordered-read-streams": "0.3.0",
+                "through2": "0.6.5",
+                "to-absolute-glob": "0.1.1",
+                "unique-stream": "2.2.1"
+              },
+              "dependencies": {
+                "extend": {
+                  "version": "3.0.0",
+                  "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/extend/-/extend-3.0.0.tgz",
+                  "integrity": "sha1-WkdDU7nzNT3dgXbf03uRyDpG8dQ=",
+                  "dev": true
+                },
+                "glob": {
+                  "version": "5.0.15",
+                  "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/glob/-/glob-5.0.15.tgz",
+                  "integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
+                  "dev": true,
+                  "requires": {
+                    "inflight": "1.0.5",
+                    "inherits": "2.0.3",
+                    "minimatch": "3.0.3",
+                    "once": "1.4.0",
+                    "path-is-absolute": "1.0.1"
+                  },
+                  "dependencies": {
+                    "inflight": {
+                      "version": "1.0.5",
+                      "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/inflight/-/inflight-1.0.5.tgz",
+                      "integrity": "sha1-2zIEzVqd4ubNiQuFxuL2a89PYgo=",
+                      "dev": true,
+                      "requires": {
+                        "once": "1.4.0",
+                        "wrappy": "1.0.2"
+                      },
+                      "dependencies": {
+                        "wrappy": {
+                          "version": "1.0.2",
+                          "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/wrappy/-/wrappy-1.0.2.tgz",
+                          "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+                          "dev": true
+                        }
+                      }
+                    },
+                    "inherits": {
+                      "version": "2.0.3",
+                      "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/inherits/-/inherits-2.0.3.tgz",
+                      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+                      "dev": true
+                    },
+                    "minimatch": {
+                      "version": "3.0.3",
+                      "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/minimatch/-/minimatch-3.0.3.tgz",
+                      "integrity": "sha1-Kk5AkLlrLbBqnX3wEFWmKnfJt3Q=",
+                      "dev": true,
+                      "requires": {
+                        "brace-expansion": "1.1.6"
+                      },
+                      "dependencies": {
+                        "brace-expansion": {
+                          "version": "1.1.6",
+                          "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/brace-expansion/-/brace-expansion-1.1.6.tgz",
+                          "integrity": "sha1-cZfX6qm4fmSDkOph/GbIRCdCDfk=",
+                          "dev": true,
+                          "requires": {
+                            "balanced-match": "0.4.2",
+                            "concat-map": "0.0.1"
+                          },
+                          "dependencies": {
+                            "balanced-match": {
+                              "version": "0.4.2",
+                              "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/balanced-match/-/balanced-match-0.4.2.tgz",
+                              "integrity": "sha1-yz8+PHMtwPAe5wtAPzAuYddwmDg=",
+                              "dev": true
+                            },
+                            "concat-map": {
+                              "version": "0.0.1",
+                              "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+                              "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+                              "dev": true
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "once": {
+                      "version": "1.4.0",
+                      "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/once/-/once-1.4.0.tgz",
+                      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+                      "dev": true,
+                      "requires": {
+                        "wrappy": "1.0.2"
+                      },
+                      "dependencies": {
+                        "wrappy": {
+                          "version": "1.0.2",
+                          "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/wrappy/-/wrappy-1.0.2.tgz",
+                          "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+                          "dev": true
+                        }
+                      }
+                    },
+                    "path-is-absolute": {
+                      "version": "1.0.1",
+                      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+                      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+                      "dev": true
+                    }
+                  }
+                },
+                "glob-parent": {
+                  "version": "3.0.0",
+                  "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-3.0.0.tgz",
+                  "integrity": "sha1-x73rUmBzIZbHQN6SdMCIFAVgFLs=",
+                  "dev": true,
+                  "requires": {
+                    "is-glob": "3.0.0"
+                  },
+                  "dependencies": {
+                    "is-glob": {
+                      "version": "3.0.0",
+                      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.0.0.tgz",
+                      "integrity": "sha1-5DPCItudd4RAhNctse/wR4RZhcE=",
+                      "dev": true,
+                      "requires": {
+                        "is-extglob": "2.0.0"
+                      },
+                      "dependencies": {
+                        "is-extglob": {
+                          "version": "2.0.0",
+                          "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.0.0.tgz",
+                          "integrity": "sha1-qbksGuLXqXWtMHvgciBJx+TqLxM=",
+                          "dev": true
+                        }
+                      }
+                    }
+                  }
+                },
+                "micromatch": {
+                  "version": "2.3.11",
+                  "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/micromatch/-/micromatch-2.3.11.tgz",
+                  "integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
+                  "dev": true,
+                  "requires": {
+                    "arr-diff": "2.0.0",
+                    "array-unique": "0.2.1",
+                    "braces": "1.8.5",
+                    "expand-brackets": "0.1.5",
+                    "extglob": "0.3.2",
+                    "filename-regex": "2.0.0",
+                    "is-extglob": "1.0.0",
+                    "is-glob": "2.0.1",
+                    "kind-of": "3.0.4",
+                    "normalize-path": "2.0.1",
+                    "object.omit": "2.0.0",
+                    "parse-glob": "3.0.4",
+                    "regex-cache": "0.4.3"
+                  },
+                  "dependencies": {
+                    "arr-diff": {
+                      "version": "2.0.0",
+                      "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/arr-diff/-/arr-diff-2.0.0.tgz",
+                      "integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
+                      "dev": true,
+                      "requires": {
+                        "arr-flatten": "1.0.1"
+                      },
+                      "dependencies": {
+                        "arr-flatten": {
+                          "version": "1.0.1",
+                          "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/arr-flatten/-/arr-flatten-1.0.1.tgz",
+                          "integrity": "sha1-5f/lTUXhnzLyFukeuZyM6JK7YEs=",
+                          "dev": true
+                        }
+                      }
+                    },
+                    "array-unique": {
+                      "version": "0.2.1",
+                      "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/array-unique/-/array-unique-0.2.1.tgz",
+                      "integrity": "sha1-odl8yvy8JiXMcPrc6zalDFiwGlM=",
+                      "dev": true
+                    },
+                    "braces": {
+                      "version": "1.8.5",
+                      "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/braces/-/braces-1.8.5.tgz",
+                      "integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
+                      "dev": true,
+                      "requires": {
+                        "expand-range": "1.8.2",
+                        "preserve": "0.2.0",
+                        "repeat-element": "1.1.2"
+                      },
+                      "dependencies": {
+                        "expand-range": {
+                          "version": "1.8.2",
+                          "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/expand-range/-/expand-range-1.8.2.tgz",
+                          "integrity": "sha1-opnv/TNf4nIeuujiV+x5ZE/IUzc=",
+                          "dev": true,
+                          "requires": {
+                            "fill-range": "2.2.3"
+                          },
+                          "dependencies": {
+                            "fill-range": {
+                              "version": "2.2.3",
+                              "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/fill-range/-/fill-range-2.2.3.tgz",
+                              "integrity": "sha1-ULd9/X5Gm8dJJHCWNpn+eoSFpyM=",
+                              "dev": true,
+                              "requires": {
+                                "is-number": "2.1.0",
+                                "isobject": "2.1.0",
+                                "randomatic": "1.1.5",
+                                "repeat-element": "1.1.2",
+                                "repeat-string": "1.5.4"
+                              },
+                              "dependencies": {
+                                "is-number": {
+                                  "version": "2.1.0",
+                                  "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/is-number/-/is-number-2.1.0.tgz",
+                                  "integrity": "sha1-Afy7s5NGOlSPL0ZszhbezknbkI8=",
+                                  "dev": true,
+                                  "requires": {
+                                    "kind-of": "3.0.4"
+                                  }
+                                },
+                                "isobject": {
+                                  "version": "2.1.0",
+                                  "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/isobject/-/isobject-2.1.0.tgz",
+                                  "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
+                                  "dev": true,
+                                  "requires": {
+                                    "isarray": "1.0.0"
+                                  },
+                                  "dependencies": {
+                                    "isarray": {
+                                      "version": "1.0.0",
+                                      "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/isarray/-/isarray-1.0.0.tgz",
+                                      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+                                      "dev": true
+                                    }
+                                  }
+                                },
+                                "randomatic": {
+                                  "version": "1.1.5",
+                                  "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/randomatic/-/randomatic-1.1.5.tgz",
+                                  "integrity": "sha1-Xp718tVzxnvSuBJK6QtRVuRXhAs=",
+                                  "dev": true,
+                                  "requires": {
+                                    "is-number": "2.1.0",
+                                    "kind-of": "3.0.4"
+                                  }
+                                },
+                                "repeat-string": {
+                                  "version": "1.5.4",
+                                  "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.5.4.tgz",
+                                  "integrity": "sha1-ZOwMkeD0tHX5DVtkNlHj5uW2wtU=",
+                                  "dev": true
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "preserve": {
+                          "version": "0.2.0",
+                          "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/preserve/-/preserve-0.2.0.tgz",
+                          "integrity": "sha1-gV7R9uvGWSb4ZbMQwHE7yzMVzks=",
+                          "dev": true
+                        },
+                        "repeat-element": {
+                          "version": "1.1.2",
+                          "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/repeat-element/-/repeat-element-1.1.2.tgz",
+                          "integrity": "sha1-7wiaF40Ug7quTZPrmLT55OEdmQo=",
+                          "dev": true
+                        }
+                      }
+                    },
+                    "expand-brackets": {
+                      "version": "0.1.5",
+                      "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/expand-brackets/-/expand-brackets-0.1.5.tgz",
+                      "integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
+                      "dev": true,
+                      "requires": {
+                        "is-posix-bracket": "0.1.1"
+                      },
+                      "dependencies": {
+                        "is-posix-bracket": {
+                          "version": "0.1.1",
+                          "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/is-posix-bracket/-/is-posix-bracket-0.1.1.tgz",
+                          "integrity": "sha1-MzTceXdDaOkvAW5vvAqI9c1ua8Q=",
+                          "dev": true
+                        }
+                      }
+                    },
+                    "extglob": {
+                      "version": "0.3.2",
+                      "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/extglob/-/extglob-0.3.2.tgz",
+                      "integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
+                      "dev": true,
+                      "requires": {
+                        "is-extglob": "1.0.0"
+                      }
+                    },
+                    "filename-regex": {
+                      "version": "2.0.0",
+                      "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/filename-regex/-/filename-regex-2.0.0.tgz",
+                      "integrity": "sha1-mW4+gEebmLmJfxWopYs9CE6SZ3U=",
+                      "dev": true
+                    },
+                    "is-extglob": {
+                      "version": "1.0.0",
+                      "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/is-extglob/-/is-extglob-1.0.0.tgz",
+                      "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
+                      "dev": true
+                    },
+                    "is-glob": {
+                      "version": "2.0.1",
+                      "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/is-glob/-/is-glob-2.0.1.tgz",
+                      "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
+                      "dev": true,
+                      "requires": {
+                        "is-extglob": "1.0.0"
+                      }
+                    },
+                    "kind-of": {
+                      "version": "3.0.4",
+                      "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/kind-of/-/kind-of-3.0.4.tgz",
+                      "integrity": "sha1-e47PGKThf4Jp1ztQHJ8jLJaIenQ=",
+                      "dev": true,
+                      "requires": {
+                        "is-buffer": "1.1.4"
+                      },
+                      "dependencies": {
+                        "is-buffer": {
+                          "version": "1.1.4",
+                          "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/is-buffer/-/is-buffer-1.1.4.tgz",
+                          "integrity": "sha1-z8hszV3FpS+oBIkRHGkgxFfi2Ys=",
+                          "dev": true
+                        }
+                      }
+                    },
+                    "normalize-path": {
+                      "version": "2.0.1",
+                      "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/normalize-path/-/normalize-path-2.0.1.tgz",
+                      "integrity": "sha1-R4hqwWYnYNQmG32XnSQXCdPOP3o=",
+                      "dev": true
+                    },
+                    "object.omit": {
+                      "version": "2.0.0",
+                      "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/object.omit/-/object.omit-2.0.0.tgz",
+                      "integrity": "sha1-hoWXMz1U5gZilAu0WGBd1q4S/pQ=",
+                      "dev": true,
+                      "requires": {
+                        "for-own": "0.1.4",
+                        "is-extendable": "0.1.1"
+                      },
+                      "dependencies": {
+                        "for-own": {
+                          "version": "0.1.4",
+                          "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/for-own/-/for-own-0.1.4.tgz",
+                          "integrity": "sha1-AUm0GjkIjHUV9R6+HBOG1F+TUHI=",
+                          "dev": true,
+                          "requires": {
+                            "for-in": "0.1.6"
+                          },
+                          "dependencies": {
+                            "for-in": {
+                              "version": "0.1.6",
+                              "resolved": "https://registry.npmjs.org/for-in/-/for-in-0.1.6.tgz",
+                              "integrity": "sha1-yfluib+tGKVFr17D7TUqHZ5bTcg=",
+                              "dev": true
+                            }
+                          }
+                        },
+                        "is-extendable": {
+                          "version": "0.1.1",
+                          "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/is-extendable/-/is-extendable-0.1.1.tgz",
+                          "integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik=",
+                          "dev": true
+                        }
+                      }
+                    },
+                    "parse-glob": {
+                      "version": "3.0.4",
+                      "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/parse-glob/-/parse-glob-3.0.4.tgz",
+                      "integrity": "sha1-ssN2z7EfNVE7rdFz7wu246OIORw=",
+                      "dev": true,
+                      "requires": {
+                        "glob-base": "0.3.0",
+                        "is-dotfile": "1.0.2",
+                        "is-extglob": "1.0.0",
+                        "is-glob": "2.0.1"
+                      },
+                      "dependencies": {
+                        "glob-base": {
+                          "version": "0.3.0",
+                          "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/glob-base/-/glob-base-0.3.0.tgz",
+                          "integrity": "sha1-27Fk9iIbHAscz4Kuoyi0l98Oo8Q=",
+                          "dev": true,
+                          "requires": {
+                            "glob-parent": "2.0.0",
+                            "is-glob": "2.0.1"
+                          },
+                          "dependencies": {
+                            "glob-parent": {
+                              "version": "2.0.0",
+                              "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/glob-parent/-/glob-parent-2.0.0.tgz",
+                              "integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
+                              "dev": true,
+                              "requires": {
+                                "is-glob": "2.0.1"
+                              }
+                            }
+                          }
+                        },
+                        "is-dotfile": {
+                          "version": "1.0.2",
+                          "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/is-dotfile/-/is-dotfile-1.0.2.tgz",
+                          "integrity": "sha1-LBMjg/ORmfjtwmjKAbmwB9IFzE0=",
+                          "dev": true
+                        }
+                      }
+                    },
+                    "regex-cache": {
+                      "version": "0.4.3",
+                      "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/regex-cache/-/regex-cache-0.4.3.tgz",
+                      "integrity": "sha1-mxpsNdTQ3871cRrmUejp09cRQUU=",
+                      "dev": true,
+                      "requires": {
+                        "is-equal-shallow": "0.1.3",
+                        "is-primitive": "2.0.0"
+                      },
+                      "dependencies": {
+                        "is-equal-shallow": {
+                          "version": "0.1.3",
+                          "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz",
+                          "integrity": "sha1-IjgJj8Ih3gvPpdnqxMRdY4qhxTQ=",
+                          "dev": true,
+                          "requires": {
+                            "is-primitive": "2.0.0"
+                          }
+                        },
+                        "is-primitive": {
+                          "version": "2.0.0",
+                          "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/is-primitive/-/is-primitive-2.0.0.tgz",
+                          "integrity": "sha1-IHurkWOEmcB7Kt8kCkGochADRXU=",
+                          "dev": true
+                        }
+                      }
+                    }
+                  }
+                },
+                "ordered-read-streams": {
+                  "version": "0.3.0",
+                  "resolved": "https://registry.npmjs.org/ordered-read-streams/-/ordered-read-streams-0.3.0.tgz",
+                  "integrity": "sha1-cTfmmzKYuzQiR6G77jiByA4v14s=",
+                  "dev": true,
+                  "requires": {
+                    "is-stream": "1.1.0",
+                    "readable-stream": "2.1.5"
+                  },
+                  "dependencies": {
+                    "is-stream": {
+                      "version": "1.1.0",
+                      "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/is-stream/-/is-stream-1.1.0.tgz",
+                      "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
+                      "dev": true
+                    }
+                  }
+                },
+                "through2": {
+                  "version": "0.6.5",
+                  "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
+                  "integrity": "sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=",
+                  "dev": true,
+                  "requires": {
+                    "readable-stream": "1.0.34",
+                    "xtend": "4.0.1"
+                  },
+                  "dependencies": {
+                    "readable-stream": {
+                      "version": "1.0.34",
+                      "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/readable-stream/-/readable-stream-1.0.34.tgz",
+                      "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
+                      "dev": true,
+                      "requires": {
+                        "core-util-is": "1.0.2",
+                        "inherits": "2.0.3",
+                        "isarray": "0.0.1",
+                        "string_decoder": "0.10.31"
+                      },
+                      "dependencies": {
+                        "core-util-is": {
+                          "version": "1.0.2",
+                          "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/core-util-is/-/core-util-is-1.0.2.tgz",
+                          "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
+                          "dev": true
+                        },
+                        "inherits": {
+                          "version": "2.0.3",
+                          "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/inherits/-/inherits-2.0.3.tgz",
+                          "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+                          "dev": true
+                        },
+                        "isarray": {
+                          "version": "0.0.1",
+                          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+                          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
+                          "dev": true
+                        },
+                        "string_decoder": {
+                          "version": "0.10.31",
+                          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+                          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
+                          "dev": true
+                        }
+                      }
+                    },
+                    "xtend": {
+                      "version": "4.0.1",
+                      "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/xtend/-/xtend-4.0.1.tgz",
+                      "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68=",
+                      "dev": true
+                    }
+                  }
+                },
+                "to-absolute-glob": {
+                  "version": "0.1.1",
+                  "resolved": "https://registry.npmjs.org/to-absolute-glob/-/to-absolute-glob-0.1.1.tgz",
+                  "integrity": "sha1-HN+kcqnvUMI57maZm2YsoOs5k38=",
+                  "dev": true,
+                  "requires": {
+                    "extend-shallow": "2.0.1"
+                  },
+                  "dependencies": {
+                    "extend-shallow": {
+                      "version": "2.0.1",
+                      "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+                      "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+                      "dev": true,
+                      "requires": {
+                        "is-extendable": "0.1.1"
+                      },
+                      "dependencies": {
+                        "is-extendable": {
+                          "version": "0.1.1",
+                          "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/is-extendable/-/is-extendable-0.1.1.tgz",
+                          "integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik=",
+                          "dev": true
+                        }
+                      }
+                    }
+                  }
+                },
+                "unique-stream": {
+                  "version": "2.2.1",
+                  "resolved": "https://registry.npmjs.org/unique-stream/-/unique-stream-2.2.1.tgz",
+                  "integrity": "sha1-WqADz76Uxf+GbE59ZouxxNuts2k=",
+                  "dev": true,
+                  "requires": {
+                    "json-stable-stringify": "1.0.1",
+                    "through2-filter": "2.0.0"
+                  },
+                  "dependencies": {
+                    "json-stable-stringify": {
+                      "version": "1.0.1",
+                      "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
+                      "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
+                      "dev": true,
+                      "requires": {
+                        "jsonify": "0.0.0"
+                      },
+                      "dependencies": {
+                        "jsonify": {
+                          "version": "0.0.0",
+                          "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
+                          "integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM=",
+                          "dev": true
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "graceful-fs": {
+              "version": "4.1.9",
+              "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.9.tgz",
+              "integrity": "sha1-uqy6N9GdEfnRRtNXi8mZWMN4fik=",
+              "dev": true
+            },
+            "gulp-sourcemaps": {
+              "version": "1.6.0",
+              "resolved": "https://registry.npmjs.org/gulp-sourcemaps/-/gulp-sourcemaps-1.6.0.tgz",
+              "integrity": "sha1-uG/zSdgBzrVuHZ59x7vLS33uYAw=",
+              "dev": true,
+              "requires": {
+                "convert-source-map": "1.3.0",
+                "graceful-fs": "4.1.9",
+                "strip-bom": "2.0.0",
+                "through2": "2.0.1",
+                "vinyl": "1.2.0"
+              },
+              "dependencies": {
+                "convert-source-map": {
+                  "version": "1.3.0",
+                  "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/convert-source-map/-/convert-source-map-1.3.0.tgz",
+                  "integrity": "sha1-6fPpxuJyjvwmdmlqcOs4L3MQamc=",
+                  "dev": true
+                }
+              }
+            },
+            "is-valid-glob": {
+              "version": "0.3.0",
+              "resolved": "https://registry.npmjs.org/is-valid-glob/-/is-valid-glob-0.3.0.tgz",
+              "integrity": "sha1-1LVcafUYhvm2XHDWwmItN+KfSP4=",
+              "dev": true
+            },
+            "lazystream": {
+              "version": "1.0.0",
+              "resolved": "https://registry.npmjs.org/lazystream/-/lazystream-1.0.0.tgz",
+              "integrity": "sha1-9plf4PggOS9hOWvolGJAe7dxaOQ=",
+              "dev": true,
+              "requires": {
+                "readable-stream": "2.1.5"
+              }
+            },
+            "lodash.isequal": {
+              "version": "4.4.0",
+              "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.4.0.tgz",
+              "integrity": "sha1-YpV2jpjhTcFc6NNi72NA24KFIDE=",
+              "dev": true
+            },
+            "merge-stream": {
+              "version": "1.0.0",
+              "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-1.0.0.tgz",
+              "integrity": "sha1-nP0Vb+81Qh4rVAPOEdxusZYrAm4=",
+              "dev": true,
+              "requires": {
+                "readable-stream": "2.1.5"
+              }
+            },
+            "mkdirp": {
+              "version": "0.5.1",
+              "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+              "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+              "dev": true,
+              "requires": {
+                "minimist": "0.0.8"
+              },
+              "dependencies": {
+                "minimist": {
+                  "version": "0.0.8",
+                  "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+                  "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+                  "dev": true
+                }
+              }
+            },
+            "object-assign": {
+              "version": "4.1.0",
+              "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/object-assign/-/object-assign-4.1.0.tgz",
+              "integrity": "sha1-ejs9DpgGPUP0wD8uiubNUahog6A=",
+              "dev": true
+            },
+            "strip-bom": {
+              "version": "2.0.0",
+              "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/strip-bom/-/strip-bom-2.0.0.tgz",
+              "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
+              "dev": true,
+              "requires": {
+                "is-utf8": "0.2.1"
+              },
+              "dependencies": {
+                "is-utf8": {
+                  "version": "0.2.1",
+                  "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/is-utf8/-/is-utf8-0.2.1.tgz",
+                  "integrity": "sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI=",
+                  "dev": true
+                }
+              }
+            },
+            "strip-bom-stream": {
+              "version": "1.0.0",
+              "resolved": "https://registry.npmjs.org/strip-bom-stream/-/strip-bom-stream-1.0.0.tgz",
+              "integrity": "sha1-5xRDmFd9Uaa+0PoZlPoF9D/ZiO4=",
+              "dev": true,
+              "requires": {
+                "first-chunk-stream": "1.0.0",
+                "strip-bom": "2.0.0"
+              },
+              "dependencies": {
+                "first-chunk-stream": {
+                  "version": "1.0.0",
+                  "resolved": "https://registry.npmjs.org/first-chunk-stream/-/first-chunk-stream-1.0.0.tgz",
+                  "integrity": "sha1-Wb+1DNkF9g18OUzT2ayqtOatk04=",
+                  "dev": true
+                }
+              }
+            },
+            "through2": {
+              "version": "2.0.1",
+              "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/through2/-/through2-2.0.1.tgz",
+              "integrity": "sha1-OE51MU1J8y3hLuu4E2uOtrXVnak=",
+              "dev": true,
+              "requires": {
+                "readable-stream": "2.0.6",
+                "xtend": "4.0.1"
+              },
+              "dependencies": {
+                "readable-stream": {
+                  "version": "2.0.6",
+                  "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/readable-stream/-/readable-stream-2.0.6.tgz",
+                  "integrity": "sha1-j5A0HmilPMySh4jaz80Rs265t44=",
+                  "dev": true,
+                  "requires": {
+                    "core-util-is": "1.0.2",
+                    "inherits": "2.0.3",
+                    "isarray": "1.0.0",
+                    "process-nextick-args": "1.0.7",
+                    "string_decoder": "0.10.31",
+                    "util-deprecate": "1.0.2"
+                  },
+                  "dependencies": {
+                    "core-util-is": {
+                      "version": "1.0.2",
+                      "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/core-util-is/-/core-util-is-1.0.2.tgz",
+                      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
+                      "dev": true
+                    },
+                    "inherits": {
+                      "version": "2.0.3",
+                      "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/inherits/-/inherits-2.0.3.tgz",
+                      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+                      "dev": true
+                    },
+                    "isarray": {
+                      "version": "1.0.0",
+                      "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/isarray/-/isarray-1.0.0.tgz",
+                      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+                      "dev": true
+                    },
+                    "process-nextick-args": {
+                      "version": "1.0.7",
+                      "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
+                      "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M=",
+                      "dev": true
+                    },
+                    "string_decoder": {
+                      "version": "0.10.31",
+                      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+                      "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
+                      "dev": true
+                    },
+                    "util-deprecate": {
+                      "version": "1.0.2",
+                      "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/util-deprecate/-/util-deprecate-1.0.2.tgz",
+                      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
+                      "dev": true
+                    }
+                  }
+                },
+                "xtend": {
+                  "version": "4.0.1",
+                  "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/xtend/-/xtend-4.0.1.tgz",
+                  "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68=",
+                  "dev": true
+                }
+              }
+            },
+            "through2-filter": {
+              "version": "2.0.0",
+              "resolved": "https://registry.npmjs.org/through2-filter/-/through2-filter-2.0.0.tgz",
+              "integrity": "sha1-YLxVoNrLdghdsfna6Zq0P4PWIuw=",
+              "dev": true,
+              "requires": {
+                "through2": "2.0.1",
+                "xtend": "4.0.1"
+              },
+              "dependencies": {
+                "xtend": {
+                  "version": "4.0.1",
+                  "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/xtend/-/xtend-4.0.1.tgz",
+                  "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68=",
+                  "dev": true
+                }
+              }
+            },
+            "vali-date": {
+              "version": "1.0.0",
+              "resolved": "https://registry.npmjs.org/vali-date/-/vali-date-1.0.0.tgz",
+              "integrity": "sha1-G5BKWWCfsyjvB4E4Qgk09rhnCaY=",
+              "dev": true
+            },
+            "vinyl": {
+              "version": "1.2.0",
+              "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-1.2.0.tgz",
+              "integrity": "sha1-XIgDbPVl5d8FVYv8kR+GVt8hiIQ=",
+              "dev": true,
+              "requires": {
+                "clone": "1.0.2",
+                "clone-stats": "0.0.1",
+                "replace-ext": "0.0.1"
+              },
+              "dependencies": {
+                "clone": {
+                  "version": "1.0.2",
+                  "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/clone/-/clone-1.0.2.tgz",
+                  "integrity": "sha1-Jgt6meux7f4kdTgXX3gyQ8sZ0Uk=",
+                  "dev": true
+                },
+                "clone-stats": {
+                  "version": "0.0.1",
+                  "resolved": "https://registry.npmjs.org/clone-stats/-/clone-stats-0.0.1.tgz",
+                  "integrity": "sha1-uI+UqCzzi4eR1YBG6kAprYjKmdE=",
+                  "dev": true
+                },
+                "replace-ext": {
+                  "version": "0.0.1",
+                  "resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-0.0.1.tgz",
+                  "integrity": "sha1-KbvZIHinOfC8zitO5B6DeVNSKSQ=",
+                  "dev": true
+                }
+              }
+            }
+          }
+        },
+        "wrap-promise": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/wrap-promise/-/wrap-promise-1.0.1.tgz",
+          "integrity": "sha1-sBn0I2zL8ftWCSG0tIcLe9ovUlU=",
+          "dev": true,
+          "requires": {
+            "es6-promise": "2.3.0"
+          },
+          "dependencies": {
+            "es6-promise": {
+              "version": "2.3.0",
+              "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-2.3.0.tgz",
+              "integrity": "sha1-lu258v2wGZWCKyY92KratnSBgbw=",
+              "dev": true
+            }
+          }
+        }
+      }
+    },
+    "gulp-istanbul": {
+      "version": "0.10.4",
+      "resolved": "https://registry.npmjs.org/gulp-istanbul/-/gulp-istanbul-0.10.4.tgz",
+      "integrity": "sha1-Kyoby+uWpix45pgh0QTW/KMu+wk=",
+      "dev": true,
+      "requires": {
+        "gulp-util": "3.0.8",
+        "istanbul": "0.4.5",
+        "istanbul-threshold-checker": "0.1.0",
+        "lodash": "4.17.11",
+        "through2": "2.0.3"
+      },
+      "dependencies": {
+        "abbrev": {
+          "version": "1.0.9",
+          "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.9.tgz",
+          "integrity": "sha1-kbR5JYinc4wl813W9jdSovh3YTU=",
+          "dev": true
+        },
+        "amdefine": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz",
+          "integrity": "sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU=",
+          "dev": true,
+          "optional": true
+        },
+        "ansi-regex": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+          "dev": true
+        },
+        "ansi-styles": {
+          "version": "2.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+          "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+          "dev": true
+        },
+        "argparse": {
+          "version": "1.0.10",
+          "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+          "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+          "dev": true,
+          "requires": {
+            "sprintf-js": "1.0.3"
+          }
+        },
+        "array-differ": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/array-differ/-/array-differ-1.0.0.tgz",
+          "integrity": "sha1-7/UuN1gknTO+QCuLuOVkuytdQDE=",
+          "dev": true
+        },
+        "array-uniq": {
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.3.tgz",
+          "integrity": "sha1-r2rId6Jcx/dOBYiUdThY39sk/bY=",
+          "dev": true
+        },
+        "async": {
+          "version": "1.5.2",
+          "resolved": "http://registry.npmjs.org/async/-/async-1.5.2.tgz",
+          "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=",
+          "dev": true
+        },
+        "balanced-match": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+          "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+          "dev": true
+        },
+        "beeper": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/beeper/-/beeper-1.1.1.tgz",
+          "integrity": "sha1-5tXqjF2tABMEpwsiY4RH9pyy+Ak=",
+          "dev": true
+        },
+        "brace-expansion": {
+          "version": "1.1.11",
+          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+          "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+          "dev": true,
+          "requires": {
+            "balanced-match": "1.0.0",
+            "concat-map": "0.0.1"
+          }
+        },
+        "chalk": {
+          "version": "1.1.3",
+          "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "2.2.1",
+            "escape-string-regexp": "1.0.5",
+            "has-ansi": "2.0.0",
+            "strip-ansi": "3.0.1",
+            "supports-color": "2.0.0"
+          }
+        },
+        "clone": {
+          "version": "1.0.4",
+          "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.4.tgz",
+          "integrity": "sha1-2jCcwmPfFZlMaIypAheco8fNfH4=",
+          "dev": true
+        },
+        "clone-stats": {
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/clone-stats/-/clone-stats-0.0.1.tgz",
+          "integrity": "sha1-uI+UqCzzi4eR1YBG6kAprYjKmdE=",
+          "dev": true
+        },
+        "concat-map": {
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+          "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+          "dev": true
+        },
+        "core-util-is": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+          "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
+          "dev": true
+        },
+        "dateformat": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-2.2.0.tgz",
+          "integrity": "sha1-QGXiATz5+5Ft39gu+1Bq1MZ2kGI=",
+          "dev": true
+        },
+        "deep-is": {
+          "version": "0.1.3",
+          "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
+          "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=",
+          "dev": true
+        },
+        "duplexer2": {
+          "version": "0.0.2",
+          "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.0.2.tgz",
+          "integrity": "sha1-xhTc9n4vsUmVqRcR5aYX6KYKMds=",
+          "dev": true,
+          "requires": {
+            "readable-stream": "1.1.14"
+          }
+        },
+        "escape-string-regexp": {
+          "version": "1.0.5",
+          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+          "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+          "dev": true
+        },
+        "escodegen": {
+          "version": "1.8.1",
+          "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.8.1.tgz",
+          "integrity": "sha1-WltTr0aTEQvrsIZ6o0MN07cKEBg=",
+          "dev": true,
+          "requires": {
+            "esprima": "2.7.3",
+            "estraverse": "1.9.3",
+            "esutils": "2.0.2",
+            "optionator": "0.8.2",
+            "source-map": "0.2.0"
+          }
+        },
+        "esprima": {
+          "version": "2.7.3",
+          "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.7.3.tgz",
+          "integrity": "sha1-luO3DVd59q1JzQMmc9HDEnZ7pYE=",
+          "dev": true
+        },
+        "estraverse": {
+          "version": "1.9.3",
+          "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-1.9.3.tgz",
+          "integrity": "sha1-r2fy3JIlgkFZUJJgkaQAXSnJu0Q=",
+          "dev": true
+        },
+        "esutils": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
+          "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=",
+          "dev": true
+        },
+        "fancy-log": {
+          "version": "1.3.2",
+          "resolved": "https://registry.npmjs.org/fancy-log/-/fancy-log-1.3.2.tgz",
+          "integrity": "sha1-9BEl49hPLn2JpD0G2VjI94vha+E=",
+          "dev": true,
+          "requires": {
+            "ansi-gray": "0.1.1",
+            "color-support": "1.1.3",
+            "time-stamp": "1.1.0"
+          }
+        },
+        "fast-levenshtein": {
+          "version": "2.0.6",
+          "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+          "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
+          "dev": true
+        },
+        "fileset": {
+          "version": "0.2.1",
+          "resolved": "https://registry.npmjs.org/fileset/-/fileset-0.2.1.tgz",
+          "integrity": "sha1-WI74lzxmI7KnbfRlEFaWuWqsgGc=",
+          "dev": true,
+          "requires": {
+            "glob": "5.0.15",
+            "minimatch": "2.0.10"
+          },
+          "dependencies": {
+            "minimatch": {
+              "version": "2.0.10",
+              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
+              "integrity": "sha1-jQh8OcazjAAbl/ynzm0OHoCvusc=",
+              "dev": true,
+              "requires": {
+                "brace-expansion": "1.1.11"
+              }
+            }
+          }
+        },
+        "glob": {
+          "version": "5.0.15",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
+          "integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
+          "dev": true,
+          "requires": {
+            "inflight": "1.0.6",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.4",
+            "once": "1.4.0",
+            "path-is-absolute": "1.0.1"
+          }
+        },
+        "glogg": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/glogg/-/glogg-1.0.1.tgz",
+          "integrity": "sha512-ynYqXLoluBKf9XGR1gA59yEJisIL7YHEH4xr3ZziHB5/yl4qWfaK8Js9jGe6gBGCSCKVqiyO30WnRZADvemUNw==",
+          "dev": true,
+          "requires": {
+            "sparkles": "1.0.1"
+          }
+        },
+        "gulp-util": {
+          "version": "3.0.8",
+          "resolved": "https://registry.npmjs.org/gulp-util/-/gulp-util-3.0.8.tgz",
+          "integrity": "sha1-AFTh50RQLifATBh8PsxQXdVLu08=",
+          "dev": true,
+          "requires": {
+            "array-differ": "1.0.0",
+            "array-uniq": "1.0.3",
+            "beeper": "1.1.1",
+            "chalk": "1.1.3",
+            "dateformat": "2.2.0",
+            "fancy-log": "1.3.2",
+            "gulplog": "1.0.0",
+            "has-gulplog": "0.1.0",
+            "lodash._reescape": "3.0.0",
+            "lodash._reevaluate": "3.0.0",
+            "lodash._reinterpolate": "3.0.0",
+            "lodash.template": "3.6.2",
+            "minimist": "1.2.0",
+            "multipipe": "0.1.2",
+            "object-assign": "3.0.0",
+            "replace-ext": "0.0.1",
+            "through2": "2.0.3",
+            "vinyl": "0.5.3"
+          }
+        },
+        "gulplog": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/gulplog/-/gulplog-1.0.0.tgz",
+          "integrity": "sha1-4oxNRdBey77YGDY86PnFkmIp/+U=",
+          "dev": true,
+          "requires": {
+            "glogg": "1.0.1"
+          }
+        },
+        "has-ansi": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+          "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "2.1.1"
+          }
+        },
+        "has-flag": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
+          "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo=",
+          "dev": true
+        },
+        "has-gulplog": {
+          "version": "0.1.0",
+          "resolved": "https://registry.npmjs.org/has-gulplog/-/has-gulplog-0.1.0.tgz",
+          "integrity": "sha1-ZBTIKRNpfaUVkDl9r7EvIpZ4Ec4=",
+          "dev": true,
+          "requires": {
+            "sparkles": "1.0.1"
+          }
+        },
+        "inflight": {
+          "version": "1.0.6",
+          "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+          "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+          "dev": true,
+          "requires": {
+            "once": "1.4.0",
+            "wrappy": "1.0.2"
+          }
+        },
+        "inherits": {
+          "version": "2.0.3",
+          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+          "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+          "dev": true
+        },
+        "isarray": {
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
+          "dev": true
+        },
+        "isexe": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+          "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
+          "dev": true
+        },
+        "istanbul": {
+          "version": "0.4.5",
+          "resolved": "https://registry.npmjs.org/istanbul/-/istanbul-0.4.5.tgz",
+          "integrity": "sha1-ZcfXPUxNqE1POsMQuRj7C4Azczs=",
+          "dev": true,
+          "requires": {
+            "abbrev": "1.0.9",
+            "async": "1.5.2",
+            "escodegen": "1.8.1",
+            "esprima": "2.7.3",
+            "glob": "5.0.15",
+            "handlebars": "4.0.5",
+            "js-yaml": "3.12.0",
+            "mkdirp": "0.5.1",
+            "nopt": "3.0.6",
+            "once": "1.4.0",
+            "resolve": "1.1.7",
+            "supports-color": "3.2.3",
+            "which": "1.3.1",
+            "wordwrap": "1.0.0"
+          },
+          "dependencies": {
+            "supports-color": {
+              "version": "3.2.3",
+              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
+              "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
+              "dev": true,
+              "requires": {
+                "has-flag": "1.0.0"
+              }
+            }
+          }
+        },
+        "istanbul-threshold-checker": {
+          "version": "0.1.0",
+          "resolved": "https://registry.npmjs.org/istanbul-threshold-checker/-/istanbul-threshold-checker-0.1.0.tgz",
+          "integrity": "sha1-DhRCwBfLJ6hfeBc0/v0hJkBco5w=",
+          "dev": true,
+          "requires": {
+            "istanbul": "0.3.22",
+            "lodash": "3.6.0"
+          },
+          "dependencies": {
+            "escodegen": {
+              "version": "1.7.1",
+              "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.7.1.tgz",
+              "integrity": "sha1-MOz89mypjcZ80v0WKr626vqM5vw=",
+              "dev": true,
+              "requires": {
+                "esprima": "1.2.5",
+                "estraverse": "1.9.3",
+                "esutils": "2.0.2",
+                "optionator": "0.5.0",
+                "source-map": "0.2.0"
+              },
+              "dependencies": {
+                "esprima": {
+                  "version": "1.2.5",
+                  "resolved": "https://registry.npmjs.org/esprima/-/esprima-1.2.5.tgz",
+                  "integrity": "sha1-CZNQL+r2aBODJXVvMPmlH+7sEek=",
+                  "dev": true
+                }
+              }
+            },
+            "esprima": {
+              "version": "2.5.0",
+              "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.5.0.tgz",
+              "integrity": "sha1-84ekb9NEwbGjm6+MIL+0O20AWMw=",
+              "dev": true
+            },
+            "fast-levenshtein": {
+              "version": "1.0.7",
+              "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-1.0.7.tgz",
+              "integrity": "sha1-AXjc3uAjuSkFGTrwlZ6KdjnP3Lk=",
+              "dev": true
+            },
+            "istanbul": {
+              "version": "0.3.22",
+              "resolved": "https://registry.npmjs.org/istanbul/-/istanbul-0.3.22.tgz",
+              "integrity": "sha1-PhZNhQIf4ZyYXR8OfvDD4i0BLrY=",
+              "dev": true,
+              "requires": {
+                "abbrev": "1.0.9",
+                "async": "1.5.2",
+                "escodegen": "1.7.1",
+                "esprima": "2.5.0",
+                "fileset": "0.2.1",
+                "handlebars": "4.0.5",
+                "js-yaml": "3.12.0",
+                "mkdirp": "0.5.1",
+                "nopt": "3.0.6",
+                "once": "1.4.0",
+                "resolve": "1.1.7",
+                "supports-color": "3.2.3",
+                "which": "1.3.1",
+                "wordwrap": "1.0.0"
+              }
+            },
+            "levn": {
+              "version": "0.2.5",
+              "resolved": "https://registry.npmjs.org/levn/-/levn-0.2.5.tgz",
+              "integrity": "sha1-uo0znQykphDjo/FFucr0iAcVUFQ=",
+              "dev": true,
+              "requires": {
+                "prelude-ls": "1.1.2",
+                "type-check": "0.3.2"
+              }
+            },
+            "lodash": {
+              "version": "3.6.0",
+              "resolved": "http://registry.npmjs.org/lodash/-/lodash-3.6.0.tgz",
+              "integrity": "sha1-Umao9J3Zib5Pn2gbbyoMVShdDZo=",
+              "dev": true
+            },
+            "optionator": {
+              "version": "0.5.0",
+              "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.5.0.tgz",
+              "integrity": "sha1-t1qJlaLUF98ltuTjhi9QqohlE2g=",
+              "dev": true,
+              "requires": {
+                "deep-is": "0.1.3",
+                "fast-levenshtein": "1.0.7",
+                "levn": "0.2.5",
+                "prelude-ls": "1.1.2",
+                "type-check": "0.3.2",
+                "wordwrap": "0.0.3"
+              },
+              "dependencies": {
+                "wordwrap": {
+                  "version": "0.0.3",
+                  "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
+                  "integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc=",
+                  "dev": true
+                }
+              }
+            },
+            "supports-color": {
+              "version": "3.2.3",
+              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
+              "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
+              "dev": true,
+              "requires": {
+                "has-flag": "1.0.0"
+              }
+            }
+          }
+        },
+        "js-yaml": {
+          "version": "3.12.0",
+          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.12.0.tgz",
+          "integrity": "sha512-PIt2cnwmPfL4hKNwqeiuz4bKfnzHTBv6HyVgjahA6mPLwPDzjDWrplJBMjHUFxku/N3FlmrbyPclad+I+4mJ3A==",
+          "dev": true,
+          "requires": {
+            "argparse": "1.0.10",
+            "esprima": "4.0.1"
+          },
+          "dependencies": {
+            "esprima": {
+              "version": "4.0.1",
+              "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+              "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+              "dev": true
+            }
+          }
+        },
+        "levn": {
+          "version": "0.3.0",
+          "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
+          "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
+          "dev": true,
+          "requires": {
+            "prelude-ls": "1.1.2",
+            "type-check": "0.3.2"
+          }
+        },
+        "lodash": {
+          "version": "4.17.11",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
+          "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
+          "dev": true
+        },
+        "lodash._basecopy": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz",
+          "integrity": "sha1-jaDmqHbPNEwK2KVIghEd08XHyjY=",
+          "dev": true
+        },
+        "lodash._basetostring": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/lodash._basetostring/-/lodash._basetostring-3.0.1.tgz",
+          "integrity": "sha1-0YYdh3+CSlL2aYMtyvPuFVZqB9U=",
+          "dev": true
+        },
+        "lodash._basevalues": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/lodash._basevalues/-/lodash._basevalues-3.0.0.tgz",
+          "integrity": "sha1-W3dXYoAr3j0yl1A+JjAIIP32Ybc=",
+          "dev": true
+        },
+        "lodash._getnative": {
+          "version": "3.9.1",
+          "resolved": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz",
+          "integrity": "sha1-VwvH3t5G1hzc3mh9ZdPuy6o6r/U=",
+          "dev": true
+        },
+        "lodash._isiterateecall": {
+          "version": "3.0.9",
+          "resolved": "https://registry.npmjs.org/lodash._isiterateecall/-/lodash._isiterateecall-3.0.9.tgz",
+          "integrity": "sha1-UgOte6Ql+uhCRg5pbbnPPmqsBXw=",
+          "dev": true
+        },
+        "lodash._reescape": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/lodash._reescape/-/lodash._reescape-3.0.0.tgz",
+          "integrity": "sha1-Kx1vXf4HyKNVdT5fJ/rH8c3hYWo=",
+          "dev": true
+        },
+        "lodash._reevaluate": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/lodash._reevaluate/-/lodash._reevaluate-3.0.0.tgz",
+          "integrity": "sha1-WLx0xAZklTrgsSTYBpltrKQx4u0=",
+          "dev": true
+        },
+        "lodash._reinterpolate": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz",
+          "integrity": "sha1-DM8tiRZq8Ds2Y8eWU4t1rG4RTZ0=",
+          "dev": true
+        },
+        "lodash._root": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/lodash._root/-/lodash._root-3.0.1.tgz",
+          "integrity": "sha1-+6HEUkwZ7ppfgTa0YJ8BfPTe1pI=",
+          "dev": true
+        },
+        "lodash.escape": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/lodash.escape/-/lodash.escape-3.2.0.tgz",
+          "integrity": "sha1-mV7g3BjBtIzJLv+ucaEKq1tIdpg=",
+          "dev": true,
+          "requires": {
+            "lodash._root": "3.0.1"
+          }
+        },
+        "lodash.isarguments": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
+          "integrity": "sha1-L1c9hcaiQon/AGY7SRwdM4/zRYo=",
+          "dev": true
+        },
+        "lodash.isarray": {
+          "version": "3.0.4",
+          "resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz",
+          "integrity": "sha1-eeTriMNqgSKvhvhEqpvNhRtfu1U=",
+          "dev": true
+        },
+        "lodash.keys": {
+          "version": "3.1.2",
+          "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
+          "integrity": "sha1-TbwEcrFWvlCgsoaFXRvQsMZWCYo=",
+          "dev": true,
+          "requires": {
+            "lodash._getnative": "3.9.1",
+            "lodash.isarguments": "3.1.0",
+            "lodash.isarray": "3.0.4"
+          }
+        },
+        "lodash.restparam": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/lodash.restparam/-/lodash.restparam-3.6.1.tgz",
+          "integrity": "sha1-k2pOMJ7zMKdkXtQUWYbIWuWyCAU=",
+          "dev": true
+        },
+        "lodash.template": {
+          "version": "3.6.2",
+          "resolved": "https://registry.npmjs.org/lodash.template/-/lodash.template-3.6.2.tgz",
+          "integrity": "sha1-+M3sxhaaJVvpCYrosMU9N4kx0U8=",
+          "dev": true,
+          "requires": {
+            "lodash._basecopy": "3.0.1",
+            "lodash._basetostring": "3.0.1",
+            "lodash._basevalues": "3.0.0",
+            "lodash._isiterateecall": "3.0.9",
+            "lodash._reinterpolate": "3.0.0",
+            "lodash.escape": "3.2.0",
+            "lodash.keys": "3.1.2",
+            "lodash.restparam": "3.6.1",
+            "lodash.templatesettings": "3.1.1"
+          }
+        },
+        "lodash.templatesettings": {
+          "version": "3.1.1",
+          "resolved": "https://registry.npmjs.org/lodash.templatesettings/-/lodash.templatesettings-3.1.1.tgz",
+          "integrity": "sha1-+zB4RHU7Zrnxr6VOJix0UwfbqOU=",
+          "dev": true,
+          "requires": {
+            "lodash._reinterpolate": "3.0.0",
+            "lodash.escape": "3.2.0"
+          }
+        },
+        "minimatch": {
+          "version": "3.0.4",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+          "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+          "dev": true,
+          "requires": {
+            "brace-expansion": "1.1.11"
+          }
+        },
+        "minimist": {
+          "version": "1.2.0",
+          "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+          "dev": true
+        },
+        "mkdirp": {
+          "version": "0.5.1",
+          "resolved": "http://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+          "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+          "dev": true,
+          "requires": {
+            "minimist": "0.0.8"
+          },
+          "dependencies": {
+            "minimist": {
+              "version": "0.0.8",
+              "resolved": "http://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+              "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+              "dev": true
+            }
+          }
+        },
+        "multipipe": {
+          "version": "0.1.2",
+          "resolved": "https://registry.npmjs.org/multipipe/-/multipipe-0.1.2.tgz",
+          "integrity": "sha1-Ko8t33Du1WTf8tV/HhoTfZ8FB4s=",
+          "dev": true,
+          "requires": {
+            "duplexer2": "0.0.2"
+          }
+        },
+        "nopt": {
+          "version": "3.0.6",
+          "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
+          "integrity": "sha1-xkZdvwirzU2zWTF/eaxopkayj/k=",
+          "dev": true,
+          "requires": {
+            "abbrev": "1.0.9"
+          }
+        },
+        "object-assign": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-3.0.0.tgz",
+          "integrity": "sha1-m+3VygiXlJvKR+f/QIBi1Un1h/I=",
+          "dev": true
+        },
+        "once": {
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+          "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+          "dev": true,
+          "requires": {
+            "wrappy": "1.0.2"
+          }
+        },
+        "optionator": {
+          "version": "0.8.2",
+          "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.2.tgz",
+          "integrity": "sha1-NkxeQJ0/TWMB1sC0wFu6UBgK62Q=",
+          "dev": true,
+          "requires": {
+            "deep-is": "0.1.3",
+            "fast-levenshtein": "2.0.6",
+            "levn": "0.3.0",
+            "prelude-ls": "1.1.2",
+            "type-check": "0.3.2",
+            "wordwrap": "1.0.0"
+          }
+        },
+        "path-is-absolute": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+          "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+          "dev": true
+        },
+        "prelude-ls": {
+          "version": "1.1.2",
+          "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
+          "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
+          "dev": true
+        },
+        "process-nextick-args": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
+          "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw==",
+          "dev": true
+        },
+        "readable-stream": {
+          "version": "1.1.14",
+          "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
+          "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
+          "dev": true,
+          "requires": {
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
+            "isarray": "0.0.1",
+            "string_decoder": "0.10.31"
+          }
+        },
+        "replace-ext": {
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-0.0.1.tgz",
+          "integrity": "sha1-KbvZIHinOfC8zitO5B6DeVNSKSQ=",
+          "dev": true
+        },
+        "resolve": {
+          "version": "1.1.7",
+          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz",
+          "integrity": "sha1-IDEU2CrSxe2ejgQRs5ModeiJ6Xs=",
+          "dev": true
+        },
+        "safe-buffer": {
+          "version": "5.1.2",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+          "dev": true
+        },
+        "source-map": {
+          "version": "0.2.0",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.2.0.tgz",
+          "integrity": "sha1-2rc/vPwrqBm03gO9b26qSBZLP50=",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "amdefine": "1.0.1"
+          }
+        },
+        "sparkles": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/sparkles/-/sparkles-1.0.1.tgz",
+          "integrity": "sha512-dSO0DDYUahUt/0/pD/Is3VIm5TGJjludZ0HVymmhYF6eNA53PVLhnUk0znSYbH8IYBuJdCE+1luR22jNLMaQdw==",
+          "dev": true
+        },
+        "sprintf-js": {
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+          "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
+          "dev": true
+        },
+        "string_decoder": {
+          "version": "0.10.31",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
+          "dev": true
+        },
+        "strip-ansi": {
+          "version": "3.0.1",
+          "resolved": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "2.1.1"
+          }
+        },
+        "supports-color": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+          "dev": true
+        },
+        "through2": {
+          "version": "2.0.3",
+          "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz",
+          "integrity": "sha1-AARWmzfHx0ujnEPzzteNGtlBQL4=",
+          "dev": true,
+          "requires": {
+            "readable-stream": "2.3.6",
+            "xtend": "4.0.1"
+          },
+          "dependencies": {
+            "isarray": {
+              "version": "1.0.0",
+              "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+              "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+              "dev": true
+            },
+            "readable-stream": {
+              "version": "2.3.6",
+              "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+              "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
+              "dev": true,
+              "requires": {
+                "core-util-is": "1.0.2",
+                "inherits": "2.0.3",
+                "isarray": "1.0.0",
+                "process-nextick-args": "2.0.0",
+                "safe-buffer": "5.1.2",
+                "string_decoder": "1.1.1",
+                "util-deprecate": "1.0.2"
+              }
+            },
+            "string_decoder": {
+              "version": "1.1.1",
+              "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+              "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+              "dev": true,
+              "requires": {
+                "safe-buffer": "5.1.2"
+              }
+            }
+          }
+        },
+        "time-stamp": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/time-stamp/-/time-stamp-1.1.0.tgz",
+          "integrity": "sha1-dkpaEa9QVhkhsTPztE5hhofg9cM=",
+          "dev": true
+        },
+        "type-check": {
+          "version": "0.3.2",
+          "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
+          "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
+          "dev": true,
+          "requires": {
+            "prelude-ls": "1.1.2"
+          }
+        },
+        "util-deprecate": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+          "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
+          "dev": true
+        },
+        "vinyl": {
+          "version": "0.5.3",
+          "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-0.5.3.tgz",
+          "integrity": "sha1-sEVbOPxeDPMNQyUTLkYZcMIJHN4=",
+          "dev": true,
+          "requires": {
+            "clone": "1.0.4",
+            "clone-stats": "0.0.1",
+            "replace-ext": "0.0.1"
+          }
+        },
+        "which": {
+          "version": "1.3.1",
+          "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
+          "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
+          "dev": true,
+          "requires": {
+            "isexe": "2.0.0"
+          }
+        },
+        "wordwrap": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
+          "integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=",
+          "dev": true
+        },
+        "wrappy": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+          "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+          "dev": true
+        },
+        "xtend": {
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
+          "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68=",
+          "dev": true
+        }
+      }
+    },
+    "gulp-mocha": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/gulp-mocha/-/gulp-mocha-2.2.0.tgz",
+      "integrity": "sha1-HOXrpLlLQMdDav7DxJgsjuqJQZI=",
+      "dev": true,
+      "requires": {
+        "gulp-util": "3.0.7",
+        "mocha": "2.5.3",
+        "plur": "2.1.2",
+        "resolve-from": "1.0.1",
+        "temp": "0.8.3",
+        "through": "2.3.8"
+      },
+      "dependencies": {
+        "gulp-util": {
+          "version": "3.0.7",
+          "resolved": "https://registry.npmjs.org/gulp-util/-/gulp-util-3.0.7.tgz",
+          "integrity": "sha1-eJJcS4+LSQBawBoBHFV+YhiUHLs=",
+          "dev": true,
+          "requires": {
+            "array-differ": "1.0.0",
+            "array-uniq": "1.0.3",
+            "beeper": "1.1.0",
+            "chalk": "1.1.3",
+            "dateformat": "1.0.12",
+            "fancy-log": "1.2.0",
+            "gulplog": "1.0.0",
+            "has-gulplog": "0.1.0",
+            "lodash._reescape": "3.0.0",
+            "lodash._reevaluate": "3.0.0",
+            "lodash._reinterpolate": "3.0.0",
+            "lodash.template": "3.6.2",
+            "minimist": "1.2.0",
+            "multipipe": "0.1.2",
+            "object-assign": "3.0.0",
+            "replace-ext": "0.0.1",
+            "through2": "2.0.1",
+            "vinyl": "0.5.3"
+          },
+          "dependencies": {
+            "array-differ": {
+              "version": "1.0.0",
+              "resolved": "https://registry.npmjs.org/array-differ/-/array-differ-1.0.0.tgz",
+              "integrity": "sha1-7/UuN1gknTO+QCuLuOVkuytdQDE=",
+              "dev": true
+            },
+            "array-uniq": {
+              "version": "1.0.3",
+              "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/array-uniq/-/array-uniq-1.0.3.tgz",
+              "integrity": "sha1-r2rId6Jcx/dOBYiUdThY39sk/bY=",
+              "dev": true
+            },
+            "beeper": {
+              "version": "1.1.0",
+              "resolved": "https://registry.npmjs.org/beeper/-/beeper-1.1.0.tgz",
+              "integrity": "sha1-nub8HOf1T+qs585zWIsFYDeGaiw=",
+              "dev": true
+            },
+            "chalk": {
+              "version": "1.1.3",
+              "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/chalk/-/chalk-1.1.3.tgz",
+              "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+              "dev": true,
+              "requires": {
+                "ansi-styles": "2.2.1",
+                "escape-string-regexp": "1.0.5",
+                "has-ansi": "2.0.0",
+                "strip-ansi": "3.0.1",
+                "supports-color": "2.0.0"
+              },
+              "dependencies": {
+                "ansi-styles": {
+                  "version": "2.2.1",
+                  "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/ansi-styles/-/ansi-styles-2.2.1.tgz",
+                  "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+                  "dev": true
+                },
+                "escape-string-regexp": {
+                  "version": "1.0.5",
+                  "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+                  "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+                  "dev": true
+                },
+                "has-ansi": {
+                  "version": "2.0.0",
+                  "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/has-ansi/-/has-ansi-2.0.0.tgz",
+                  "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
+                  "dev": true,
+                  "requires": {
+                    "ansi-regex": "2.0.0"
+                  },
+                  "dependencies": {
+                    "ansi-regex": {
+                      "version": "2.0.0",
+                      "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/ansi-regex/-/ansi-regex-2.0.0.tgz",
+                      "integrity": "sha1-xQYbbg74qBd15Q9dZhUb9r83EQc=",
+                      "dev": true
+                    }
+                  }
+                },
+                "strip-ansi": {
+                  "version": "3.0.1",
+                  "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/strip-ansi/-/strip-ansi-3.0.1.tgz",
+                  "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+                  "dev": true,
+                  "requires": {
+                    "ansi-regex": "2.0.0"
+                  },
+                  "dependencies": {
+                    "ansi-regex": {
+                      "version": "2.0.0",
+                      "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/ansi-regex/-/ansi-regex-2.0.0.tgz",
+                      "integrity": "sha1-xQYbbg74qBd15Q9dZhUb9r83EQc=",
+                      "dev": true
+                    }
+                  }
+                },
+                "supports-color": {
+                  "version": "2.0.0",
+                  "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/supports-color/-/supports-color-2.0.0.tgz",
+                  "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+                  "dev": true
+                }
+              }
+            },
+            "dateformat": {
+              "version": "1.0.12",
+              "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-1.0.12.tgz",
+              "integrity": "sha1-nxJLZ1lMk3/3BpMuSmQsyo27/uk=",
+              "dev": true,
+              "requires": {
+                "get-stdin": "4.0.1",
+                "meow": "3.7.0"
+              },
+              "dependencies": {
+                "get-stdin": {
+                  "version": "4.0.1",
+                  "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz",
+                  "integrity": "sha1-uWjGsKBDhDJJAui/Gl3zJXmkUP4=",
+                  "dev": true
+                },
+                "meow": {
+                  "version": "3.7.0",
+                  "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/meow/-/meow-3.7.0.tgz",
+                  "integrity": "sha1-cstmi0JSKCkKu/qFaJJYcwioAfs=",
+                  "dev": true,
+                  "requires": {
+                    "camelcase-keys": "2.1.0",
+                    "decamelize": "1.2.0",
+                    "loud-rejection": "1.6.0",
+                    "map-obj": "1.0.1",
+                    "minimist": "1.2.0",
+                    "normalize-package-data": "2.3.5",
+                    "object-assign": "4.1.0",
+                    "read-pkg-up": "1.0.1",
+                    "redent": "1.0.0",
+                    "trim-newlines": "1.0.0"
+                  },
+                  "dependencies": {
+                    "camelcase-keys": {
+                      "version": "2.1.0",
+                      "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/camelcase-keys/-/camelcase-keys-2.1.0.tgz",
+                      "integrity": "sha1-MIvur/3ygRkFHvodkyITyRuPkuc=",
+                      "dev": true,
+                      "requires": {
+                        "camelcase": "2.1.1",
+                        "map-obj": "1.0.1"
+                      },
+                      "dependencies": {
+                        "camelcase": {
+                          "version": "2.1.1",
+                          "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/camelcase/-/camelcase-2.1.1.tgz",
+                          "integrity": "sha1-fB0W1nmhu+WcoCys7PsBHiAfWh8=",
+                          "dev": true
+                        }
+                      }
+                    },
+                    "decamelize": {
+                      "version": "1.2.0",
+                      "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/decamelize/-/decamelize-1.2.0.tgz",
+                      "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
+                      "dev": true
+                    },
+                    "loud-rejection": {
+                      "version": "1.6.0",
+                      "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/loud-rejection/-/loud-rejection-1.6.0.tgz",
+                      "integrity": "sha1-W0b4AUft7leIcPCG0Eghz5mOVR8=",
+                      "dev": true,
+                      "requires": {
+                        "currently-unhandled": "0.4.1",
+                        "signal-exit": "3.0.1"
+                      },
+                      "dependencies": {
+                        "currently-unhandled": {
+                          "version": "0.4.1",
+                          "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/currently-unhandled/-/currently-unhandled-0.4.1.tgz",
+                          "integrity": "sha1-mI3zP+qxke95mmE2nddsF635V+o=",
+                          "dev": true,
+                          "requires": {
+                            "array-find-index": "1.0.2"
+                          },
+                          "dependencies": {
+                            "array-find-index": {
+                              "version": "1.0.2",
+                              "resolved": "https://registry.npmjs.org/array-find-index/-/array-find-index-1.0.2.tgz",
+                              "integrity": "sha1-3wEKoSh+Fku9pvlyOwqWoexBh6E=",
+                              "dev": true
+                            }
+                          }
+                        },
+                        "signal-exit": {
+                          "version": "3.0.1",
+                          "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.1.tgz",
+                          "integrity": "sha1-WkyISZK2OnrNm623iUw+6c/MrYE=",
+                          "dev": true
+                        }
+                      }
+                    },
+                    "map-obj": {
+                      "version": "1.0.1",
+                      "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
+                      "integrity": "sha1-2TPOuSBdgr3PSIb2dCvcK03qFG0=",
+                      "dev": true
+                    },
+                    "normalize-package-data": {
+                      "version": "2.3.5",
+                      "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/normalize-package-data/-/normalize-package-data-2.3.5.tgz",
+                      "integrity": "sha1-jZJPFClg4Xd+f/4XBUNjHMfLAt8=",
+                      "dev": true,
+                      "requires": {
+                        "hosted-git-info": "2.1.5",
+                        "is-builtin-module": "1.0.0",
+                        "semver": "5.3.0",
+                        "validate-npm-package-license": "3.0.1"
+                      },
+                      "dependencies": {
+                        "hosted-git-info": {
+                          "version": "2.1.5",
+                          "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/hosted-git-info/-/hosted-git-info-2.1.5.tgz",
+                          "integrity": "sha1-C6gdkNouJas0ozLm7HeTbhWYEYs=",
+                          "dev": true
+                        },
+                        "is-builtin-module": {
+                          "version": "1.0.0",
+                          "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
+                          "integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
+                          "dev": true,
+                          "requires": {
+                            "builtin-modules": "1.1.1"
+                          },
+                          "dependencies": {
+                            "builtin-modules": {
+                              "version": "1.1.1",
+                              "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/builtin-modules/-/builtin-modules-1.1.1.tgz",
+                              "integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8=",
+                              "dev": true
+                            }
+                          }
+                        },
+                        "validate-npm-package-license": {
+                          "version": "3.0.1",
+                          "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/validate-npm-package-license/-/validate-npm-package-license-3.0.1.tgz",
+                          "integrity": "sha1-KAS6vnEq0zeUWaz74kdGqywwP7w=",
+                          "dev": true,
+                          "requires": {
+                            "spdx-correct": "1.0.2",
+                            "spdx-expression-parse": "1.0.4"
+                          },
+                          "dependencies": {
+                            "spdx-correct": {
+                              "version": "1.0.2",
+                              "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/spdx-correct/-/spdx-correct-1.0.2.tgz",
+                              "integrity": "sha1-SzBz2TP/UfORLwOsVRlJikFQ20A=",
+                              "dev": true,
+                              "requires": {
+                                "spdx-license-ids": "1.2.2"
+                              },
+                              "dependencies": {
+                                "spdx-license-ids": {
+                                  "version": "1.2.2",
+                                  "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/spdx-license-ids/-/spdx-license-ids-1.2.2.tgz",
+                                  "integrity": "sha1-yd96NCRZSt5r0RkA1ZZpbcBrrFc=",
+                                  "dev": true
+                                }
+                              }
+                            },
+                            "spdx-expression-parse": {
+                              "version": "1.0.4",
+                              "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-1.0.4.tgz",
+                              "integrity": "sha1-m98vIOH0DtRH++JzJmGR/O1RYmw=",
+                              "dev": true
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "object-assign": {
+                      "version": "4.1.0",
+                      "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/object-assign/-/object-assign-4.1.0.tgz",
+                      "integrity": "sha1-ejs9DpgGPUP0wD8uiubNUahog6A=",
+                      "dev": true
+                    },
+                    "read-pkg-up": {
+                      "version": "1.0.1",
+                      "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
+                      "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
+                      "dev": true,
+                      "requires": {
+                        "find-up": "1.1.2",
+                        "read-pkg": "1.1.0"
+                      },
+                      "dependencies": {
+                        "find-up": {
+                          "version": "1.1.2",
+                          "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/find-up/-/find-up-1.1.2.tgz",
+                          "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
+                          "dev": true,
+                          "requires": {
+                            "path-exists": "2.1.0",
+                            "pinkie-promise": "2.0.1"
+                          },
+                          "dependencies": {
+                            "path-exists": {
+                              "version": "2.1.0",
+                              "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/path-exists/-/path-exists-2.1.0.tgz",
+                              "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
+                              "dev": true,
+                              "requires": {
+                                "pinkie-promise": "2.0.1"
+                              }
+                            },
+                            "pinkie-promise": {
+                              "version": "2.0.1",
+                              "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
+                              "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
+                              "dev": true,
+                              "requires": {
+                                "pinkie": "2.0.4"
+                              },
+                              "dependencies": {
+                                "pinkie": {
+                                  "version": "2.0.4",
+                                  "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/pinkie/-/pinkie-2.0.4.tgz",
+                                  "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA=",
+                                  "dev": true
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "read-pkg": {
+                          "version": "1.1.0",
+                          "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/read-pkg/-/read-pkg-1.1.0.tgz",
+                          "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
+                          "dev": true,
+                          "requires": {
+                            "load-json-file": "1.1.0",
+                            "normalize-package-data": "2.3.5",
+                            "path-type": "1.1.0"
+                          },
+                          "dependencies": {
+                            "load-json-file": {
+                              "version": "1.1.0",
+                              "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/load-json-file/-/load-json-file-1.1.0.tgz",
+                              "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
+                              "dev": true,
+                              "requires": {
+                                "graceful-fs": "4.1.9",
+                                "parse-json": "2.2.0",
+                                "pify": "2.3.0",
+                                "pinkie-promise": "2.0.1",
+                                "strip-bom": "2.0.0"
+                              },
+                              "dependencies": {
+                                "graceful-fs": {
+                                  "version": "4.1.9",
+                                  "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.9.tgz",
+                                  "integrity": "sha1-uqy6N9GdEfnRRtNXi8mZWMN4fik=",
+                                  "dev": true
+                                },
+                                "parse-json": {
+                                  "version": "2.2.0",
+                                  "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/parse-json/-/parse-json-2.2.0.tgz",
+                                  "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
+                                  "dev": true,
+                                  "requires": {
+                                    "error-ex": "1.3.0"
+                                  },
+                                  "dependencies": {
+                                    "error-ex": {
+                                      "version": "1.3.0",
+                                      "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/error-ex/-/error-ex-1.3.0.tgz",
+                                      "integrity": "sha1-5ntD8+gsluo6WE/+4Ln8MyXYAtk=",
+                                      "dev": true,
+                                      "requires": {
+                                        "is-arrayish": "0.2.1"
+                                      },
+                                      "dependencies": {
+                                        "is-arrayish": {
+                                          "version": "0.2.1",
+                                          "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/is-arrayish/-/is-arrayish-0.2.1.tgz",
+                                          "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
+                                          "dev": true
+                                        }
+                                      }
+                                    }
+                                  }
+                                },
+                                "pify": {
+                                  "version": "2.3.0",
+                                  "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/pify/-/pify-2.3.0.tgz",
+                                  "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
+                                  "dev": true
+                                },
+                                "pinkie-promise": {
+                                  "version": "2.0.1",
+                                  "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
+                                  "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
+                                  "dev": true,
+                                  "requires": {
+                                    "pinkie": "2.0.4"
+                                  },
+                                  "dependencies": {
+                                    "pinkie": {
+                                      "version": "2.0.4",
+                                      "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/pinkie/-/pinkie-2.0.4.tgz",
+                                      "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA=",
+                                      "dev": true
+                                    }
+                                  }
+                                },
+                                "strip-bom": {
+                                  "version": "2.0.0",
+                                  "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/strip-bom/-/strip-bom-2.0.0.tgz",
+                                  "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
+                                  "dev": true,
+                                  "requires": {
+                                    "is-utf8": "0.2.1"
+                                  },
+                                  "dependencies": {
+                                    "is-utf8": {
+                                      "version": "0.2.1",
+                                      "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/is-utf8/-/is-utf8-0.2.1.tgz",
+                                      "integrity": "sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI=",
+                                      "dev": true
+                                    }
+                                  }
+                                }
+                              }
+                            },
+                            "path-type": {
+                              "version": "1.1.0",
+                              "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/path-type/-/path-type-1.1.0.tgz",
+                              "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
+                              "dev": true,
+                              "requires": {
+                                "graceful-fs": "4.1.9",
+                                "pify": "2.3.0",
+                                "pinkie-promise": "2.0.1"
+                              },
+                              "dependencies": {
+                                "graceful-fs": {
+                                  "version": "4.1.9",
+                                  "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.9.tgz",
+                                  "integrity": "sha1-uqy6N9GdEfnRRtNXi8mZWMN4fik=",
+                                  "dev": true
+                                },
+                                "pify": {
+                                  "version": "2.3.0",
+                                  "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/pify/-/pify-2.3.0.tgz",
+                                  "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
+                                  "dev": true
+                                },
+                                "pinkie-promise": {
+                                  "version": "2.0.1",
+                                  "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
+                                  "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
+                                  "dev": true,
+                                  "requires": {
+                                    "pinkie": "2.0.4"
+                                  },
+                                  "dependencies": {
+                                    "pinkie": {
+                                      "version": "2.0.4",
+                                      "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/pinkie/-/pinkie-2.0.4.tgz",
+                                      "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA=",
+                                      "dev": true
+                                    }
+                                  }
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "redent": {
+                      "version": "1.0.0",
+                      "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/redent/-/redent-1.0.0.tgz",
+                      "integrity": "sha1-z5Fqsf1fHxbfsggi3W7H9zDCr94=",
+                      "dev": true,
+                      "requires": {
+                        "indent-string": "2.1.0",
+                        "strip-indent": "1.0.1"
+                      },
+                      "dependencies": {
+                        "indent-string": {
+                          "version": "2.1.0",
+                          "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/indent-string/-/indent-string-2.1.0.tgz",
+                          "integrity": "sha1-ji1INIdCEhtKghi3oTfppSBJ3IA=",
+                          "dev": true,
+                          "requires": {
+                            "repeating": "2.0.1"
+                          },
+                          "dependencies": {
+                            "repeating": {
+                              "version": "2.0.1",
+                              "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/repeating/-/repeating-2.0.1.tgz",
+                              "integrity": "sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo=",
+                              "dev": true,
+                              "requires": {
+                                "is-finite": "1.0.2"
+                              },
+                              "dependencies": {
+                                "is-finite": {
+                                  "version": "1.0.2",
+                                  "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.2.tgz",
+                                  "integrity": "sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko=",
+                                  "dev": true,
+                                  "requires": {
+                                    "number-is-nan": "1.0.1"
+                                  },
+                                  "dependencies": {
+                                    "number-is-nan": {
+                                      "version": "1.0.1",
+                                      "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
+                                      "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
+                                      "dev": true
+                                    }
+                                  }
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "strip-indent": {
+                          "version": "1.0.1",
+                          "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/strip-indent/-/strip-indent-1.0.1.tgz",
+                          "integrity": "sha1-DHlipq3vp7vUrDZkYKY4VSrhoKI=",
+                          "dev": true,
+                          "requires": {
+                            "get-stdin": "4.0.1"
+                          }
+                        }
+                      }
+                    },
+                    "trim-newlines": {
+                      "version": "1.0.0",
+                      "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/trim-newlines/-/trim-newlines-1.0.0.tgz",
+                      "integrity": "sha1-WIeWa7WCpFA6QetST301ARgVphM=",
+                      "dev": true
+                    }
+                  }
+                }
+              }
+            },
+            "fancy-log": {
+              "version": "1.2.0",
+              "resolved": "https://registry.npmjs.org/fancy-log/-/fancy-log-1.2.0.tgz",
+              "integrity": "sha1-1aUbU+mrIsoH1VjytnrlX9tfy9g=",
+              "dev": true,
+              "requires": {
+                "chalk": "1.1.3",
+                "time-stamp": "1.0.1"
+              },
+              "dependencies": {
+                "time-stamp": {
+                  "version": "1.0.1",
+                  "resolved": "https://registry.npmjs.org/time-stamp/-/time-stamp-1.0.1.tgz",
+                  "integrity": "sha1-n0vSNVnJNllm8zAtu6KwfGuZsVE=",
+                  "dev": true
+                }
+              }
+            },
+            "gulplog": {
+              "version": "1.0.0",
+              "resolved": "https://registry.npmjs.org/gulplog/-/gulplog-1.0.0.tgz",
+              "integrity": "sha1-4oxNRdBey77YGDY86PnFkmIp/+U=",
+              "dev": true,
+              "requires": {
+                "glogg": "1.0.0"
+              },
+              "dependencies": {
+                "glogg": {
+                  "version": "1.0.0",
+                  "resolved": "https://registry.npmjs.org/glogg/-/glogg-1.0.0.tgz",
+                  "integrity": "sha1-f+DxmfV6yQbPUS/urY+Q7kooT8U=",
+                  "dev": true,
+                  "requires": {
+                    "sparkles": "1.0.0"
+                  },
+                  "dependencies": {
+                    "sparkles": {
+                      "version": "1.0.0",
+                      "resolved": "https://registry.npmjs.org/sparkles/-/sparkles-1.0.0.tgz",
+                      "integrity": "sha1-Gsu/tZJDbRC76PeFt8xvgoFQEsM=",
+                      "dev": true
+                    }
+                  }
+                }
+              }
+            },
+            "has-gulplog": {
+              "version": "0.1.0",
+              "resolved": "https://registry.npmjs.org/has-gulplog/-/has-gulplog-0.1.0.tgz",
+              "integrity": "sha1-ZBTIKRNpfaUVkDl9r7EvIpZ4Ec4=",
+              "dev": true,
+              "requires": {
+                "sparkles": "1.0.0"
+              },
+              "dependencies": {
+                "sparkles": {
+                  "version": "1.0.0",
+                  "resolved": "https://registry.npmjs.org/sparkles/-/sparkles-1.0.0.tgz",
+                  "integrity": "sha1-Gsu/tZJDbRC76PeFt8xvgoFQEsM=",
+                  "dev": true
+                }
+              }
+            },
+            "lodash._reescape": {
+              "version": "3.0.0",
+              "resolved": "https://registry.npmjs.org/lodash._reescape/-/lodash._reescape-3.0.0.tgz",
+              "integrity": "sha1-Kx1vXf4HyKNVdT5fJ/rH8c3hYWo=",
+              "dev": true
+            },
+            "lodash._reevaluate": {
+              "version": "3.0.0",
+              "resolved": "https://registry.npmjs.org/lodash._reevaluate/-/lodash._reevaluate-3.0.0.tgz",
+              "integrity": "sha1-WLx0xAZklTrgsSTYBpltrKQx4u0=",
+              "dev": true
+            },
+            "lodash._reinterpolate": {
+              "version": "3.0.0",
+              "resolved": "https://registry.npmjs.org/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz",
+              "integrity": "sha1-DM8tiRZq8Ds2Y8eWU4t1rG4RTZ0=",
+              "dev": true
+            },
+            "lodash.template": {
+              "version": "3.6.2",
+              "resolved": "https://registry.npmjs.org/lodash.template/-/lodash.template-3.6.2.tgz",
+              "integrity": "sha1-+M3sxhaaJVvpCYrosMU9N4kx0U8=",
+              "dev": true,
+              "requires": {
+                "lodash._basecopy": "3.0.1",
+                "lodash._basetostring": "3.0.1",
+                "lodash._basevalues": "3.0.0",
+                "lodash._isiterateecall": "3.0.9",
+                "lodash._reinterpolate": "3.0.0",
+                "lodash.escape": "3.2.0",
+                "lodash.keys": "3.1.2",
+                "lodash.restparam": "3.6.1",
+                "lodash.templatesettings": "3.1.1"
+              },
+              "dependencies": {
+                "lodash._basecopy": {
+                  "version": "3.0.1",
+                  "resolved": "https://registry.npmjs.org/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz",
+                  "integrity": "sha1-jaDmqHbPNEwK2KVIghEd08XHyjY=",
+                  "dev": true
+                },
+                "lodash._basetostring": {
+                  "version": "3.0.1",
+                  "resolved": "https://registry.npmjs.org/lodash._basetostring/-/lodash._basetostring-3.0.1.tgz",
+                  "integrity": "sha1-0YYdh3+CSlL2aYMtyvPuFVZqB9U=",
+                  "dev": true
+                },
+                "lodash._basevalues": {
+                  "version": "3.0.0",
+                  "resolved": "https://registry.npmjs.org/lodash._basevalues/-/lodash._basevalues-3.0.0.tgz",
+                  "integrity": "sha1-W3dXYoAr3j0yl1A+JjAIIP32Ybc=",
+                  "dev": true
+                },
+                "lodash._isiterateecall": {
+                  "version": "3.0.9",
+                  "resolved": "https://registry.npmjs.org/lodash._isiterateecall/-/lodash._isiterateecall-3.0.9.tgz",
+                  "integrity": "sha1-UgOte6Ql+uhCRg5pbbnPPmqsBXw=",
+                  "dev": true
+                },
+                "lodash.escape": {
+                  "version": "3.2.0",
+                  "resolved": "https://registry.npmjs.org/lodash.escape/-/lodash.escape-3.2.0.tgz",
+                  "integrity": "sha1-mV7g3BjBtIzJLv+ucaEKq1tIdpg=",
+                  "dev": true,
+                  "requires": {
+                    "lodash._root": "3.0.1"
+                  },
+                  "dependencies": {
+                    "lodash._root": {
+                      "version": "3.0.1",
+                      "resolved": "https://registry.npmjs.org/lodash._root/-/lodash._root-3.0.1.tgz",
+                      "integrity": "sha1-+6HEUkwZ7ppfgTa0YJ8BfPTe1pI=",
+                      "dev": true
+                    }
+                  }
+                },
+                "lodash.keys": {
+                  "version": "3.1.2",
+                  "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/lodash.keys/-/lodash.keys-3.1.2.tgz",
+                  "integrity": "sha1-TbwEcrFWvlCgsoaFXRvQsMZWCYo=",
+                  "dev": true,
+                  "requires": {
+                    "lodash._getnative": "3.9.1",
+                    "lodash.isarguments": "3.1.0",
+                    "lodash.isarray": "3.0.4"
+                  },
+                  "dependencies": {
+                    "lodash._getnative": {
+                      "version": "3.9.1",
+                      "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/lodash._getnative/-/lodash._getnative-3.9.1.tgz",
+                      "integrity": "sha1-VwvH3t5G1hzc3mh9ZdPuy6o6r/U=",
+                      "dev": true
+                    },
+                    "lodash.isarguments": {
+                      "version": "3.1.0",
+                      "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
+                      "integrity": "sha1-L1c9hcaiQon/AGY7SRwdM4/zRYo=",
+                      "dev": true
+                    },
+                    "lodash.isarray": {
+                      "version": "3.0.4",
+                      "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/lodash.isarray/-/lodash.isarray-3.0.4.tgz",
+                      "integrity": "sha1-eeTriMNqgSKvhvhEqpvNhRtfu1U=",
+                      "dev": true
+                    }
+                  }
+                },
+                "lodash.restparam": {
+                  "version": "3.6.1",
+                  "resolved": "https://registry.npmjs.org/lodash.restparam/-/lodash.restparam-3.6.1.tgz",
+                  "integrity": "sha1-k2pOMJ7zMKdkXtQUWYbIWuWyCAU=",
+                  "dev": true
+                },
+                "lodash.templatesettings": {
+                  "version": "3.1.1",
+                  "resolved": "https://registry.npmjs.org/lodash.templatesettings/-/lodash.templatesettings-3.1.1.tgz",
+                  "integrity": "sha1-+zB4RHU7Zrnxr6VOJix0UwfbqOU=",
+                  "dev": true,
+                  "requires": {
+                    "lodash._reinterpolate": "3.0.0",
+                    "lodash.escape": "3.2.0"
+                  }
+                }
+              }
+            },
+            "minimist": {
+              "version": "1.2.0",
+              "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/minimist/-/minimist-1.2.0.tgz",
+              "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+              "dev": true
+            },
+            "multipipe": {
+              "version": "0.1.2",
+              "resolved": "https://registry.npmjs.org/multipipe/-/multipipe-0.1.2.tgz",
+              "integrity": "sha1-Ko8t33Du1WTf8tV/HhoTfZ8FB4s=",
+              "dev": true,
+              "requires": {
+                "duplexer2": "0.0.2"
+              },
+              "dependencies": {
+                "duplexer2": {
+                  "version": "0.0.2",
+                  "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.0.2.tgz",
+                  "integrity": "sha1-xhTc9n4vsUmVqRcR5aYX6KYKMds=",
+                  "dev": true,
+                  "requires": {
+                    "readable-stream": "1.1.14"
+                  },
+                  "dependencies": {
+                    "readable-stream": {
+                      "version": "1.1.14",
+                      "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/readable-stream/-/readable-stream-1.1.14.tgz",
+                      "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
+                      "dev": true,
+                      "requires": {
+                        "core-util-is": "1.0.2",
+                        "inherits": "2.0.3",
+                        "isarray": "0.0.1",
+                        "string_decoder": "0.10.31"
+                      },
+                      "dependencies": {
+                        "core-util-is": {
+                          "version": "1.0.2",
+                          "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/core-util-is/-/core-util-is-1.0.2.tgz",
+                          "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
+                          "dev": true
+                        },
+                        "inherits": {
+                          "version": "2.0.3",
+                          "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/inherits/-/inherits-2.0.3.tgz",
+                          "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+                          "dev": true
+                        },
+                        "isarray": {
+                          "version": "0.0.1",
+                          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+                          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
+                          "dev": true
+                        },
+                        "string_decoder": {
+                          "version": "0.10.31",
+                          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+                          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
+                          "dev": true
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "object-assign": {
+              "version": "3.0.0",
+              "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/object-assign/-/object-assign-3.0.0.tgz",
+              "integrity": "sha1-m+3VygiXlJvKR+f/QIBi1Un1h/I=",
+              "dev": true
+            },
+            "replace-ext": {
+              "version": "0.0.1",
+              "resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-0.0.1.tgz",
+              "integrity": "sha1-KbvZIHinOfC8zitO5B6DeVNSKSQ=",
+              "dev": true
+            },
+            "through2": {
+              "version": "2.0.1",
+              "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/through2/-/through2-2.0.1.tgz",
+              "integrity": "sha1-OE51MU1J8y3hLuu4E2uOtrXVnak=",
+              "dev": true,
+              "requires": {
+                "readable-stream": "2.0.6",
+                "xtend": "4.0.1"
+              },
+              "dependencies": {
+                "readable-stream": {
+                  "version": "2.0.6",
+                  "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/readable-stream/-/readable-stream-2.0.6.tgz",
+                  "integrity": "sha1-j5A0HmilPMySh4jaz80Rs265t44=",
+                  "dev": true,
+                  "requires": {
+                    "core-util-is": "1.0.2",
+                    "inherits": "2.0.3",
+                    "isarray": "1.0.0",
+                    "process-nextick-args": "1.0.7",
+                    "string_decoder": "0.10.31",
+                    "util-deprecate": "1.0.2"
+                  },
+                  "dependencies": {
+                    "core-util-is": {
+                      "version": "1.0.2",
+                      "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/core-util-is/-/core-util-is-1.0.2.tgz",
+                      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
+                      "dev": true
+                    },
+                    "inherits": {
+                      "version": "2.0.3",
+                      "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/inherits/-/inherits-2.0.3.tgz",
+                      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+                      "dev": true
+                    },
+                    "isarray": {
+                      "version": "1.0.0",
+                      "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/isarray/-/isarray-1.0.0.tgz",
+                      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+                      "dev": true
+                    },
+                    "process-nextick-args": {
+                      "version": "1.0.7",
+                      "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
+                      "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M=",
+                      "dev": true
+                    },
+                    "string_decoder": {
+                      "version": "0.10.31",
+                      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+                      "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
+                      "dev": true
+                    },
+                    "util-deprecate": {
+                      "version": "1.0.2",
+                      "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/util-deprecate/-/util-deprecate-1.0.2.tgz",
+                      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
+                      "dev": true
+                    }
+                  }
+                },
+                "xtend": {
+                  "version": "4.0.1",
+                  "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/xtend/-/xtend-4.0.1.tgz",
+                  "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68=",
+                  "dev": true
+                }
+              }
+            },
+            "vinyl": {
+              "version": "0.5.3",
+              "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-0.5.3.tgz",
+              "integrity": "sha1-sEVbOPxeDPMNQyUTLkYZcMIJHN4=",
+              "dev": true,
+              "requires": {
+                "clone": "1.0.2",
+                "clone-stats": "0.0.1",
+                "replace-ext": "0.0.1"
+              },
+              "dependencies": {
+                "clone": {
+                  "version": "1.0.2",
+                  "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/clone/-/clone-1.0.2.tgz",
+                  "integrity": "sha1-Jgt6meux7f4kdTgXX3gyQ8sZ0Uk=",
+                  "dev": true
+                },
+                "clone-stats": {
+                  "version": "0.0.1",
+                  "resolved": "https://registry.npmjs.org/clone-stats/-/clone-stats-0.0.1.tgz",
+                  "integrity": "sha1-uI+UqCzzi4eR1YBG6kAprYjKmdE=",
+                  "dev": true
+                }
+              }
+            }
+          }
+        },
+        "mocha": {
+          "version": "2.5.3",
+          "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/mocha/-/mocha-2.5.3.tgz",
+          "integrity": "sha1-FhvlvetJZ3HrmzV0UFC2IrWu/Fg=",
+          "dev": true,
+          "requires": {
+            "commander": "2.3.0",
+            "debug": "2.2.0",
+            "diff": "1.4.0",
+            "escape-string-regexp": "1.0.2",
+            "glob": "3.2.11",
+            "growl": "1.9.2",
+            "jade": "0.26.3",
+            "mkdirp": "0.5.1",
+            "supports-color": "1.2.0",
+            "to-iso-string": "0.0.2"
+          },
+          "dependencies": {
+            "commander": {
+              "version": "2.3.0",
+              "resolved": "https://registry.npmjs.org/commander/-/commander-2.3.0.tgz",
+              "integrity": "sha1-/UMOiJgy7DU7ms0d4hfBHLPu+HM=",
+              "dev": true
+            },
+            "diff": {
+              "version": "1.4.0",
+              "resolved": "https://registry.npmjs.org/diff/-/diff-1.4.0.tgz",
+              "integrity": "sha1-fyjS657nsVqX79ic5j3P2qPMur8=",
+              "dev": true
+            },
+            "escape-string-regexp": {
+              "version": "1.0.2",
+              "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.2.tgz",
+              "integrity": "sha1-Tbwv5nTnGUnK8/smlc5/LcHZqNE=",
+              "dev": true
+            },
+            "glob": {
+              "version": "3.2.11",
+              "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
+              "integrity": "sha1-Spc/Y1uRkPcV0QmH1cAP0oFevj0=",
+              "dev": true,
+              "requires": {
+                "inherits": "2.0.3",
+                "minimatch": "0.3.0"
+              },
+              "dependencies": {
+                "inherits": {
+                  "version": "2.0.3",
+                  "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/inherits/-/inherits-2.0.3.tgz",
+                  "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+                  "dev": true
+                },
+                "minimatch": {
+                  "version": "0.3.0",
+                  "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
+                  "integrity": "sha1-J12O2qxPG7MyZHIInnlJyDlGmd0=",
+                  "dev": true,
+                  "requires": {
+                    "lru-cache": "2.7.3",
+                    "sigmund": "1.0.1"
+                  },
+                  "dependencies": {
+                    "lru-cache": {
+                      "version": "2.7.3",
+                      "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/lru-cache/-/lru-cache-2.7.3.tgz",
+                      "integrity": "sha1-bUUk6LlV+V1PW1iFHOId1y+06VI=",
+                      "dev": true
+                    },
+                    "sigmund": {
+                      "version": "1.0.1",
+                      "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz",
+                      "integrity": "sha1-P/IfGYytIXX587eBhT/ZTQ0ZtZA=",
+                      "dev": true
+                    }
+                  }
+                }
+              }
+            },
+            "growl": {
+              "version": "1.9.2",
+              "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/growl/-/growl-1.9.2.tgz",
+              "integrity": "sha1-Dqd0NxXbjY3ixe3hd14bRayFwC8=",
+              "dev": true
+            },
+            "jade": {
+              "version": "0.26.3",
+              "resolved": "https://registry.npmjs.org/jade/-/jade-0.26.3.tgz",
+              "integrity": "sha1-jxDXl32NefL2/4YqgbBRPMslaGw=",
+              "dev": true,
+              "requires": {
+                "commander": "0.6.1",
+                "mkdirp": "0.3.0"
+              },
+              "dependencies": {
+                "commander": {
+                  "version": "0.6.1",
+                  "resolved": "https://registry.npmjs.org/commander/-/commander-0.6.1.tgz",
+                  "integrity": "sha1-+mihT2qUXVTbvlDYzbMyDp47GgY=",
+                  "dev": true
+                },
+                "mkdirp": {
+                  "version": "0.3.0",
+                  "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.0.tgz",
+                  "integrity": "sha1-G79asbqCevI1dRQ0kEJkVfSB/h4=",
+                  "dev": true
+                }
+              }
+            },
+            "mkdirp": {
+              "version": "0.5.1",
+              "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+              "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+              "dev": true,
+              "requires": {
+                "minimist": "0.0.8"
+              },
+              "dependencies": {
+                "minimist": {
+                  "version": "0.0.8",
+                  "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+                  "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+                  "dev": true
+                }
+              }
+            },
+            "supports-color": {
+              "version": "1.2.0",
+              "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/supports-color/-/supports-color-1.2.0.tgz",
+              "integrity": "sha1-/x7R5hFp0Gs88tWI4YixjYhH4X4=",
+              "dev": true
+            },
+            "to-iso-string": {
+              "version": "0.0.2",
+              "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/to-iso-string/-/to-iso-string-0.0.2.tgz",
+              "integrity": "sha1-TcGeZk38y+Jb2NtQiwDG2hWCVdE=",
+              "dev": true
+            }
+          }
+        },
+        "plur": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/plur/-/plur-2.1.2.tgz",
+          "integrity": "sha1-dIJFLBoPUI4+NE6uwxLJHCncZVo=",
+          "dev": true,
+          "requires": {
+            "irregular-plurals": "1.2.0"
+          },
+          "dependencies": {
+            "irregular-plurals": {
+              "version": "1.2.0",
+              "resolved": "https://registry.npmjs.org/irregular-plurals/-/irregular-plurals-1.2.0.tgz",
+              "integrity": "sha1-OPKZg0uowAwwvpxVThNyaXUv86w=",
+              "dev": true
+            }
+          }
+        },
+        "resolve-from": {
+          "version": "1.0.1",
+          "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/resolve-from/-/resolve-from-1.0.1.tgz",
+          "integrity": "sha1-Jsv+k10a7uq7Kbw/5a6wHpPUQiY=",
+          "dev": true
+        },
+        "temp": {
+          "version": "0.8.3",
+          "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/temp/-/temp-0.8.3.tgz",
+          "integrity": "sha1-4Ma8TSa5AxJEEOT+2BEDAU38H1k=",
+          "dev": true,
+          "requires": {
+            "os-tmpdir": "1.0.2",
+            "rimraf": "2.2.8"
+          },
+          "dependencies": {
+            "os-tmpdir": {
+              "version": "1.0.2",
+              "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+              "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
+              "dev": true
+            },
+            "rimraf": {
+              "version": "2.2.8",
+              "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/rimraf/-/rimraf-2.2.8.tgz",
+              "integrity": "sha1-5Dm+Kq7jJzIZUnMPmaiSnk/FBYI=",
+              "dev": true
+            }
+          }
+        },
+        "through": {
+          "version": "2.3.8",
+          "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/through/-/through-2.3.8.tgz",
+          "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
+          "dev": true
+        }
+      }
+    },
+    "handlebars": {
+      "version": "4.0.5",
+      "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/handlebars/-/handlebars-4.0.5.tgz",
+      "integrity": "sha1-ksbta7FkEQxQ1NjQ+93HCAbG+Oc=",
+      "dev": true,
+      "requires": {
+        "async": "1.5.2",
+        "optimist": "0.6.1",
+        "source-map": "0.4.4",
+        "uglify-js": "2.7.3"
+      },
+      "dependencies": {
+        "async": {
+          "version": "1.5.2",
+          "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/async/-/async-1.5.2.tgz",
+          "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=",
+          "dev": true
+        },
+        "optimist": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
+          "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
+          "dev": true,
+          "requires": {
+            "minimist": "0.0.10",
+            "wordwrap": "0.0.3"
+          },
+          "dependencies": {
+            "minimist": {
+              "version": "0.0.10",
+              "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
+              "integrity": "sha1-3j+YVD2/lggr5IrRoMfNqDYwHc8=",
+              "dev": true
+            },
+            "wordwrap": {
+              "version": "0.0.3",
+              "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
+              "integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc=",
+              "dev": true
+            }
+          }
+        },
+        "source-map": {
+          "version": "0.4.4",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
+          "integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
+          "dev": true,
+          "requires": {
+            "amdefine": "1.0.0"
+          },
+          "dependencies": {
+            "amdefine": {
+              "version": "1.0.0",
+              "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz",
+              "integrity": "sha1-/RdHRwDLXMnCtwnwvp0jzjwZjDM=",
+              "dev": true
+            }
+          }
+        },
+        "uglify-js": {
+          "version": "2.7.3",
+          "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/uglify-js/-/uglify-js-2.7.3.tgz",
+          "integrity": "sha1-ObOnMpuJ9exQfjRMbiJWhpjvSGg=",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "async": "0.2.10",
+            "source-map": "0.5.6",
+            "uglify-to-browserify": "1.0.2",
+            "yargs": "3.10.0"
+          },
+          "dependencies": {
+            "async": {
+              "version": "0.2.10",
+              "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz",
+              "integrity": "sha1-trvgsGdLnXGXCMo43owjfLUmw9E=",
+              "dev": true,
+              "optional": true
+            },
+            "source-map": {
+              "version": "0.5.6",
+              "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/source-map/-/source-map-0.5.6.tgz",
+              "integrity": "sha1-dc449SvwczxafwwRjYEzSiu19BI=",
+              "dev": true,
+              "optional": true
+            },
+            "uglify-to-browserify": {
+              "version": "1.0.2",
+              "resolved": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz",
+              "integrity": "sha1-bgkk1r2mta/jSeOabWMoUKD4grc=",
+              "dev": true,
+              "optional": true
+            },
+            "yargs": {
+              "version": "3.10.0",
+              "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
+              "integrity": "sha1-9+572FfdfB0tOMDnTvvWgdFDH9E=",
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "camelcase": "1.2.1",
+                "cliui": "2.1.0",
+                "decamelize": "1.2.0",
+                "window-size": "0.1.0"
+              },
+              "dependencies": {
+                "camelcase": {
+                  "version": "1.2.1",
+                  "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
+                  "integrity": "sha1-m7UwTS4LVmmLLHWLCKPqqdqlijk=",
+                  "dev": true,
+                  "optional": true
+                },
+                "cliui": {
+                  "version": "2.1.0",
+                  "resolved": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
+                  "integrity": "sha1-S0dXYP+AJkx2LDoXGQMukcf+oNE=",
+                  "dev": true,
+                  "optional": true,
+                  "requires": {
+                    "center-align": "0.1.3",
+                    "right-align": "0.1.3",
+                    "wordwrap": "0.0.2"
+                  },
+                  "dependencies": {
+                    "center-align": {
+                      "version": "0.1.3",
+                      "resolved": "https://registry.npmjs.org/center-align/-/center-align-0.1.3.tgz",
+                      "integrity": "sha1-qg0yYptu6XIgBBHL1EYckHvCt60=",
+                      "dev": true,
+                      "optional": true,
+                      "requires": {
+                        "align-text": "0.1.4",
+                        "lazy-cache": "1.0.4"
+                      },
+                      "dependencies": {
+                        "align-text": {
+                          "version": "0.1.4",
+                          "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
+                          "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
+                          "dev": true,
+                          "optional": true,
+                          "requires": {
+                            "kind-of": "3.0.4",
+                            "longest": "1.0.1",
+                            "repeat-string": "1.5.4"
+                          },
+                          "dependencies": {
+                            "kind-of": {
+                              "version": "3.0.4",
+                              "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/kind-of/-/kind-of-3.0.4.tgz",
+                              "integrity": "sha1-e47PGKThf4Jp1ztQHJ8jLJaIenQ=",
+                              "dev": true,
+                              "optional": true,
+                              "requires": {
+                                "is-buffer": "1.1.4"
+                              },
+                              "dependencies": {
+                                "is-buffer": {
+                                  "version": "1.1.4",
+                                  "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/is-buffer/-/is-buffer-1.1.4.tgz",
+                                  "integrity": "sha1-z8hszV3FpS+oBIkRHGkgxFfi2Ys=",
+                                  "dev": true,
+                                  "optional": true
+                                }
+                              }
+                            },
+                            "longest": {
+                              "version": "1.0.1",
+                              "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
+                              "integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc=",
+                              "dev": true,
+                              "optional": true
+                            },
+                            "repeat-string": {
+                              "version": "1.5.4",
+                              "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.5.4.tgz",
+                              "integrity": "sha1-ZOwMkeD0tHX5DVtkNlHj5uW2wtU=",
+                              "dev": true,
+                              "optional": true
+                            }
+                          }
+                        },
+                        "lazy-cache": {
+                          "version": "1.0.4",
+                          "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/lazy-cache/-/lazy-cache-1.0.4.tgz",
+                          "integrity": "sha1-odePw6UEdMuAhF07O24dpJpEbo4=",
+                          "dev": true,
+                          "optional": true
+                        }
+                      }
+                    },
+                    "right-align": {
+                      "version": "0.1.3",
+                      "resolved": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
+                      "integrity": "sha1-YTObci/mo1FWiSENJOFMlhSGE+8=",
+                      "dev": true,
+                      "optional": true,
+                      "requires": {
+                        "align-text": "0.1.4"
+                      },
+                      "dependencies": {
+                        "align-text": {
+                          "version": "0.1.4",
+                          "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
+                          "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
+                          "dev": true,
+                          "optional": true,
+                          "requires": {
+                            "kind-of": "3.0.4",
+                            "longest": "1.0.1",
+                            "repeat-string": "1.5.4"
+                          },
+                          "dependencies": {
+                            "kind-of": {
+                              "version": "3.0.4",
+                              "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/kind-of/-/kind-of-3.0.4.tgz",
+                              "integrity": "sha1-e47PGKThf4Jp1ztQHJ8jLJaIenQ=",
+                              "dev": true,
+                              "optional": true,
+                              "requires": {
+                                "is-buffer": "1.1.4"
+                              },
+                              "dependencies": {
+                                "is-buffer": {
+                                  "version": "1.1.4",
+                                  "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/is-buffer/-/is-buffer-1.1.4.tgz",
+                                  "integrity": "sha1-z8hszV3FpS+oBIkRHGkgxFfi2Ys=",
+                                  "dev": true,
+                                  "optional": true
+                                }
+                              }
+                            },
+                            "longest": {
+                              "version": "1.0.1",
+                              "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
+                              "integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc=",
+                              "dev": true,
+                              "optional": true
+                            },
+                            "repeat-string": {
+                              "version": "1.5.4",
+                              "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.5.4.tgz",
+                              "integrity": "sha1-ZOwMkeD0tHX5DVtkNlHj5uW2wtU=",
+                              "dev": true,
+                              "optional": true
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "wordwrap": {
+                      "version": "0.0.2",
+                      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
+                      "integrity": "sha1-t5Zpu0LstAn4PVg8rVLKF+qhZD8=",
+                      "dev": true,
+                      "optional": true
+                    }
+                  }
+                },
+                "decamelize": {
+                  "version": "1.2.0",
+                  "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+                  "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
+                  "dev": true,
+                  "optional": true
+                },
+                "window-size": {
+                  "version": "0.1.0",
+                  "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz",
+                  "integrity": "sha1-VDjNLqk7IC76Ohn+iIeu58lPnJ0=",
+                  "dev": true,
+                  "optional": true
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "lodash.includes": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
+      "integrity": "sha1-YLuYqHy5I8aMoeUTJUgzFISfVT8="
+    },
+    "lodash.merge": {
+      "version": "4.6.0",
+      "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/lodash.merge/-/lodash.merge-4.6.0.tgz",
+      "integrity": "sha1-aYhLoUSsM/5plzemCG3v+t0PicU="
+    },
+    "mocha": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-3.1.0.tgz",
+      "integrity": "sha1-EvJW/qiF4WoeYnoXHWi+7w8tYYw=",
+      "dev": true,
+      "requires": {
+        "browser-stdout": "1.3.0",
+        "commander": "2.9.0",
+        "debug": "2.2.0",
+        "diff": "1.4.0",
+        "escape-string-regexp": "1.0.5",
+        "glob": "7.0.5",
+        "growl": "1.9.2",
+        "json3": "3.3.2",
+        "lodash.create": "3.1.1",
+        "mkdirp": "0.5.1",
+        "supports-color": "3.1.2"
+      },
+      "dependencies": {
+        "browser-stdout": {
+          "version": "1.3.0",
+          "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.0.tgz",
+          "integrity": "sha1-81HTKWnTL6XXpVZxVCY9korjvR8=",
+          "dev": true
+        },
+        "commander": {
+          "version": "2.9.0",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
+          "integrity": "sha1-nJkJQXbhIkDLItbFFGCYQA/g99Q=",
+          "dev": true,
+          "requires": {
+            "graceful-readlink": "1.0.1"
+          },
+          "dependencies": {
+            "graceful-readlink": {
+              "version": "1.0.1",
+              "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz",
+              "integrity": "sha1-TK+tdrxi8C+gObL5Tpo906ORpyU=",
+              "dev": true
+            }
+          }
+        },
+        "diff": {
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/diff/-/diff-1.4.0.tgz",
+          "integrity": "sha1-fyjS657nsVqX79ic5j3P2qPMur8=",
+          "dev": true
+        },
+        "escape-string-regexp": {
+          "version": "1.0.5",
+          "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+          "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+          "dev": true
+        },
+        "glob": {
+          "version": "7.0.5",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.0.5.tgz",
+          "integrity": "sha1-tCAqaQmbu00pKnwblbZoK2fr3JU=",
+          "dev": true,
+          "requires": {
+            "fs.realpath": "1.0.0",
+            "inflight": "1.0.5",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.3",
+            "once": "1.4.0",
+            "path-is-absolute": "1.0.1"
+          },
+          "dependencies": {
+            "fs.realpath": {
+              "version": "1.0.0",
+              "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/fs.realpath/-/fs.realpath-1.0.0.tgz",
+              "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+              "dev": true
+            },
+            "inflight": {
+              "version": "1.0.5",
+              "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/inflight/-/inflight-1.0.5.tgz",
+              "integrity": "sha1-2zIEzVqd4ubNiQuFxuL2a89PYgo=",
+              "dev": true,
+              "requires": {
+                "once": "1.4.0",
+                "wrappy": "1.0.2"
+              },
+              "dependencies": {
+                "wrappy": {
+                  "version": "1.0.2",
+                  "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/wrappy/-/wrappy-1.0.2.tgz",
+                  "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+                  "dev": true
+                }
+              }
+            },
+            "inherits": {
+              "version": "2.0.3",
+              "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/inherits/-/inherits-2.0.3.tgz",
+              "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+              "dev": true
+            },
+            "minimatch": {
+              "version": "3.0.3",
+              "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/minimatch/-/minimatch-3.0.3.tgz",
+              "integrity": "sha1-Kk5AkLlrLbBqnX3wEFWmKnfJt3Q=",
+              "dev": true,
+              "requires": {
+                "brace-expansion": "1.1.6"
+              },
+              "dependencies": {
+                "brace-expansion": {
+                  "version": "1.1.6",
+                  "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/brace-expansion/-/brace-expansion-1.1.6.tgz",
+                  "integrity": "sha1-cZfX6qm4fmSDkOph/GbIRCdCDfk=",
+                  "dev": true,
+                  "requires": {
+                    "balanced-match": "0.4.2",
+                    "concat-map": "0.0.1"
+                  },
+                  "dependencies": {
+                    "balanced-match": {
+                      "version": "0.4.2",
+                      "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/balanced-match/-/balanced-match-0.4.2.tgz",
+                      "integrity": "sha1-yz8+PHMtwPAe5wtAPzAuYddwmDg=",
+                      "dev": true
+                    },
+                    "concat-map": {
+                      "version": "0.0.1",
+                      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+                      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+                      "dev": true
+                    }
+                  }
+                }
+              }
+            },
+            "once": {
+              "version": "1.4.0",
+              "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/once/-/once-1.4.0.tgz",
+              "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+              "dev": true,
+              "requires": {
+                "wrappy": "1.0.2"
+              },
+              "dependencies": {
+                "wrappy": {
+                  "version": "1.0.2",
+                  "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/wrappy/-/wrappy-1.0.2.tgz",
+                  "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+                  "dev": true
+                }
+              }
+            },
+            "path-is-absolute": {
+              "version": "1.0.1",
+              "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+              "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+              "dev": true
+            }
+          }
+        },
+        "growl": {
+          "version": "1.9.2",
+          "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/growl/-/growl-1.9.2.tgz",
+          "integrity": "sha1-Dqd0NxXbjY3ixe3hd14bRayFwC8=",
+          "dev": true
+        },
+        "json3": {
+          "version": "3.3.2",
+          "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/json3/-/json3-3.3.2.tgz",
+          "integrity": "sha1-PAQ0dD35Pi9cQq7nsZvLSDV19OE=",
+          "dev": true
+        },
+        "lodash.create": {
+          "version": "3.1.1",
+          "resolved": "https://registry.npmjs.org/lodash.create/-/lodash.create-3.1.1.tgz",
+          "integrity": "sha1-1/KEnw29p+BGgruM1yqwIkYd6+c=",
+          "dev": true,
+          "requires": {
+            "lodash._baseassign": "3.2.0",
+            "lodash._basecreate": "3.0.3",
+            "lodash._isiterateecall": "3.0.9"
+          },
+          "dependencies": {
+            "lodash._baseassign": {
+              "version": "3.2.0",
+              "resolved": "https://registry.npmjs.org/lodash._baseassign/-/lodash._baseassign-3.2.0.tgz",
+              "integrity": "sha1-jDigmVAPIVrQnlnxci/QxSv+Ck4=",
+              "dev": true,
+              "requires": {
+                "lodash._basecopy": "3.0.1",
+                "lodash.keys": "3.1.2"
+              },
+              "dependencies": {
+                "lodash._basecopy": {
+                  "version": "3.0.1",
+                  "resolved": "https://registry.npmjs.org/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz",
+                  "integrity": "sha1-jaDmqHbPNEwK2KVIghEd08XHyjY=",
+                  "dev": true
+                },
+                "lodash.keys": {
+                  "version": "3.1.2",
+                  "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/lodash.keys/-/lodash.keys-3.1.2.tgz",
+                  "integrity": "sha1-TbwEcrFWvlCgsoaFXRvQsMZWCYo=",
+                  "dev": true,
+                  "requires": {
+                    "lodash._getnative": "3.9.1",
+                    "lodash.isarguments": "3.1.0",
+                    "lodash.isarray": "3.0.4"
+                  },
+                  "dependencies": {
+                    "lodash._getnative": {
+                      "version": "3.9.1",
+                      "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/lodash._getnative/-/lodash._getnative-3.9.1.tgz",
+                      "integrity": "sha1-VwvH3t5G1hzc3mh9ZdPuy6o6r/U=",
+                      "dev": true
+                    },
+                    "lodash.isarguments": {
+                      "version": "3.1.0",
+                      "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
+                      "integrity": "sha1-L1c9hcaiQon/AGY7SRwdM4/zRYo=",
+                      "dev": true
+                    },
+                    "lodash.isarray": {
+                      "version": "3.0.4",
+                      "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/lodash.isarray/-/lodash.isarray-3.0.4.tgz",
+                      "integrity": "sha1-eeTriMNqgSKvhvhEqpvNhRtfu1U=",
+                      "dev": true
+                    }
+                  }
+                }
+              }
+            },
+            "lodash._basecreate": {
+              "version": "3.0.3",
+              "resolved": "https://registry.npmjs.org/lodash._basecreate/-/lodash._basecreate-3.0.3.tgz",
+              "integrity": "sha1-G8ZhYU2qf8MRt9A78WgGoCE8+CE=",
+              "dev": true
+            },
+            "lodash._isiterateecall": {
+              "version": "3.0.9",
+              "resolved": "https://registry.npmjs.org/lodash._isiterateecall/-/lodash._isiterateecall-3.0.9.tgz",
+              "integrity": "sha1-UgOte6Ql+uhCRg5pbbnPPmqsBXw=",
+              "dev": true
+            }
+          }
+        },
+        "mkdirp": {
+          "version": "0.5.1",
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+          "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+          "dev": true,
+          "requires": {
+            "minimist": "0.0.8"
+          },
+          "dependencies": {
+            "minimist": {
+              "version": "0.0.8",
+              "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+              "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+              "dev": true
+            }
+          }
+        },
+        "supports-color": {
+          "version": "3.1.2",
+          "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/supports-color/-/supports-color-3.1.2.tgz",
+          "integrity": "sha1-cqJiiU2dQIuVbKBf83su2KbiotU=",
+          "dev": true,
+          "requires": {
+            "has-flag": "1.0.0"
+          },
+          "dependencies": {
+            "has-flag": {
+              "version": "1.0.0",
+              "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/has-flag/-/has-flag-1.0.0.tgz",
+              "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo=",
+              "dev": true
+            }
+          }
+        }
+      }
+    },
+    "node-sass": {
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/node-sass/-/node-sass-3.10.1.tgz",
+      "integrity": "sha1-xTWy4aVDkkBZHgbXMIy2Y4INYWw=",
+      "requires": {
+        "async-foreach": "0.1.3",
+        "chalk": "1.1.3",
+        "cross-spawn": "3.0.1",
+        "gaze": "1.1.2",
+        "get-stdin": "4.0.1",
+        "glob": "7.1.0",
+        "in-publish": "2.0.0",
+        "lodash.assign": "4.2.0",
+        "lodash.clonedeep": "4.5.0",
+        "meow": "3.7.0",
+        "mkdirp": "0.5.1",
+        "nan": "2.4.0",
+        "node-gyp": "3.4.0",
+        "npmlog": "4.0.0",
+        "request": "2.75.0",
+        "sass-graph": "2.1.2"
+      },
+      "dependencies": {
+        "async-foreach": {
+          "version": "0.1.3",
+          "resolved": "https://registry.npmjs.org/async-foreach/-/async-foreach-0.1.3.tgz",
+          "integrity": "sha1-NhIfhFwFeBct5Bmpfb6x0W7DRUI="
+        },
+        "chalk": {
+          "version": "1.1.3",
+          "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/chalk/-/chalk-1.1.3.tgz",
+          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+          "requires": {
+            "ansi-styles": "2.2.1",
+            "escape-string-regexp": "1.0.5",
+            "has-ansi": "2.0.0",
+            "strip-ansi": "3.0.1",
+            "supports-color": "2.0.0"
+          },
+          "dependencies": {
+            "ansi-styles": {
+              "version": "2.2.1",
+              "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/ansi-styles/-/ansi-styles-2.2.1.tgz",
+              "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
+            },
+            "escape-string-regexp": {
+              "version": "1.0.5",
+              "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+              "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
+            },
+            "has-ansi": {
+              "version": "2.0.0",
+              "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/has-ansi/-/has-ansi-2.0.0.tgz",
+              "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
+              "requires": {
+                "ansi-regex": "2.0.0"
+              },
+              "dependencies": {
+                "ansi-regex": {
+                  "version": "2.0.0",
+                  "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/ansi-regex/-/ansi-regex-2.0.0.tgz",
+                  "integrity": "sha1-xQYbbg74qBd15Q9dZhUb9r83EQc="
+                }
+              }
+            },
+            "strip-ansi": {
+              "version": "3.0.1",
+              "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/strip-ansi/-/strip-ansi-3.0.1.tgz",
+              "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+              "requires": {
+                "ansi-regex": "2.0.0"
+              },
+              "dependencies": {
+                "ansi-regex": {
+                  "version": "2.0.0",
+                  "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/ansi-regex/-/ansi-regex-2.0.0.tgz",
+                  "integrity": "sha1-xQYbbg74qBd15Q9dZhUb9r83EQc="
+                }
+              }
+            },
+            "supports-color": {
+              "version": "2.0.0",
+              "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/supports-color/-/supports-color-2.0.0.tgz",
+              "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
+            }
+          }
+        },
+        "cross-spawn": {
+          "version": "3.0.1",
+          "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/cross-spawn/-/cross-spawn-3.0.1.tgz",
+          "integrity": "sha1-ElYDfsufDF9549bvE14wdwGEuYI=",
+          "requires": {
+            "lru-cache": "4.0.1",
+            "which": "1.2.11"
+          },
+          "dependencies": {
+            "lru-cache": {
+              "version": "4.0.1",
+              "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/lru-cache/-/lru-cache-4.0.1.tgz",
+              "integrity": "sha1-E0OVXtry432bnn7nJB4nxLn7cr4=",
+              "requires": {
+                "pseudomap": "1.0.2",
+                "yallist": "2.0.0"
+              },
+              "dependencies": {
+                "pseudomap": {
+                  "version": "1.0.2",
+                  "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/pseudomap/-/pseudomap-1.0.2.tgz",
+                  "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM="
+                },
+                "yallist": {
+                  "version": "2.0.0",
+                  "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/yallist/-/yallist-2.0.0.tgz",
+                  "integrity": "sha1-MGxUODXwnuGkyyO3vOmrNByRzdQ="
+                }
+              }
+            },
+            "which": {
+              "version": "1.2.11",
+              "resolved": "https://registry.npmjs.org/which/-/which-1.2.11.tgz",
+              "integrity": "sha1-yLLu6muMFln6fB3U/aq+lTPcXos=",
+              "requires": {
+                "isexe": "1.1.2"
+              },
+              "dependencies": {
+                "isexe": {
+                  "version": "1.1.2",
+                  "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/isexe/-/isexe-1.1.2.tgz",
+                  "integrity": "sha1-NvPiLmB1CSD15yQaR2qMakInWtA="
+                }
+              }
+            }
+          }
+        },
+        "gaze": {
+          "version": "1.1.2",
+          "resolved": "https://registry.npmjs.org/gaze/-/gaze-1.1.2.tgz",
+          "integrity": "sha1-hHIkZ3rbiHDWeSV+0ziP22HkAQU=",
+          "requires": {
+            "globule": "1.0.0"
+          },
+          "dependencies": {
+            "globule": {
+              "version": "1.0.0",
+              "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/globule/-/globule-1.0.0.tgz",
+              "integrity": "sha1-8irrqszgK+SSRT6XnDrptpg/HGw=",
+              "requires": {
+                "glob": "7.0.6",
+                "lodash": "4.9.0",
+                "minimatch": "3.0.3"
+              },
+              "dependencies": {
+                "glob": {
+                  "version": "7.0.6",
+                  "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/glob/-/glob-7.0.6.tgz",
+                  "integrity": "sha1-IRuvr0nlJbjNkyYNFKsTYVKz9Xo=",
+                  "requires": {
+                    "fs.realpath": "1.0.0",
+                    "inflight": "1.0.5",
+                    "inherits": "2.0.3",
+                    "minimatch": "3.0.3",
+                    "once": "1.4.0",
+                    "path-is-absolute": "1.0.1"
+                  },
+                  "dependencies": {
+                    "fs.realpath": {
+                      "version": "1.0.0",
+                      "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/fs.realpath/-/fs.realpath-1.0.0.tgz",
+                      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
+                    },
+                    "inflight": {
+                      "version": "1.0.5",
+                      "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/inflight/-/inflight-1.0.5.tgz",
+                      "integrity": "sha1-2zIEzVqd4ubNiQuFxuL2a89PYgo=",
+                      "requires": {
+                        "once": "1.4.0",
+                        "wrappy": "1.0.2"
+                      },
+                      "dependencies": {
+                        "wrappy": {
+                          "version": "1.0.2",
+                          "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/wrappy/-/wrappy-1.0.2.tgz",
+                          "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+                        }
+                      }
+                    },
+                    "inherits": {
+                      "version": "2.0.3",
+                      "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/inherits/-/inherits-2.0.3.tgz",
+                      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
+                    },
+                    "once": {
+                      "version": "1.4.0",
+                      "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/once/-/once-1.4.0.tgz",
+                      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+                      "requires": {
+                        "wrappy": "1.0.2"
+                      },
+                      "dependencies": {
+                        "wrappy": {
+                          "version": "1.0.2",
+                          "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/wrappy/-/wrappy-1.0.2.tgz",
+                          "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+                        }
+                      }
+                    },
+                    "path-is-absolute": {
+                      "version": "1.0.1",
+                      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+                      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
+                    }
+                  }
+                },
+                "lodash": {
+                  "version": "4.9.0",
+                  "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/lodash/-/lodash-4.9.0.tgz",
+                  "integrity": "sha1-TCDXQvA86F3HAODderm8q4Xm/BQ="
+                },
+                "minimatch": {
+                  "version": "3.0.3",
+                  "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/minimatch/-/minimatch-3.0.3.tgz",
+                  "integrity": "sha1-Kk5AkLlrLbBqnX3wEFWmKnfJt3Q=",
+                  "requires": {
+                    "brace-expansion": "1.1.6"
+                  },
+                  "dependencies": {
+                    "brace-expansion": {
+                      "version": "1.1.6",
+                      "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/brace-expansion/-/brace-expansion-1.1.6.tgz",
+                      "integrity": "sha1-cZfX6qm4fmSDkOph/GbIRCdCDfk=",
+                      "requires": {
+                        "balanced-match": "0.4.2",
+                        "concat-map": "0.0.1"
+                      },
+                      "dependencies": {
+                        "balanced-match": {
+                          "version": "0.4.2",
+                          "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/balanced-match/-/balanced-match-0.4.2.tgz",
+                          "integrity": "sha1-yz8+PHMtwPAe5wtAPzAuYddwmDg="
+                        },
+                        "concat-map": {
+                          "version": "0.0.1",
+                          "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+                          "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "get-stdin": {
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz",
+          "integrity": "sha1-uWjGsKBDhDJJAui/Gl3zJXmkUP4="
+        },
+        "in-publish": {
+          "version": "2.0.0",
+          "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/in-publish/-/in-publish-2.0.0.tgz",
+          "integrity": "sha1-4g/146KvwmkDILbcVSaCqcf631E="
+        },
+        "lodash.assign": {
+          "version": "4.2.0",
+          "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/lodash.assign/-/lodash.assign-4.2.0.tgz",
+          "integrity": "sha1-DZnzzNem0mHRm9rrkkUAXShYCOc="
+        },
+        "lodash.clonedeep": {
+          "version": "4.5.0",
+          "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
+          "integrity": "sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8="
+        },
+        "meow": {
+          "version": "3.7.0",
+          "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/meow/-/meow-3.7.0.tgz",
+          "integrity": "sha1-cstmi0JSKCkKu/qFaJJYcwioAfs=",
+          "requires": {
+            "camelcase-keys": "2.1.0",
+            "decamelize": "1.2.0",
+            "loud-rejection": "1.6.0",
+            "map-obj": "1.0.1",
+            "minimist": "1.2.0",
+            "normalize-package-data": "2.3.5",
+            "object-assign": "4.1.0",
+            "read-pkg-up": "1.0.1",
+            "redent": "1.0.0",
+            "trim-newlines": "1.0.0"
+          },
+          "dependencies": {
+            "camelcase-keys": {
+              "version": "2.1.0",
+              "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/camelcase-keys/-/camelcase-keys-2.1.0.tgz",
+              "integrity": "sha1-MIvur/3ygRkFHvodkyITyRuPkuc=",
+              "requires": {
+                "camelcase": "2.1.1",
+                "map-obj": "1.0.1"
+              },
+              "dependencies": {
+                "camelcase": {
+                  "version": "2.1.1",
+                  "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/camelcase/-/camelcase-2.1.1.tgz",
+                  "integrity": "sha1-fB0W1nmhu+WcoCys7PsBHiAfWh8="
+                }
+              }
+            },
+            "decamelize": {
+              "version": "1.2.0",
+              "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+              "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA="
+            },
+            "loud-rejection": {
+              "version": "1.6.0",
+              "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/loud-rejection/-/loud-rejection-1.6.0.tgz",
+              "integrity": "sha1-W0b4AUft7leIcPCG0Eghz5mOVR8=",
+              "requires": {
+                "currently-unhandled": "0.4.1",
+                "signal-exit": "3.0.1"
+              },
+              "dependencies": {
+                "currently-unhandled": {
+                  "version": "0.4.1",
+                  "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/currently-unhandled/-/currently-unhandled-0.4.1.tgz",
+                  "integrity": "sha1-mI3zP+qxke95mmE2nddsF635V+o=",
+                  "requires": {
+                    "array-find-index": "1.0.2"
+                  },
+                  "dependencies": {
+                    "array-find-index": {
+                      "version": "1.0.2",
+                      "resolved": "https://registry.npmjs.org/array-find-index/-/array-find-index-1.0.2.tgz",
+                      "integrity": "sha1-3wEKoSh+Fku9pvlyOwqWoexBh6E="
+                    }
+                  }
+                },
+                "signal-exit": {
+                  "version": "3.0.1",
+                  "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.1.tgz",
+                  "integrity": "sha1-WkyISZK2OnrNm623iUw+6c/MrYE="
+                }
+              }
+            },
+            "map-obj": {
+              "version": "1.0.1",
+              "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
+              "integrity": "sha1-2TPOuSBdgr3PSIb2dCvcK03qFG0="
+            },
+            "minimist": {
+              "version": "1.2.0",
+              "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/minimist/-/minimist-1.2.0.tgz",
+              "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
+            },
+            "normalize-package-data": {
+              "version": "2.3.5",
+              "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/normalize-package-data/-/normalize-package-data-2.3.5.tgz",
+              "integrity": "sha1-jZJPFClg4Xd+f/4XBUNjHMfLAt8=",
+              "requires": {
+                "hosted-git-info": "2.1.5",
+                "is-builtin-module": "1.0.0",
+                "semver": "5.3.0",
+                "validate-npm-package-license": "3.0.1"
+              },
+              "dependencies": {
+                "hosted-git-info": {
+                  "version": "2.1.5",
+                  "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/hosted-git-info/-/hosted-git-info-2.1.5.tgz",
+                  "integrity": "sha1-C6gdkNouJas0ozLm7HeTbhWYEYs="
+                },
+                "is-builtin-module": {
+                  "version": "1.0.0",
+                  "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
+                  "integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
+                  "requires": {
+                    "builtin-modules": "1.1.1"
+                  },
+                  "dependencies": {
+                    "builtin-modules": {
+                      "version": "1.1.1",
+                      "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/builtin-modules/-/builtin-modules-1.1.1.tgz",
+                      "integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8="
+                    }
+                  }
+                },
+                "validate-npm-package-license": {
+                  "version": "3.0.1",
+                  "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/validate-npm-package-license/-/validate-npm-package-license-3.0.1.tgz",
+                  "integrity": "sha1-KAS6vnEq0zeUWaz74kdGqywwP7w=",
+                  "requires": {
+                    "spdx-correct": "1.0.2",
+                    "spdx-expression-parse": "1.0.4"
+                  },
+                  "dependencies": {
+                    "spdx-correct": {
+                      "version": "1.0.2",
+                      "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/spdx-correct/-/spdx-correct-1.0.2.tgz",
+                      "integrity": "sha1-SzBz2TP/UfORLwOsVRlJikFQ20A=",
+                      "requires": {
+                        "spdx-license-ids": "1.2.2"
+                      },
+                      "dependencies": {
+                        "spdx-license-ids": {
+                          "version": "1.2.2",
+                          "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/spdx-license-ids/-/spdx-license-ids-1.2.2.tgz",
+                          "integrity": "sha1-yd96NCRZSt5r0RkA1ZZpbcBrrFc="
+                        }
+                      }
+                    },
+                    "spdx-expression-parse": {
+                      "version": "1.0.4",
+                      "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-1.0.4.tgz",
+                      "integrity": "sha1-m98vIOH0DtRH++JzJmGR/O1RYmw="
+                    }
+                  }
+                }
+              }
+            },
+            "object-assign": {
+              "version": "4.1.0",
+              "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/object-assign/-/object-assign-4.1.0.tgz",
+              "integrity": "sha1-ejs9DpgGPUP0wD8uiubNUahog6A="
+            },
+            "read-pkg-up": {
+              "version": "1.0.1",
+              "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
+              "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
+              "requires": {
+                "find-up": "1.1.2",
+                "read-pkg": "1.1.0"
+              },
+              "dependencies": {
+                "find-up": {
+                  "version": "1.1.2",
+                  "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/find-up/-/find-up-1.1.2.tgz",
+                  "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
+                  "requires": {
+                    "path-exists": "2.1.0",
+                    "pinkie-promise": "2.0.1"
+                  },
+                  "dependencies": {
+                    "path-exists": {
+                      "version": "2.1.0",
+                      "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/path-exists/-/path-exists-2.1.0.tgz",
+                      "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
+                      "requires": {
+                        "pinkie-promise": "2.0.1"
+                      }
+                    },
+                    "pinkie-promise": {
+                      "version": "2.0.1",
+                      "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
+                      "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
+                      "requires": {
+                        "pinkie": "2.0.4"
+                      },
+                      "dependencies": {
+                        "pinkie": {
+                          "version": "2.0.4",
+                          "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/pinkie/-/pinkie-2.0.4.tgz",
+                          "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA="
+                        }
+                      }
+                    }
+                  }
+                },
+                "read-pkg": {
+                  "version": "1.1.0",
+                  "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/read-pkg/-/read-pkg-1.1.0.tgz",
+                  "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
+                  "requires": {
+                    "load-json-file": "1.1.0",
+                    "normalize-package-data": "2.3.5",
+                    "path-type": "1.1.0"
+                  },
+                  "dependencies": {
+                    "load-json-file": {
+                      "version": "1.1.0",
+                      "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/load-json-file/-/load-json-file-1.1.0.tgz",
+                      "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
+                      "requires": {
+                        "graceful-fs": "4.1.9",
+                        "parse-json": "2.2.0",
+                        "pify": "2.3.0",
+                        "pinkie-promise": "2.0.1",
+                        "strip-bom": "2.0.0"
+                      },
+                      "dependencies": {
+                        "graceful-fs": {
+                          "version": "4.1.9",
+                          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.9.tgz",
+                          "integrity": "sha1-uqy6N9GdEfnRRtNXi8mZWMN4fik="
+                        },
+                        "parse-json": {
+                          "version": "2.2.0",
+                          "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/parse-json/-/parse-json-2.2.0.tgz",
+                          "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
+                          "requires": {
+                            "error-ex": "1.3.0"
+                          },
+                          "dependencies": {
+                            "error-ex": {
+                              "version": "1.3.0",
+                              "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/error-ex/-/error-ex-1.3.0.tgz",
+                              "integrity": "sha1-5ntD8+gsluo6WE/+4Ln8MyXYAtk=",
+                              "requires": {
+                                "is-arrayish": "0.2.1"
+                              },
+                              "dependencies": {
+                                "is-arrayish": {
+                                  "version": "0.2.1",
+                                  "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/is-arrayish/-/is-arrayish-0.2.1.tgz",
+                                  "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0="
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "pify": {
+                          "version": "2.3.0",
+                          "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/pify/-/pify-2.3.0.tgz",
+                          "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw="
+                        },
+                        "pinkie-promise": {
+                          "version": "2.0.1",
+                          "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
+                          "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
+                          "requires": {
+                            "pinkie": "2.0.4"
+                          },
+                          "dependencies": {
+                            "pinkie": {
+                              "version": "2.0.4",
+                              "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/pinkie/-/pinkie-2.0.4.tgz",
+                              "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA="
+                            }
+                          }
+                        },
+                        "strip-bom": {
+                          "version": "2.0.0",
+                          "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/strip-bom/-/strip-bom-2.0.0.tgz",
+                          "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
+                          "requires": {
+                            "is-utf8": "0.2.1"
+                          },
+                          "dependencies": {
+                            "is-utf8": {
+                              "version": "0.2.1",
+                              "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/is-utf8/-/is-utf8-0.2.1.tgz",
+                              "integrity": "sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI="
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "path-type": {
+                      "version": "1.1.0",
+                      "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/path-type/-/path-type-1.1.0.tgz",
+                      "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
+                      "requires": {
+                        "graceful-fs": "4.1.9",
+                        "pify": "2.3.0",
+                        "pinkie-promise": "2.0.1"
+                      },
+                      "dependencies": {
+                        "graceful-fs": {
+                          "version": "4.1.9",
+                          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.9.tgz",
+                          "integrity": "sha1-uqy6N9GdEfnRRtNXi8mZWMN4fik="
+                        },
+                        "pify": {
+                          "version": "2.3.0",
+                          "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/pify/-/pify-2.3.0.tgz",
+                          "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw="
+                        },
+                        "pinkie-promise": {
+                          "version": "2.0.1",
+                          "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
+                          "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
+                          "requires": {
+                            "pinkie": "2.0.4"
+                          },
+                          "dependencies": {
+                            "pinkie": {
+                              "version": "2.0.4",
+                              "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/pinkie/-/pinkie-2.0.4.tgz",
+                              "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA="
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "redent": {
+              "version": "1.0.0",
+              "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/redent/-/redent-1.0.0.tgz",
+              "integrity": "sha1-z5Fqsf1fHxbfsggi3W7H9zDCr94=",
+              "requires": {
+                "indent-string": "2.1.0",
+                "strip-indent": "1.0.1"
+              },
+              "dependencies": {
+                "indent-string": {
+                  "version": "2.1.0",
+                  "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/indent-string/-/indent-string-2.1.0.tgz",
+                  "integrity": "sha1-ji1INIdCEhtKghi3oTfppSBJ3IA=",
+                  "requires": {
+                    "repeating": "2.0.1"
+                  },
+                  "dependencies": {
+                    "repeating": {
+                      "version": "2.0.1",
+                      "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/repeating/-/repeating-2.0.1.tgz",
+                      "integrity": "sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo=",
+                      "requires": {
+                        "is-finite": "1.0.2"
+                      },
+                      "dependencies": {
+                        "is-finite": {
+                          "version": "1.0.2",
+                          "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.2.tgz",
+                          "integrity": "sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko=",
+                          "requires": {
+                            "number-is-nan": "1.0.1"
+                          },
+                          "dependencies": {
+                            "number-is-nan": {
+                              "version": "1.0.1",
+                              "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
+                              "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                },
+                "strip-indent": {
+                  "version": "1.0.1",
+                  "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/strip-indent/-/strip-indent-1.0.1.tgz",
+                  "integrity": "sha1-DHlipq3vp7vUrDZkYKY4VSrhoKI=",
+                  "requires": {
+                    "get-stdin": "4.0.1"
+                  }
+                }
+              }
+            },
+            "trim-newlines": {
+              "version": "1.0.0",
+              "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/trim-newlines/-/trim-newlines-1.0.0.tgz",
+              "integrity": "sha1-WIeWa7WCpFA6QetST301ARgVphM="
+            }
+          }
+        },
+        "mkdirp": {
+          "version": "0.5.1",
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+          "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+          "requires": {
+            "minimist": "0.0.8"
+          },
+          "dependencies": {
+            "minimist": {
+              "version": "0.0.8",
+              "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+              "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
+            }
+          }
+        },
+        "nan": {
+          "version": "2.4.0",
+          "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/nan/-/nan-2.4.0.tgz",
+          "integrity": "sha1-+zxZ1F/k7/4hXwuJD4rfbrMtIjI="
+        },
+        "node-gyp": {
+          "version": "3.4.0",
+          "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/node-gyp/-/node-gyp-3.4.0.tgz",
+          "integrity": "sha1-3aVYOTs+y74kyea4cDxxGUxj+jY=",
+          "requires": {
+            "fstream": "1.0.10",
+            "glob": "7.1.0",
+            "graceful-fs": "4.1.9",
+            "minimatch": "3.0.3",
+            "mkdirp": "0.5.1",
+            "nopt": "3.0.6",
+            "npmlog": "3.1.2",
+            "osenv": "0.1.3",
+            "path-array": "1.0.1",
+            "request": "2.75.0",
+            "rimraf": "2.5.4",
+            "semver": "5.3.0",
+            "tar": "2.2.1",
+            "which": "1.2.11"
+          },
+          "dependencies": {
+            "fstream": {
+              "version": "1.0.10",
+              "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/fstream/-/fstream-1.0.10.tgz",
+              "integrity": "sha1-YE6Kkv4m/9n2+uMDmdSYThqyKCI=",
+              "requires": {
+                "graceful-fs": "4.1.9",
+                "inherits": "2.0.3",
+                "mkdirp": "0.5.1",
+                "rimraf": "2.5.4"
+              },
+              "dependencies": {
+                "inherits": {
+                  "version": "2.0.3",
+                  "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/inherits/-/inherits-2.0.3.tgz",
+                  "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
+                }
+              }
+            },
+            "graceful-fs": {
+              "version": "4.1.9",
+              "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.9.tgz",
+              "integrity": "sha1-uqy6N9GdEfnRRtNXi8mZWMN4fik="
+            },
+            "minimatch": {
+              "version": "3.0.3",
+              "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/minimatch/-/minimatch-3.0.3.tgz",
+              "integrity": "sha1-Kk5AkLlrLbBqnX3wEFWmKnfJt3Q=",
+              "requires": {
+                "brace-expansion": "1.1.6"
+              },
+              "dependencies": {
+                "brace-expansion": {
+                  "version": "1.1.6",
+                  "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/brace-expansion/-/brace-expansion-1.1.6.tgz",
+                  "integrity": "sha1-cZfX6qm4fmSDkOph/GbIRCdCDfk=",
+                  "requires": {
+                    "balanced-match": "0.4.2",
+                    "concat-map": "0.0.1"
+                  },
+                  "dependencies": {
+                    "balanced-match": {
+                      "version": "0.4.2",
+                      "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/balanced-match/-/balanced-match-0.4.2.tgz",
+                      "integrity": "sha1-yz8+PHMtwPAe5wtAPzAuYddwmDg="
+                    },
+                    "concat-map": {
+                      "version": "0.0.1",
+                      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+                      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+                    }
+                  }
+                }
+              }
+            },
+            "nopt": {
+              "version": "3.0.6",
+              "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/nopt/-/nopt-3.0.6.tgz",
+              "integrity": "sha1-xkZdvwirzU2zWTF/eaxopkayj/k=",
+              "requires": {
+                "abbrev": "1.0.9"
+              },
+              "dependencies": {
+                "abbrev": {
+                  "version": "1.0.9",
+                  "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/abbrev/-/abbrev-1.0.9.tgz",
+                  "integrity": "sha1-kbR5JYinc4wl813W9jdSovh3YTU="
+                }
+              }
+            },
+            "npmlog": {
+              "version": "3.1.2",
+              "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/npmlog/-/npmlog-3.1.2.tgz",
+              "integrity": "sha1-LUb6h0M3r5SYovErtD2NC+SjaHM=",
+              "requires": {
+                "are-we-there-yet": "1.1.2",
+                "console-control-strings": "1.1.0",
+                "gauge": "2.6.0",
+                "set-blocking": "2.0.0"
+              },
+              "dependencies": {
+                "are-we-there-yet": {
+                  "version": "1.1.2",
+                  "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/are-we-there-yet/-/are-we-there-yet-1.1.2.tgz",
+                  "integrity": "sha1-gORw6VoIR5T+GJkmLFZnxuiN4bM=",
+                  "requires": {
+                    "delegates": "1.0.0",
+                    "readable-stream": "2.1.5"
+                  },
+                  "dependencies": {
+                    "delegates": {
+                      "version": "1.0.0",
+                      "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/delegates/-/delegates-1.0.0.tgz",
+                      "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o="
+                    },
+                    "readable-stream": {
+                      "version": "2.1.5",
+                      "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/readable-stream/-/readable-stream-2.1.5.tgz",
+                      "integrity": "sha1-ZvqLcg4UOLNkaB8q0aY8YYRIydA=",
+                      "requires": {
+                        "buffer-shims": "1.0.0",
+                        "core-util-is": "1.0.2",
+                        "inherits": "2.0.3",
+                        "isarray": "1.0.0",
+                        "process-nextick-args": "1.0.7",
+                        "string_decoder": "0.10.31",
+                        "util-deprecate": "1.0.2"
+                      },
+                      "dependencies": {
+                        "buffer-shims": {
+                          "version": "1.0.0",
+                          "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/buffer-shims/-/buffer-shims-1.0.0.tgz",
+                          "integrity": "sha1-mXjOMXOIxkmth5MCjDR37wRKi1E="
+                        },
+                        "core-util-is": {
+                          "version": "1.0.2",
+                          "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/core-util-is/-/core-util-is-1.0.2.tgz",
+                          "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
+                        },
+                        "inherits": {
+                          "version": "2.0.3",
+                          "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/inherits/-/inherits-2.0.3.tgz",
+                          "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
+                        },
+                        "isarray": {
+                          "version": "1.0.0",
+                          "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/isarray/-/isarray-1.0.0.tgz",
+                          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+                        },
+                        "process-nextick-args": {
+                          "version": "1.0.7",
+                          "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
+                          "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M="
+                        },
+                        "string_decoder": {
+                          "version": "0.10.31",
+                          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+                          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
+                        },
+                        "util-deprecate": {
+                          "version": "1.0.2",
+                          "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/util-deprecate/-/util-deprecate-1.0.2.tgz",
+                          "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
+                        }
+                      }
+                    }
+                  }
+                },
+                "console-control-strings": {
+                  "version": "1.1.0",
+                  "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/console-control-strings/-/console-control-strings-1.1.0.tgz",
+                  "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4="
+                },
+                "gauge": {
+                  "version": "2.6.0",
+                  "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/gauge/-/gauge-2.6.0.tgz",
+                  "integrity": "sha1-01MBrRjpaQK0dR3LvkD0IYuUKkY=",
+                  "requires": {
+                    "aproba": "1.0.4",
+                    "console-control-strings": "1.1.0",
+                    "has-color": "0.1.7",
+                    "has-unicode": "2.0.1",
+                    "object-assign": "4.1.0",
+                    "signal-exit": "3.0.1",
+                    "string-width": "1.0.2",
+                    "strip-ansi": "3.0.1",
+                    "wide-align": "1.1.0"
+                  },
+                  "dependencies": {
+                    "aproba": {
+                      "version": "1.0.4",
+                      "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/aproba/-/aproba-1.0.4.tgz",
+                      "integrity": "sha1-JxNoB3XnYUyLoYbAZdTi5S0QcsA="
+                    },
+                    "has-color": {
+                      "version": "0.1.7",
+                      "resolved": "https://registry.npmjs.org/has-color/-/has-color-0.1.7.tgz",
+                      "integrity": "sha1-ZxRKUmDDT8PMpnfQQdr1L+e3iy8="
+                    },
+                    "has-unicode": {
+                      "version": "2.0.1",
+                      "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/has-unicode/-/has-unicode-2.0.1.tgz",
+                      "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk="
+                    },
+                    "object-assign": {
+                      "version": "4.1.0",
+                      "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/object-assign/-/object-assign-4.1.0.tgz",
+                      "integrity": "sha1-ejs9DpgGPUP0wD8uiubNUahog6A="
+                    },
+                    "signal-exit": {
+                      "version": "3.0.1",
+                      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.1.tgz",
+                      "integrity": "sha1-WkyISZK2OnrNm623iUw+6c/MrYE="
+                    },
+                    "string-width": {
+                      "version": "1.0.2",
+                      "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/string-width/-/string-width-1.0.2.tgz",
+                      "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+                      "requires": {
+                        "code-point-at": "1.0.1",
+                        "is-fullwidth-code-point": "1.0.0",
+                        "strip-ansi": "3.0.1"
+                      },
+                      "dependencies": {
+                        "code-point-at": {
+                          "version": "1.0.1",
+                          "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.0.1.tgz",
+                          "integrity": "sha1-EQTNNPm1tF0+uojxurwZJOHONfs=",
+                          "requires": {
+                            "number-is-nan": "1.0.1"
+                          },
+                          "dependencies": {
+                            "number-is-nan": {
+                              "version": "1.0.1",
+                              "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
+                              "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
+                            }
+                          }
+                        },
+                        "is-fullwidth-code-point": {
+                          "version": "1.0.0",
+                          "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+                          "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+                          "requires": {
+                            "number-is-nan": "1.0.1"
+                          },
+                          "dependencies": {
+                            "number-is-nan": {
+                              "version": "1.0.1",
+                              "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
+                              "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "strip-ansi": {
+                      "version": "3.0.1",
+                      "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/strip-ansi/-/strip-ansi-3.0.1.tgz",
+                      "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+                      "requires": {
+                        "ansi-regex": "2.0.0"
+                      },
+                      "dependencies": {
+                        "ansi-regex": {
+                          "version": "2.0.0",
+                          "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/ansi-regex/-/ansi-regex-2.0.0.tgz",
+                          "integrity": "sha1-xQYbbg74qBd15Q9dZhUb9r83EQc="
+                        }
+                      }
+                    },
+                    "wide-align": {
+                      "version": "1.1.0",
+                      "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/wide-align/-/wide-align-1.1.0.tgz",
+                      "integrity": "sha1-QO3egCpx/qHwcNo+YtzaLnrdlq0=",
+                      "requires": {
+                        "string-width": "1.0.2"
+                      }
+                    }
+                  }
+                },
+                "set-blocking": {
+                  "version": "2.0.0",
+                  "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/set-blocking/-/set-blocking-2.0.0.tgz",
+                  "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc="
+                }
+              }
+            },
+            "osenv": {
+              "version": "0.1.3",
+              "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/osenv/-/osenv-0.1.3.tgz",
+              "integrity": "sha1-g88FxtZFj8TVrGNi6jJdkvJ1Qhc=",
+              "requires": {
+                "os-homedir": "1.0.2",
+                "os-tmpdir": "1.0.2"
+              },
+              "dependencies": {
+                "os-homedir": {
+                  "version": "1.0.2",
+                  "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
+                  "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M="
+                },
+                "os-tmpdir": {
+                  "version": "1.0.2",
+                  "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+                  "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ="
+                }
+              }
+            },
+            "path-array": {
+              "version": "1.0.1",
+              "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/path-array/-/path-array-1.0.1.tgz",
+              "integrity": "sha1-fi8PNfB6IBUSK4aLfqwOssT+wnE=",
+              "requires": {
+                "array-index": "1.0.0"
+              },
+              "dependencies": {
+                "array-index": {
+                  "version": "1.0.0",
+                  "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/array-index/-/array-index-1.0.0.tgz",
+                  "integrity": "sha1-7FanSe4QPk4Ix5C5w1PfFgVbl/k=",
+                  "requires": {
+                    "debug": "2.2.0",
+                    "es6-symbol": "3.1.0"
+                  },
+                  "dependencies": {
+                    "es6-symbol": {
+                      "version": "3.1.0",
+                      "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/es6-symbol/-/es6-symbol-3.1.0.tgz",
+                      "integrity": "sha1-lEgcZV56fK2C66gy2X1UM0ltf/o=",
+                      "requires": {
+                        "d": "0.1.1",
+                        "es5-ext": "0.10.12"
+                      },
+                      "dependencies": {
+                        "d": {
+                          "version": "0.1.1",
+                          "resolved": "https://registry.npmjs.org/d/-/d-0.1.1.tgz",
+                          "integrity": "sha1-2hhMU10Y2O57oqoim5FACfrhEwk=",
+                          "requires": {
+                            "es5-ext": "0.10.12"
+                          }
+                        },
+                        "es5-ext": {
+                          "version": "0.10.12",
+                          "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/es5-ext/-/es5-ext-0.10.12.tgz",
+                          "integrity": "sha1-qoRkHU23a2Krul5F/YBey6sUAEc=",
+                          "requires": {
+                            "es6-iterator": "2.0.0",
+                            "es6-symbol": "3.1.0"
+                          },
+                          "dependencies": {
+                            "es6-iterator": {
+                              "version": "2.0.0",
+                              "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/es6-iterator/-/es6-iterator-2.0.0.tgz",
+                              "integrity": "sha1-vZaFZ9YWNeM8C4BydhPJy0sJa6w=",
+                              "requires": {
+                                "d": "0.1.1",
+                                "es5-ext": "0.10.12",
+                                "es6-symbol": "3.1.0"
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "rimraf": {
+              "version": "2.5.4",
+              "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/rimraf/-/rimraf-2.5.4.tgz",
+              "integrity": "sha1-loAAk8vxoMhr2VtGJUZ1NcKd+gQ=",
+              "requires": {
+                "glob": "7.1.0"
+              }
+            },
+            "tar": {
+              "version": "2.2.1",
+              "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/tar/-/tar-2.2.1.tgz",
+              "integrity": "sha1-jk0qJWwOIYXGsYrWlK7JaLg8sdE=",
+              "requires": {
+                "block-stream": "0.0.9",
+                "fstream": "1.0.10",
+                "inherits": "2.0.3"
+              },
+              "dependencies": {
+                "block-stream": {
+                  "version": "0.0.9",
+                  "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/block-stream/-/block-stream-0.0.9.tgz",
+                  "integrity": "sha1-E+v+d4oDIFz+A3UUgeu0szAMEmo=",
+                  "requires": {
+                    "inherits": "2.0.3"
+                  }
+                },
+                "inherits": {
+                  "version": "2.0.3",
+                  "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/inherits/-/inherits-2.0.3.tgz",
+                  "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
+                }
+              }
+            },
+            "which": {
+              "version": "1.2.11",
+              "resolved": "https://registry.npmjs.org/which/-/which-1.2.11.tgz",
+              "integrity": "sha1-yLLu6muMFln6fB3U/aq+lTPcXos=",
+              "requires": {
+                "isexe": "1.1.2"
+              },
+              "dependencies": {
+                "isexe": {
+                  "version": "1.1.2",
+                  "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/isexe/-/isexe-1.1.2.tgz",
+                  "integrity": "sha1-NvPiLmB1CSD15yQaR2qMakInWtA="
+                }
+              }
+            }
+          }
+        },
+        "npmlog": {
+          "version": "4.0.0",
+          "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/npmlog/-/npmlog-4.0.0.tgz",
+          "integrity": "sha1-4JRQOWHHDBd063ZpIIDo1Xip+I8=",
+          "requires": {
+            "are-we-there-yet": "1.1.2",
+            "console-control-strings": "1.1.0",
+            "gauge": "2.6.0",
+            "set-blocking": "2.0.0"
+          },
+          "dependencies": {
+            "are-we-there-yet": {
+              "version": "1.1.2",
+              "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/are-we-there-yet/-/are-we-there-yet-1.1.2.tgz",
+              "integrity": "sha1-gORw6VoIR5T+GJkmLFZnxuiN4bM=",
+              "requires": {
+                "delegates": "1.0.0",
+                "readable-stream": "2.1.5"
+              },
+              "dependencies": {
+                "delegates": {
+                  "version": "1.0.0",
+                  "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/delegates/-/delegates-1.0.0.tgz",
+                  "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o="
+                },
+                "readable-stream": {
+                  "version": "2.1.5",
+                  "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/readable-stream/-/readable-stream-2.1.5.tgz",
+                  "integrity": "sha1-ZvqLcg4UOLNkaB8q0aY8YYRIydA=",
+                  "requires": {
+                    "buffer-shims": "1.0.0",
+                    "core-util-is": "1.0.2",
+                    "inherits": "2.0.3",
+                    "isarray": "1.0.0",
+                    "process-nextick-args": "1.0.7",
+                    "string_decoder": "0.10.31",
+                    "util-deprecate": "1.0.2"
+                  },
+                  "dependencies": {
+                    "buffer-shims": {
+                      "version": "1.0.0",
+                      "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/buffer-shims/-/buffer-shims-1.0.0.tgz",
+                      "integrity": "sha1-mXjOMXOIxkmth5MCjDR37wRKi1E="
+                    },
+                    "core-util-is": {
+                      "version": "1.0.2",
+                      "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/core-util-is/-/core-util-is-1.0.2.tgz",
+                      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
+                    },
+                    "inherits": {
+                      "version": "2.0.3",
+                      "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/inherits/-/inherits-2.0.3.tgz",
+                      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
+                    },
+                    "isarray": {
+                      "version": "1.0.0",
+                      "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/isarray/-/isarray-1.0.0.tgz",
+                      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+                    },
+                    "process-nextick-args": {
+                      "version": "1.0.7",
+                      "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
+                      "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M="
+                    },
+                    "string_decoder": {
+                      "version": "0.10.31",
+                      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+                      "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
+                    },
+                    "util-deprecate": {
+                      "version": "1.0.2",
+                      "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/util-deprecate/-/util-deprecate-1.0.2.tgz",
+                      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
+                    }
+                  }
+                }
+              }
+            },
+            "console-control-strings": {
+              "version": "1.1.0",
+              "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/console-control-strings/-/console-control-strings-1.1.0.tgz",
+              "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4="
+            },
+            "gauge": {
+              "version": "2.6.0",
+              "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/gauge/-/gauge-2.6.0.tgz",
+              "integrity": "sha1-01MBrRjpaQK0dR3LvkD0IYuUKkY=",
+              "requires": {
+                "aproba": "1.0.4",
+                "console-control-strings": "1.1.0",
+                "has-color": "0.1.7",
+                "has-unicode": "2.0.1",
+                "object-assign": "4.1.0",
+                "signal-exit": "3.0.1",
+                "string-width": "1.0.2",
+                "strip-ansi": "3.0.1",
+                "wide-align": "1.1.0"
+              },
+              "dependencies": {
+                "aproba": {
+                  "version": "1.0.4",
+                  "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/aproba/-/aproba-1.0.4.tgz",
+                  "integrity": "sha1-JxNoB3XnYUyLoYbAZdTi5S0QcsA="
+                },
+                "has-color": {
+                  "version": "0.1.7",
+                  "resolved": "https://registry.npmjs.org/has-color/-/has-color-0.1.7.tgz",
+                  "integrity": "sha1-ZxRKUmDDT8PMpnfQQdr1L+e3iy8="
+                },
+                "has-unicode": {
+                  "version": "2.0.1",
+                  "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/has-unicode/-/has-unicode-2.0.1.tgz",
+                  "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk="
+                },
+                "object-assign": {
+                  "version": "4.1.0",
+                  "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/object-assign/-/object-assign-4.1.0.tgz",
+                  "integrity": "sha1-ejs9DpgGPUP0wD8uiubNUahog6A="
+                },
+                "signal-exit": {
+                  "version": "3.0.1",
+                  "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.1.tgz",
+                  "integrity": "sha1-WkyISZK2OnrNm623iUw+6c/MrYE="
+                },
+                "string-width": {
+                  "version": "1.0.2",
+                  "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/string-width/-/string-width-1.0.2.tgz",
+                  "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+                  "requires": {
+                    "code-point-at": "1.0.1",
+                    "is-fullwidth-code-point": "1.0.0",
+                    "strip-ansi": "3.0.1"
+                  },
+                  "dependencies": {
+                    "code-point-at": {
+                      "version": "1.0.1",
+                      "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.0.1.tgz",
+                      "integrity": "sha1-EQTNNPm1tF0+uojxurwZJOHONfs=",
+                      "requires": {
+                        "number-is-nan": "1.0.1"
+                      },
+                      "dependencies": {
+                        "number-is-nan": {
+                          "version": "1.0.1",
+                          "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
+                          "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
+                        }
+                      }
+                    },
+                    "is-fullwidth-code-point": {
+                      "version": "1.0.0",
+                      "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+                      "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+                      "requires": {
+                        "number-is-nan": "1.0.1"
+                      },
+                      "dependencies": {
+                        "number-is-nan": {
+                          "version": "1.0.1",
+                          "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
+                          "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
+                        }
+                      }
+                    }
+                  }
+                },
+                "strip-ansi": {
+                  "version": "3.0.1",
+                  "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/strip-ansi/-/strip-ansi-3.0.1.tgz",
+                  "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+                  "requires": {
+                    "ansi-regex": "2.0.0"
+                  },
+                  "dependencies": {
+                    "ansi-regex": {
+                      "version": "2.0.0",
+                      "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/ansi-regex/-/ansi-regex-2.0.0.tgz",
+                      "integrity": "sha1-xQYbbg74qBd15Q9dZhUb9r83EQc="
+                    }
+                  }
+                },
+                "wide-align": {
+                  "version": "1.1.0",
+                  "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/wide-align/-/wide-align-1.1.0.tgz",
+                  "integrity": "sha1-QO3egCpx/qHwcNo+YtzaLnrdlq0=",
+                  "requires": {
+                    "string-width": "1.0.2"
+                  }
+                }
+              }
+            },
+            "set-blocking": {
+              "version": "2.0.0",
+              "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/set-blocking/-/set-blocking-2.0.0.tgz",
+              "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc="
+            }
+          }
+        },
+        "request": {
+          "version": "2.75.0",
+          "resolved": "https://registry.npmjs.org/request/-/request-2.75.0.tgz",
+          "integrity": "sha1-0rgmiihtoT6qXQGt9dGMyQ9lfZM=",
+          "requires": {
+            "aws-sign2": "0.6.0",
+            "aws4": "1.4.1",
+            "bl": "1.1.2",
+            "caseless": "0.11.0",
+            "combined-stream": "1.0.5",
+            "extend": "3.0.0",
+            "forever-agent": "0.6.1",
+            "form-data": "2.0.0",
+            "har-validator": "2.0.6",
+            "hawk": "3.1.3",
+            "http-signature": "1.1.1",
+            "is-typedarray": "1.0.0",
+            "isstream": "0.1.2",
+            "json-stringify-safe": "5.0.1",
+            "mime-types": "2.1.12",
+            "node-uuid": "1.4.7",
+            "oauth-sign": "0.8.2",
+            "qs": "6.2.1",
+            "stringstream": "0.0.5",
+            "tough-cookie": "2.3.1",
+            "tunnel-agent": "0.4.3"
+          },
+          "dependencies": {
+            "aws-sign2": {
+              "version": "0.6.0",
+              "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/aws-sign2/-/aws-sign2-0.6.0.tgz",
+              "integrity": "sha1-FDQt0428yU0OW4fXY81jYSwOeU8="
+            },
+            "aws4": {
+              "version": "1.4.1",
+              "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/aws4/-/aws4-1.4.1.tgz",
+              "integrity": "sha1-/efVKSRm0jDl7g9OA42d+qsI/GE="
+            },
+            "bl": {
+              "version": "1.1.2",
+              "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/bl/-/bl-1.1.2.tgz",
+              "integrity": "sha1-/cqHGplxOqANGeO7ukHER4emU5g=",
+              "requires": {
+                "readable-stream": "2.0.6"
+              },
+              "dependencies": {
+                "readable-stream": {
+                  "version": "2.0.6",
+                  "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/readable-stream/-/readable-stream-2.0.6.tgz",
+                  "integrity": "sha1-j5A0HmilPMySh4jaz80Rs265t44=",
+                  "requires": {
+                    "core-util-is": "1.0.2",
+                    "inherits": "2.0.3",
+                    "isarray": "1.0.0",
+                    "process-nextick-args": "1.0.7",
+                    "string_decoder": "0.10.31",
+                    "util-deprecate": "1.0.2"
+                  },
+                  "dependencies": {
+                    "core-util-is": {
+                      "version": "1.0.2",
+                      "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/core-util-is/-/core-util-is-1.0.2.tgz",
+                      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
+                    },
+                    "inherits": {
+                      "version": "2.0.3",
+                      "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/inherits/-/inherits-2.0.3.tgz",
+                      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
+                    },
+                    "isarray": {
+                      "version": "1.0.0",
+                      "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/isarray/-/isarray-1.0.0.tgz",
+                      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+                    },
+                    "process-nextick-args": {
+                      "version": "1.0.7",
+                      "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
+                      "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M="
+                    },
+                    "string_decoder": {
+                      "version": "0.10.31",
+                      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+                      "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
+                    },
+                    "util-deprecate": {
+                      "version": "1.0.2",
+                      "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/util-deprecate/-/util-deprecate-1.0.2.tgz",
+                      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
+                    }
+                  }
+                }
+              }
+            },
+            "caseless": {
+              "version": "0.11.0",
+              "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/caseless/-/caseless-0.11.0.tgz",
+              "integrity": "sha1-cVuW6phBWTzDMGeSP17GDr2k99c="
+            },
+            "combined-stream": {
+              "version": "1.0.5",
+              "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/combined-stream/-/combined-stream-1.0.5.tgz",
+              "integrity": "sha1-k4NwpXtKUd6ix3wV1cX9+JUWQAk=",
+              "requires": {
+                "delayed-stream": "1.0.0"
+              },
+              "dependencies": {
+                "delayed-stream": {
+                  "version": "1.0.0",
+                  "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/delayed-stream/-/delayed-stream-1.0.0.tgz",
+                  "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
+                }
+              }
+            },
+            "extend": {
+              "version": "3.0.0",
+              "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/extend/-/extend-3.0.0.tgz",
+              "integrity": "sha1-WkdDU7nzNT3dgXbf03uRyDpG8dQ="
+            },
+            "forever-agent": {
+              "version": "0.6.1",
+              "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
+              "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE="
+            },
+            "form-data": {
+              "version": "2.0.0",
+              "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.0.0.tgz",
+              "integrity": "sha1-bwrrrcxdoWwT4ezBETfYX5uIOyU=",
+              "requires": {
+                "asynckit": "0.4.0",
+                "combined-stream": "1.0.5",
+                "mime-types": "2.1.12"
+              },
+              "dependencies": {
+                "asynckit": {
+                  "version": "0.4.0",
+                  "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+                  "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
+                }
+              }
+            },
+            "har-validator": {
+              "version": "2.0.6",
+              "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/har-validator/-/har-validator-2.0.6.tgz",
+              "integrity": "sha1-zcvAgYgmWtEZtqWnyKtw7s+10n0=",
+              "requires": {
+                "chalk": "1.1.3",
+                "commander": "2.9.0",
+                "is-my-json-valid": "2.15.0",
+                "pinkie-promise": "2.0.1"
+              },
+              "dependencies": {
+                "commander": {
+                  "version": "2.9.0",
+                  "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
+                  "integrity": "sha1-nJkJQXbhIkDLItbFFGCYQA/g99Q=",
+                  "requires": {
+                    "graceful-readlink": "1.0.1"
+                  },
+                  "dependencies": {
+                    "graceful-readlink": {
+                      "version": "1.0.1",
+                      "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz",
+                      "integrity": "sha1-TK+tdrxi8C+gObL5Tpo906ORpyU="
+                    }
+                  }
+                },
+                "is-my-json-valid": {
+                  "version": "2.15.0",
+                  "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.15.0.tgz",
+                  "integrity": "sha1-k27do8o8IR/ZjzstPgjaQ/eykVs=",
+                  "requires": {
+                    "generate-function": "2.0.0",
+                    "generate-object-property": "1.2.0",
+                    "jsonpointer": "4.0.0",
+                    "xtend": "4.0.1"
+                  },
+                  "dependencies": {
+                    "generate-function": {
+                      "version": "2.0.0",
+                      "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz",
+                      "integrity": "sha1-aFj+fAlpt9TpCTM3ZHrHn2DfvnQ="
+                    },
+                    "generate-object-property": {
+                      "version": "1.2.0",
+                      "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
+                      "integrity": "sha1-nA4cQDCM6AT0eDYYuTf6iPmdUNA=",
+                      "requires": {
+                        "is-property": "1.0.2"
+                      },
+                      "dependencies": {
+                        "is-property": {
+                          "version": "1.0.2",
+                          "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
+                          "integrity": "sha1-V/4cTkhHTt1lsJkR8msc1Ald2oQ="
+                        }
+                      }
+                    },
+                    "jsonpointer": {
+                      "version": "4.0.0",
+                      "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-4.0.0.tgz",
+                      "integrity": "sha1-ZmHhYdL8RF8Z+YQwIxNDci4fy9U="
+                    },
+                    "xtend": {
+                      "version": "4.0.1",
+                      "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/xtend/-/xtend-4.0.1.tgz",
+                      "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68="
+                    }
+                  }
+                },
+                "pinkie-promise": {
+                  "version": "2.0.1",
+                  "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
+                  "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
+                  "requires": {
+                    "pinkie": "2.0.4"
+                  },
+                  "dependencies": {
+                    "pinkie": {
+                      "version": "2.0.4",
+                      "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/pinkie/-/pinkie-2.0.4.tgz",
+                      "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA="
+                    }
+                  }
+                }
+              }
+            },
+            "hawk": {
+              "version": "3.1.3",
+              "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/hawk/-/hawk-3.1.3.tgz",
+              "integrity": "sha1-B4REvXwWQLD+VA0sm3PVlnjo4cQ=",
+              "requires": {
+                "boom": "2.10.1",
+                "cryptiles": "2.0.5",
+                "hoek": "2.16.3",
+                "sntp": "1.0.9"
+              },
+              "dependencies": {
+                "boom": {
+                  "version": "2.10.1",
+                  "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/boom/-/boom-2.10.1.tgz",
+                  "integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
+                  "requires": {
+                    "hoek": "2.16.3"
+                  }
+                },
+                "cryptiles": {
+                  "version": "2.0.5",
+                  "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/cryptiles/-/cryptiles-2.0.5.tgz",
+                  "integrity": "sha1-O9/s3GCBR8HGcgL6KR59ylnqo7g=",
+                  "requires": {
+                    "boom": "2.10.1"
+                  }
+                },
+                "hoek": {
+                  "version": "2.16.3",
+                  "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/hoek/-/hoek-2.16.3.tgz",
+                  "integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0="
+                },
+                "sntp": {
+                  "version": "1.0.9",
+                  "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
+                  "integrity": "sha1-ZUEYTMkK7qbG57NeJlkIJEPGYZg=",
+                  "requires": {
+                    "hoek": "2.16.3"
+                  }
+                }
+              }
+            },
+            "http-signature": {
+              "version": "1.1.1",
+              "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/http-signature/-/http-signature-1.1.1.tgz",
+              "integrity": "sha1-33LiZwZs0Kxn+3at+OE0qPvPkb8=",
+              "requires": {
+                "assert-plus": "0.2.0",
+                "jsprim": "1.3.1",
+                "sshpk": "1.10.1"
+              },
+              "dependencies": {
+                "assert-plus": {
+                  "version": "0.2.0",
+                  "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/assert-plus/-/assert-plus-0.2.0.tgz",
+                  "integrity": "sha1-104bh+ev/A24qttwIfP+SBAasjQ="
+                },
+                "jsprim": {
+                  "version": "1.3.1",
+                  "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.3.1.tgz",
+                  "integrity": "sha1-KnJW9wQSop7jZwqspiWZTE3P8lI=",
+                  "requires": {
+                    "extsprintf": "1.0.2",
+                    "json-schema": "0.2.3",
+                    "verror": "1.3.6"
+                  },
+                  "dependencies": {
+                    "extsprintf": {
+                      "version": "1.0.2",
+                      "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/extsprintf/-/extsprintf-1.0.2.tgz",
+                      "integrity": "sha1-4QgOBljjALBilJkMxw4VAiNf1VA="
+                    },
+                    "json-schema": {
+                      "version": "0.2.3",
+                      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
+                      "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM="
+                    },
+                    "verror": {
+                      "version": "1.3.6",
+                      "resolved": "https://registry.npmjs.org/verror/-/verror-1.3.6.tgz",
+                      "integrity": "sha1-z/XfEpRtKX0rqu+qJoniW+AcAFw=",
+                      "requires": {
+                        "extsprintf": "1.0.2"
+                      }
+                    }
+                  }
+                },
+                "sshpk": {
+                  "version": "1.10.1",
+                  "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.10.1.tgz",
+                  "integrity": "sha1-MOGl0ykkSXShr2FREznVla9mOLA=",
+                  "requires": {
+                    "asn1": "0.2.3",
+                    "assert-plus": "1.0.0",
+                    "bcrypt-pbkdf": "1.0.0",
+                    "dashdash": "1.14.0",
+                    "ecc-jsbn": "0.1.1",
+                    "getpass": "0.1.6",
+                    "jodid25519": "1.0.2",
+                    "jsbn": "0.1.0",
+                    "tweetnacl": "0.14.3"
+                  },
+                  "dependencies": {
+                    "asn1": {
+                      "version": "0.2.3",
+                      "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/asn1/-/asn1-0.2.3.tgz",
+                      "integrity": "sha1-2sh4dxPJlmhJ/IGAd36+nB3fO4Y="
+                    },
+                    "assert-plus": {
+                      "version": "1.0.0",
+                      "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/assert-plus/-/assert-plus-1.0.0.tgz",
+                      "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
+                    },
+                    "bcrypt-pbkdf": {
+                      "version": "1.0.0",
+                      "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.0.tgz",
+                      "integrity": "sha1-PKdrhSQccXC/fZcD57mqdGMAQNQ=",
+                      "optional": true,
+                      "requires": {
+                        "tweetnacl": "0.14.3"
+                      }
+                    },
+                    "dashdash": {
+                      "version": "1.14.0",
+                      "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/dashdash/-/dashdash-1.14.0.tgz",
+                      "integrity": "sha1-KeSGxUGL8PNWA0qZPVFoajPoQUE=",
+                      "requires": {
+                        "assert-plus": "1.0.0"
+                      }
+                    },
+                    "ecc-jsbn": {
+                      "version": "0.1.1",
+                      "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
+                      "integrity": "sha1-D8c6ntXw1Tw4GTOYUj735UN3dQU=",
+                      "optional": true,
+                      "requires": {
+                        "jsbn": "0.1.0"
+                      }
+                    },
+                    "getpass": {
+                      "version": "0.1.6",
+                      "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/getpass/-/getpass-0.1.6.tgz",
+                      "integrity": "sha1-KD/9n8ElaECHUxHBtg6MQBhxEOY=",
+                      "requires": {
+                        "assert-plus": "1.0.0"
+                      }
+                    },
+                    "jodid25519": {
+                      "version": "1.0.2",
+                      "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/jodid25519/-/jodid25519-1.0.2.tgz",
+                      "integrity": "sha1-BtSRIlUJNBlHfUJWM2BuDpB4KWc=",
+                      "optional": true,
+                      "requires": {
+                        "jsbn": "0.1.0"
+                      }
+                    },
+                    "jsbn": {
+                      "version": "0.1.0",
+                      "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/jsbn/-/jsbn-0.1.0.tgz",
+                      "integrity": "sha1-ZQmH2g3XT06/WhE3eiqi0nPpff0=",
+                      "optional": true
+                    },
+                    "tweetnacl": {
+                      "version": "0.14.3",
+                      "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/tweetnacl/-/tweetnacl-0.14.3.tgz",
+                      "integrity": "sha1-PaOC9nDyXe1417PReSEZvKC3Ey0=",
+                      "optional": true
+                    }
+                  }
+                }
+              }
+            },
+            "is-typedarray": {
+              "version": "1.0.0",
+              "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/is-typedarray/-/is-typedarray-1.0.0.tgz",
+              "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo="
+            },
+            "isstream": {
+              "version": "0.1.2",
+              "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
+              "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo="
+            },
+            "json-stringify-safe": {
+              "version": "5.0.1",
+              "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+              "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
+            },
+            "mime-types": {
+              "version": "2.1.12",
+              "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.12.tgz",
+              "integrity": "sha1-FSuiVndwIN1GY/VMLnvCY4HnFyk=",
+              "requires": {
+                "mime-db": "1.24.0"
+              },
+              "dependencies": {
+                "mime-db": {
+                  "version": "1.24.0",
+                  "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.24.0.tgz",
+                  "integrity": "sha1-4tE/k58AFsbk6a0lqGUvEmxGfww="
+                }
+              }
+            },
+            "node-uuid": {
+              "version": "1.4.7",
+              "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/node-uuid/-/node-uuid-1.4.7.tgz",
+              "integrity": "sha1-baWhdmjEs91ZYjvaEc9/pMH2Cm8="
+            },
+            "oauth-sign": {
+              "version": "0.8.2",
+              "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/oauth-sign/-/oauth-sign-0.8.2.tgz",
+              "integrity": "sha1-Rqarfwrq2N6unsBWV4C31O/rnUM="
+            },
+            "qs": {
+              "version": "6.2.1",
+              "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/qs/-/qs-6.2.1.tgz",
+              "integrity": "sha1-zgPF/wk1vB2daanxTL0Y5WjWdiU="
+            },
+            "stringstream": {
+              "version": "0.0.5",
+              "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/stringstream/-/stringstream-0.0.5.tgz",
+              "integrity": "sha1-TkhM1N5aC7vuGORjB3EKioFiGHg="
+            },
+            "tough-cookie": {
+              "version": "2.3.1",
+              "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/tough-cookie/-/tough-cookie-2.3.1.tgz",
+              "integrity": "sha1-mcd9+7fYBCSeiimdTLD9gf7wg/0="
+            },
+            "tunnel-agent": {
+              "version": "0.4.3",
+              "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/tunnel-agent/-/tunnel-agent-0.4.3.tgz",
+              "integrity": "sha1-Y3PbdpCf5XDgjXNYM2Xtgop07us="
+            }
+          }
+        },
+        "sass-graph": {
+          "version": "2.1.2",
+          "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/sass-graph/-/sass-graph-2.1.2.tgz",
+          "integrity": "sha1-llEEviPoEDy35fcQ32WTWzF9pXs=",
+          "requires": {
+            "glob": "7.1.0",
+            "lodash": "4.16.4",
+            "yargs": "4.8.1"
+          },
+          "dependencies": {
+            "lodash": {
+              "version": "4.16.4",
+              "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.16.4.tgz",
+              "integrity": "sha1-Ac4wa5utExnypVKGdPiCl663ASc="
+            },
+            "yargs": {
+              "version": "4.8.1",
+              "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/yargs/-/yargs-4.8.1.tgz",
+              "integrity": "sha1-wMQpJMpKqmsObaFznfshZDn53cA=",
+              "requires": {
+                "cliui": "3.2.0",
+                "decamelize": "1.2.0",
+                "get-caller-file": "1.0.2",
+                "lodash.assign": "4.2.0",
+                "os-locale": "1.4.0",
+                "read-pkg-up": "1.0.1",
+                "require-directory": "2.1.1",
+                "require-main-filename": "1.0.1",
+                "set-blocking": "2.0.0",
+                "string-width": "1.0.2",
+                "which-module": "1.0.0",
+                "window-size": "0.2.0",
+                "y18n": "3.2.1",
+                "yargs-parser": "2.4.1"
+              },
+              "dependencies": {
+                "cliui": {
+                  "version": "3.2.0",
+                  "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/cliui/-/cliui-3.2.0.tgz",
+                  "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
+                  "requires": {
+                    "string-width": "1.0.2",
+                    "strip-ansi": "3.0.1",
+                    "wrap-ansi": "2.0.0"
+                  },
+                  "dependencies": {
+                    "strip-ansi": {
+                      "version": "3.0.1",
+                      "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/strip-ansi/-/strip-ansi-3.0.1.tgz",
+                      "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+                      "requires": {
+                        "ansi-regex": "2.0.0"
+                      },
+                      "dependencies": {
+                        "ansi-regex": {
+                          "version": "2.0.0",
+                          "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/ansi-regex/-/ansi-regex-2.0.0.tgz",
+                          "integrity": "sha1-xQYbbg74qBd15Q9dZhUb9r83EQc="
+                        }
+                      }
+                    },
+                    "wrap-ansi": {
+                      "version": "2.0.0",
+                      "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/wrap-ansi/-/wrap-ansi-2.0.0.tgz",
+                      "integrity": "sha1-fTD4+HP5pbvDpk2ryNF34HGuQm8=",
+                      "requires": {
+                        "string-width": "1.0.2"
+                      }
+                    }
+                  }
+                },
+                "decamelize": {
+                  "version": "1.2.0",
+                  "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+                  "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA="
+                },
+                "get-caller-file": {
+                  "version": "1.0.2",
+                  "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/get-caller-file/-/get-caller-file-1.0.2.tgz",
+                  "integrity": "sha1-9wLmMSfn4jHBYKgMFVSstw1QR+U="
+                },
+                "os-locale": {
+                  "version": "1.4.0",
+                  "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/os-locale/-/os-locale-1.4.0.tgz",
+                  "integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
+                  "requires": {
+                    "lcid": "1.0.0"
+                  },
+                  "dependencies": {
+                    "lcid": {
+                      "version": "1.0.0",
+                      "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/lcid/-/lcid-1.0.0.tgz",
+                      "integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
+                      "requires": {
+                        "invert-kv": "1.0.0"
+                      },
+                      "dependencies": {
+                        "invert-kv": {
+                          "version": "1.0.0",
+                          "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/invert-kv/-/invert-kv-1.0.0.tgz",
+                          "integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY="
+                        }
+                      }
+                    }
+                  }
+                },
+                "read-pkg-up": {
+                  "version": "1.0.1",
+                  "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
+                  "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
+                  "requires": {
+                    "find-up": "1.1.2",
+                    "read-pkg": "1.1.0"
+                  },
+                  "dependencies": {
+                    "find-up": {
+                      "version": "1.1.2",
+                      "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/find-up/-/find-up-1.1.2.tgz",
+                      "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
+                      "requires": {
+                        "path-exists": "2.1.0",
+                        "pinkie-promise": "2.0.1"
+                      },
+                      "dependencies": {
+                        "path-exists": {
+                          "version": "2.1.0",
+                          "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/path-exists/-/path-exists-2.1.0.tgz",
+                          "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
+                          "requires": {
+                            "pinkie-promise": "2.0.1"
+                          }
+                        },
+                        "pinkie-promise": {
+                          "version": "2.0.1",
+                          "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
+                          "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
+                          "requires": {
+                            "pinkie": "2.0.4"
+                          },
+                          "dependencies": {
+                            "pinkie": {
+                              "version": "2.0.4",
+                              "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/pinkie/-/pinkie-2.0.4.tgz",
+                              "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA="
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "read-pkg": {
+                      "version": "1.1.0",
+                      "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/read-pkg/-/read-pkg-1.1.0.tgz",
+                      "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
+                      "requires": {
+                        "load-json-file": "1.1.0",
+                        "normalize-package-data": "2.3.5",
+                        "path-type": "1.1.0"
+                      },
+                      "dependencies": {
+                        "load-json-file": {
+                          "version": "1.1.0",
+                          "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/load-json-file/-/load-json-file-1.1.0.tgz",
+                          "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
+                          "requires": {
+                            "graceful-fs": "4.1.9",
+                            "parse-json": "2.2.0",
+                            "pify": "2.3.0",
+                            "pinkie-promise": "2.0.1",
+                            "strip-bom": "2.0.0"
+                          },
+                          "dependencies": {
+                            "graceful-fs": {
+                              "version": "4.1.9",
+                              "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.9.tgz",
+                              "integrity": "sha1-uqy6N9GdEfnRRtNXi8mZWMN4fik="
+                            },
+                            "parse-json": {
+                              "version": "2.2.0",
+                              "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/parse-json/-/parse-json-2.2.0.tgz",
+                              "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
+                              "requires": {
+                                "error-ex": "1.3.0"
+                              },
+                              "dependencies": {
+                                "error-ex": {
+                                  "version": "1.3.0",
+                                  "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/error-ex/-/error-ex-1.3.0.tgz",
+                                  "integrity": "sha1-5ntD8+gsluo6WE/+4Ln8MyXYAtk=",
+                                  "requires": {
+                                    "is-arrayish": "0.2.1"
+                                  },
+                                  "dependencies": {
+                                    "is-arrayish": {
+                                      "version": "0.2.1",
+                                      "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/is-arrayish/-/is-arrayish-0.2.1.tgz",
+                                      "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0="
+                                    }
+                                  }
+                                }
+                              }
+                            },
+                            "pify": {
+                              "version": "2.3.0",
+                              "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/pify/-/pify-2.3.0.tgz",
+                              "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw="
+                            },
+                            "pinkie-promise": {
+                              "version": "2.0.1",
+                              "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
+                              "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
+                              "requires": {
+                                "pinkie": "2.0.4"
+                              },
+                              "dependencies": {
+                                "pinkie": {
+                                  "version": "2.0.4",
+                                  "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/pinkie/-/pinkie-2.0.4.tgz",
+                                  "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA="
+                                }
+                              }
+                            },
+                            "strip-bom": {
+                              "version": "2.0.0",
+                              "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/strip-bom/-/strip-bom-2.0.0.tgz",
+                              "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
+                              "requires": {
+                                "is-utf8": "0.2.1"
+                              },
+                              "dependencies": {
+                                "is-utf8": {
+                                  "version": "0.2.1",
+                                  "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/is-utf8/-/is-utf8-0.2.1.tgz",
+                                  "integrity": "sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI="
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "normalize-package-data": {
+                          "version": "2.3.5",
+                          "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/normalize-package-data/-/normalize-package-data-2.3.5.tgz",
+                          "integrity": "sha1-jZJPFClg4Xd+f/4XBUNjHMfLAt8=",
+                          "requires": {
+                            "hosted-git-info": "2.1.5",
+                            "is-builtin-module": "1.0.0",
+                            "semver": "5.3.0",
+                            "validate-npm-package-license": "3.0.1"
+                          },
+                          "dependencies": {
+                            "hosted-git-info": {
+                              "version": "2.1.5",
+                              "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/hosted-git-info/-/hosted-git-info-2.1.5.tgz",
+                              "integrity": "sha1-C6gdkNouJas0ozLm7HeTbhWYEYs="
+                            },
+                            "is-builtin-module": {
+                              "version": "1.0.0",
+                              "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
+                              "integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
+                              "requires": {
+                                "builtin-modules": "1.1.1"
+                              },
+                              "dependencies": {
+                                "builtin-modules": {
+                                  "version": "1.1.1",
+                                  "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/builtin-modules/-/builtin-modules-1.1.1.tgz",
+                                  "integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8="
+                                }
+                              }
+                            },
+                            "validate-npm-package-license": {
+                              "version": "3.0.1",
+                              "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/validate-npm-package-license/-/validate-npm-package-license-3.0.1.tgz",
+                              "integrity": "sha1-KAS6vnEq0zeUWaz74kdGqywwP7w=",
+                              "requires": {
+                                "spdx-correct": "1.0.2",
+                                "spdx-expression-parse": "1.0.4"
+                              },
+                              "dependencies": {
+                                "spdx-correct": {
+                                  "version": "1.0.2",
+                                  "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/spdx-correct/-/spdx-correct-1.0.2.tgz",
+                                  "integrity": "sha1-SzBz2TP/UfORLwOsVRlJikFQ20A=",
+                                  "requires": {
+                                    "spdx-license-ids": "1.2.2"
+                                  },
+                                  "dependencies": {
+                                    "spdx-license-ids": {
+                                      "version": "1.2.2",
+                                      "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/spdx-license-ids/-/spdx-license-ids-1.2.2.tgz",
+                                      "integrity": "sha1-yd96NCRZSt5r0RkA1ZZpbcBrrFc="
+                                    }
+                                  }
+                                },
+                                "spdx-expression-parse": {
+                                  "version": "1.0.4",
+                                  "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-1.0.4.tgz",
+                                  "integrity": "sha1-m98vIOH0DtRH++JzJmGR/O1RYmw="
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "path-type": {
+                          "version": "1.1.0",
+                          "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/path-type/-/path-type-1.1.0.tgz",
+                          "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
+                          "requires": {
+                            "graceful-fs": "4.1.9",
+                            "pify": "2.3.0",
+                            "pinkie-promise": "2.0.1"
+                          },
+                          "dependencies": {
+                            "graceful-fs": {
+                              "version": "4.1.9",
+                              "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.9.tgz",
+                              "integrity": "sha1-uqy6N9GdEfnRRtNXi8mZWMN4fik="
+                            },
+                            "pify": {
+                              "version": "2.3.0",
+                              "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/pify/-/pify-2.3.0.tgz",
+                              "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw="
+                            },
+                            "pinkie-promise": {
+                              "version": "2.0.1",
+                              "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
+                              "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
+                              "requires": {
+                                "pinkie": "2.0.4"
+                              },
+                              "dependencies": {
+                                "pinkie": {
+                                  "version": "2.0.4",
+                                  "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/pinkie/-/pinkie-2.0.4.tgz",
+                                  "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA="
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                },
+                "require-directory": {
+                  "version": "2.1.1",
+                  "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/require-directory/-/require-directory-2.1.1.tgz",
+                  "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I="
+                },
+                "require-main-filename": {
+                  "version": "1.0.1",
+                  "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/require-main-filename/-/require-main-filename-1.0.1.tgz",
+                  "integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE="
+                },
+                "set-blocking": {
+                  "version": "2.0.0",
+                  "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/set-blocking/-/set-blocking-2.0.0.tgz",
+                  "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc="
+                },
+                "string-width": {
+                  "version": "1.0.2",
+                  "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/string-width/-/string-width-1.0.2.tgz",
+                  "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+                  "requires": {
+                    "code-point-at": "1.0.1",
+                    "is-fullwidth-code-point": "1.0.0",
+                    "strip-ansi": "3.0.1"
+                  },
+                  "dependencies": {
+                    "code-point-at": {
+                      "version": "1.0.1",
+                      "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.0.1.tgz",
+                      "integrity": "sha1-EQTNNPm1tF0+uojxurwZJOHONfs=",
+                      "requires": {
+                        "number-is-nan": "1.0.1"
+                      },
+                      "dependencies": {
+                        "number-is-nan": {
+                          "version": "1.0.1",
+                          "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
+                          "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
+                        }
+                      }
+                    },
+                    "is-fullwidth-code-point": {
+                      "version": "1.0.0",
+                      "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+                      "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+                      "requires": {
+                        "number-is-nan": "1.0.1"
+                      },
+                      "dependencies": {
+                        "number-is-nan": {
+                          "version": "1.0.1",
+                          "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
+                          "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
+                        }
+                      }
+                    },
+                    "strip-ansi": {
+                      "version": "3.0.1",
+                      "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/strip-ansi/-/strip-ansi-3.0.1.tgz",
+                      "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+                      "requires": {
+                        "ansi-regex": "2.0.0"
+                      },
+                      "dependencies": {
+                        "ansi-regex": {
+                          "version": "2.0.0",
+                          "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/ansi-regex/-/ansi-regex-2.0.0.tgz",
+                          "integrity": "sha1-xQYbbg74qBd15Q9dZhUb9r83EQc="
+                        }
+                      }
+                    }
+                  }
+                },
+                "which-module": {
+                  "version": "1.0.0",
+                  "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/which-module/-/which-module-1.0.0.tgz",
+                  "integrity": "sha1-u6Y8qGGUiZT/MHc2CJ47lgJsKk8="
+                },
+                "window-size": {
+                  "version": "0.2.0",
+                  "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/window-size/-/window-size-0.2.0.tgz",
+                  "integrity": "sha1-tDFbtCFKPXBY6+7okuE/ok2YsHU="
+                },
+                "y18n": {
+                  "version": "3.2.1",
+                  "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/y18n/-/y18n-3.2.1.tgz",
+                  "integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE="
+                },
+                "yargs-parser": {
+                  "version": "2.4.1",
+                  "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/yargs-parser/-/yargs-parser-2.4.1.tgz",
+                  "integrity": "sha1-hVaN488VD/SfpRgl8DqMiA3cxcQ=",
+                  "requires": {
+                    "camelcase": "3.0.0",
+                    "lodash.assign": "4.2.0"
+                  },
+                  "dependencies": {
+                    "camelcase": {
+                      "version": "3.0.0",
+                      "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/camelcase/-/camelcase-3.0.0.tgz",
+                      "integrity": "sha1-MvxLn82vhF/N9+c7uXysImHwqwo="
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "node-sass-utils": {
+      "version": "1.1.2",
+      "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/node-sass-utils/-/node-sass-utils-1.1.2.tgz",
+      "integrity": "sha1-0DY5z6T8liOYujZIq0ZvDbfMITE="
+    },
+    "semver": {
+      "version": "5.3.0",
+      "resolved": "http://artifactory.corp.linkedin.com:8081/artifactory/api/npm/npm-external/semver/-/semver-5.3.0.tgz",
+      "integrity": "sha1-myzl094C0XxgEq0yaqa00M9U+U8="
+    },
+    "should": {
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/should/-/should-11.1.0.tgz",
+      "integrity": "sha1-HS7n07FQ6WVhHr43vn3PD+IHWo4=",
+      "dev": true,
+      "requires": {
+        "should-equal": "1.0.1",
+        "should-format": "3.0.1",
+        "should-type": "1.4.0",
+        "should-type-adaptors": "1.0.0",
+        "should-util": "1.0.0"
+      },
+      "dependencies": {
+        "should-equal": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/should-equal/-/should-equal-1.0.1.tgz",
+          "integrity": "sha1-C26VFvJgGp+wuy3MNpr6HH4gCvc=",
+          "dev": true,
+          "requires": {
+            "should-type": "1.4.0"
+          }
+        },
+        "should-format": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/should-format/-/should-format-3.0.1.tgz",
+          "integrity": "sha1-Mkm3GcCSG017JtNH0bDMbiMq0yQ=",
+          "dev": true,
+          "requires": {
+            "should-type": "1.4.0",
+            "should-type-adaptors": "1.0.0"
+          }
+        },
+        "should-type": {
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/should-type/-/should-type-1.4.0.tgz",
+          "integrity": "sha1-B1bYzoRt/QmEOmlHcZ36DUz/XPM=",
+          "dev": true
+        },
+        "should-type-adaptors": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/should-type-adaptors/-/should-type-adaptors-1.0.0.tgz",
+          "integrity": "sha1-A0soQ7jBUbt7ZuY1DroAVD55dQA=",
+          "dev": true,
+          "requires": {
+            "should-type": "1.4.0",
+            "should-util": "1.0.0"
+          }
+        },
+        "should-util": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/should-util/-/should-util-1.0.0.tgz",
+          "integrity": "sha1-yYzaN0qmsZDfi6h8mInCtNtiAGM=",
+          "dev": true
+        }
+      }
+    }
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "eyeglass",
-  "version": "1.2.1",
+  "version": "1.5.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -65,6 +65,11 @@
           "integrity": "sha1-nNE8A62/8ltl7/3nzoZO6VIBcJg="
         }
       }
+    },
+    "ensure-symlink": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/ensure-symlink/-/ensure-symlink-1.0.2.tgz",
+      "integrity": "sha1-WOvCbRWpU5ueedAKqWI/j6Zf8Y0="
     },
     "eslint": {
       "version": "1.10.3",
@@ -16550,6 +16555,19 @@
           }
         }
       }
+    },
+    "json-stable-stringify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
+      "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
+      "requires": {
+        "jsonify": "0.0.0"
+      }
+    },
+    "jsonify": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
+      "integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM="
     },
     "lodash.includes": {
       "version": "4.3.0",

--- a/test/test_SimpleCache.js
+++ b/test/test_SimpleCache.js
@@ -1,0 +1,65 @@
+"use strict";
+
+var assert = require("assert");
+var SimpleCache = require("../lib/util/SimpleCache");
+
+function Spy(callback) {
+  this.called = 0;
+  this.callable = function() {
+    this.called++;
+    if (callback) {
+      return callback(Array.from(arguments));
+    }
+  }.bind(this);
+}
+
+describe("SimpleCache", function () {
+  it("should create an instance of SimpleCache", function() {
+    var cache = new SimpleCache();
+    assert(cache instanceof SimpleCache);
+  });
+
+  it("should set a value in cache and be able to retrieve it", function() {
+    var cache = new SimpleCache();
+    var key = "testKey";
+    var value = "testValue";
+    cache.set(key, value);
+    assert.equal(cache.get(key), value);
+  });
+
+  it("getOrElse should return the value", function() {
+    var cache = new SimpleCache();
+    var key = "testKey";
+    var value = "testValue";
+    var spy = new Spy();
+    cache.set(key, value);
+    assert.equal(cache.getOrElse(key, spy.callable), value);
+    assert.equal(spy.called, 0);
+  });
+
+  it("getOrElse should set the value and return if not yet set", function() {
+    var cache = new SimpleCache();
+    var key = "testKey";
+    var value = "testValue";
+    var spy = new Spy(function() {
+      return value;
+    });
+    assert.equal(cache.getOrElse(key, spy.callable), value);
+    assert.equal(spy.called, 1);
+  });
+
+  it("should purge", function() {
+    var cache =  new SimpleCache();
+    var keys = ["foo", "bar"];
+    keys.forEach(function(key, index) {
+      cache.set(key, index);
+      assert.equal(cache.has(key), true);
+      assert.equal(cache.get(key), index);
+    });
+    cache.purge();
+    keys.forEach(function(key) {
+      assert.equal(cache.has(key), false);
+      assert.equal(cache.get(key), undefined);
+    });
+  });
+});


### PR DESCRIPTION
This adds module discovery caching to `EyeglassModules`.

The cache is fairly simple and is stored per instance of `EyeglassModules` (which translates to per `Eyeglass` instance).

I tested against a fairly large code base to see the difference between per-instance vs global caching and the savings were statistically insignificant. That said, if you are creating hundreds/thousands of eyeglass instances, it might be beneficial.

Here are some metrics of time spent in `discoverModules` (averaged across 3 runs each):
- **no caching**: 114.349s
- **per-instance caching**: 34.372s
- **global caching**: 37.052s

Other minor changes:
- updated the `canAccess` cache to share the same `SimpleCache`
- updated `debug.*` to only create functions if the debugger is enabled. this allows us to short-circuit some semi expensive debug message generation if we aren't going to use it.

Related: #187 #186