### PR TITLE
Fixes #200, using \x00 as cacheKey separator

### DIFF
--- a/packages/eyeglass/src/assets/AssetsCollection.ts
+++ b/packages/eyeglass/src/assets/AssetsCollection.ts
@@ -66,6 +66,6 @@ export default class AssetsCollection {
   cacheKey(name: string): string {
     return this.sources.map(function (source) {
       return source.cacheKey(name);
-    }).sort().join(":");
+    }).sort().join("\x00");
   }
 }


### PR DESCRIPTION
This addresses #200, using @stefanpenner's suggestion of `\x00` as a cache key separator. This preempts any issues with `:` in a key name. I made the change and reran the tests to ensure we didn't break anything as part of this PR.